### PR TITLE
feat: 번역 진행률 표시 및 UI 개선

### DIFF
--- a/src/services/categoryApi.ts
+++ b/src/services/categoryApi.ts
@@ -1,0 +1,61 @@
+import apiClient from './api';
+
+export interface CategoryResponse {
+  id: number;
+  name: string;
+  description?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateCategoryRequest {
+  name: string;
+  description?: string;
+}
+
+export interface UpdateCategoryRequest {
+  name?: string;
+  description?: string;
+}
+
+export const categoryApi = {
+  /**
+   * 카테고리 목록 조회
+   */
+  getAllCategories: async (): Promise<CategoryResponse[]> => {
+    const response = await apiClient.get<CategoryResponse[]>('/categories');
+    return response.data;
+  },
+
+  /**
+   * 카테고리 상세 조회
+   */
+  getCategory: async (id: number): Promise<CategoryResponse> => {
+    const response = await apiClient.get<CategoryResponse>(`/categories/${id}`);
+    return response.data;
+  },
+
+  /**
+   * 카테고리 생성 (관리자 권한 필요)
+   */
+  createCategory: async (request: CreateCategoryRequest): Promise<CategoryResponse> => {
+    const response = await apiClient.post<CategoryResponse>('/categories', request);
+    return response.data;
+  },
+
+  /**
+   * 카테고리 수정 (관리자 권한 필요)
+   */
+  updateCategory: async (id: number, request: UpdateCategoryRequest): Promise<CategoryResponse> => {
+    const response = await apiClient.put<CategoryResponse>(`/categories/${id}`, request);
+    return response.data;
+  },
+
+  /**
+   * 카테고리 삭제 (관리자 권한 필요)
+   */
+  deleteCategory: async (id: number): Promise<void> => {
+    await apiClient.delete(`/categories/${id}`);
+  },
+};
+

--- a/src/services/translationWorkApi.ts
+++ b/src/services/translationWorkApi.ts
@@ -9,6 +9,7 @@ export interface LockStatusResponse {
   };
   lockedAt?: string;
   canEdit: boolean;
+  completedParagraphs?: number[];
 }
 
 export interface HandoverRequest {

--- a/src/types/document.ts
+++ b/src/types/document.ts
@@ -20,6 +20,8 @@ export interface DocumentListItem {
   assignedManager?: string; // 담당 관리자
   isFinal: boolean; // Final 여부
   originalUrl?: string;
+  currentWorker?: string; // 현재 작업자 (IN_TRANSLATION 상태인 경우)
+  currentVersionId?: number; // 현재 버전 ID
 }
 
 export interface DocumentFilter {


### PR DESCRIPTION
- 번역 진행률 계산 및 표시 기능 구현
  - ORIGINAL 버전에서 전체 문단 수 계산
  - completedParagraphs 기반 진행률 계산
  - TranslationsPending에서 진행률 바 표시

- NewTranslation Step 6 개선
  - 문서 제목 자동 파싱 및 번역 기능
  - 카테고리 동적 로딩 (categoryApi 추가)
  - 예상 분량 계산 개선 (Version 1 body 텍스트만)

- TranslationWork 개선
  - 초기 로드 시 completedParagraphs 복원
  - 락 정보에서 완료된 문단 정보 가져오기

- TranslationsPending 개선
  - 진행률 계산 로직 구현
  - 완료된 문서 버튼 초록색 스타일 적용
  - 카테고리 이름 표시 (ID 대신 이름)

- categoryApi 서비스 추가
  - 카테고리 목록 조회 API 연동