### PR TITLE
feat/issue-66/번역 완료 이메일 공지 및 평어 번역및 UI

### DIFF
--- a/src/pages/DocumentDetail.tsx
+++ b/src/pages/DocumentDetail.tsx
@@ -1,345 +1,418 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
-import { ChevronDown, ChevronUp } from 'lucide-react';
-import { documentApi, DocumentResponse, DocumentVersionResponse } from '../services/documentApi';
-import { colors } from '../constants/designTokens';
-import { Button } from '../components/Button';
-import { StatusBadge } from '../components/StatusBadge';
-import { DocumentState } from '../types/translation';
-import ErrorBoundary from '../components/ErrorBoundary';
-import { formatLastModifiedDateDisplay } from '../utils/dateUtils';
-import { DocumentChat } from '../components/DocumentChat';
-import { termApi } from '../services/termApi';
+import React, { useState, useEffect, useRef } from "react";
+import { useParams, useNavigate, useSearchParams } from "react-router-dom";
+import { ChevronDown, ChevronUp } from "lucide-react";
+import {
+	documentApi,
+	type DocumentResponse,
+	type DocumentVersionResponse,
+} from "../services/documentApi";
+import { colors } from "../constants/designTokens";
+import { Button } from "../components/Button";
+import { StatusBadge } from "../components/StatusBadge";
+import { DocumentState } from "../types/translation";
+import ErrorBoundary from "../components/ErrorBoundary";
+import { formatLastModifiedDateDisplay } from "../utils/dateUtils";
+import { DocumentChat } from "../components/DocumentChat";
+import { termApi } from "../services/termApi";
 
 const WORD_CHAR_REGEX = /[A-Za-z0-9_]/;
 type GlossaryTermPair = { sourceTerm: string; targetTerm: string };
 
-const highlightGlossaryInOriginalIframe = (doc: Document, glossaryTerms: GlossaryTermPair[]) => {
-  if (!doc.body || glossaryTerms.length === 0) return;
+const highlightGlossaryInOriginalIframe = (
+	doc: Document,
+	glossaryTerms: GlossaryTermPair[],
+) => {
+	if (!doc.body || glossaryTerms.length === 0) return;
 
-  const sortedTerms = [...glossaryTerms]
-    .map((t) => ({ sourceTerm: t.sourceTerm.trim(), targetTerm: t.targetTerm.trim() }))
-    .filter((t) => t.sourceTerm.length > 1 && t.targetTerm.length > 0)
-    .sort((a, b) => b.sourceTerm.length - a.sourceTerm.length);
+	const sortedTerms = [...glossaryTerms]
+		.map((t) => ({
+			sourceTerm: t.sourceTerm.trim(),
+			targetTerm: t.targetTerm.trim(),
+		}))
+		.filter((t) => t.sourceTerm.length > 1 && t.targetTerm.length > 0)
+		.sort((a, b) => b.sourceTerm.length - a.sourceTerm.length);
 
-  if (sortedTerms.length === 0) return;
+	if (sortedTerms.length === 0) return;
 
-  const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_TEXT);
-  const textNodes: Text[] = [];
-  let current: Node | null = walker.nextNode();
-  while (current) {
-    const parentTag = (current.parentElement?.tagName || '').toLowerCase();
-    if (parentTag !== 'script' && parentTag !== 'style' && current.textContent?.trim()) {
-      textNodes.push(current as Text);
-    }
-    current = walker.nextNode();
-  }
+	const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_TEXT);
+	const textNodes: Text[] = [];
+	let current: Node | null = walker.nextNode();
+	while (current) {
+		const parentTag = (current.parentElement?.tagName || "").toLowerCase();
+		if (
+			parentTag !== "script" &&
+			parentTag !== "style" &&
+			current.textContent?.trim()
+		) {
+			textNodes.push(current as Text);
+		}
+		current = walker.nextNode();
+	}
 
-  textNodes.forEach((textNode) => {
-    const source = textNode.textContent || '';
-    const lower = source.toLowerCase();
-    let cursor = 0;
-    const fragment = doc.createDocumentFragment();
-    let matched = false;
+	textNodes.forEach((textNode) => {
+		const source = textNode.textContent || "";
+		const lower = source.toLowerCase();
+		let cursor = 0;
+		const fragment = doc.createDocumentFragment();
+		let matched = false;
 
-    while (cursor < source.length) {
-      let bestStart = -1;
-      let bestEnd = -1;
-      let bestTerm: GlossaryTermPair | null = null;
+		while (cursor < source.length) {
+			let bestStart = -1;
+			let bestEnd = -1;
+			let bestTerm: GlossaryTermPair | null = null;
 
-      for (const term of sortedTerms) {
-        const termLower = term.sourceTerm.toLowerCase();
-        const found = lower.indexOf(termLower, cursor);
-        if (found === -1) continue;
-        const end = found + termLower.length;
+			for (const term of sortedTerms) {
+				const termLower = term.sourceTerm.toLowerCase();
+				const found = lower.indexOf(termLower, cursor);
+				if (found === -1) continue;
+				const end = found + termLower.length;
 
-        const before = found > 0 ? source[found - 1] : '';
-        const after = end < source.length ? source[end] : '';
-        const leftBoundary = !before || !WORD_CHAR_REGEX.test(before);
-        const rightBoundary = !after || !WORD_CHAR_REGEX.test(after);
-        if (!leftBoundary || !rightBoundary) continue;
+				const before = found > 0 ? source[found - 1] : "";
+				const after = end < source.length ? source[end] : "";
+				const leftBoundary = !before || !WORD_CHAR_REGEX.test(before);
+				const rightBoundary = !after || !WORD_CHAR_REGEX.test(after);
+				if (!leftBoundary || !rightBoundary) continue;
 
-        if (bestStart === -1 || found < bestStart || (found === bestStart && bestTerm && term.sourceTerm.length > bestTerm.sourceTerm.length)) {
-          bestStart = found;
-          bestEnd = end;
-          bestTerm = term;
-        }
-      }
+				if (
+					bestStart === -1 ||
+					found < bestStart ||
+					(found === bestStart &&
+						bestTerm &&
+						term.sourceTerm.length > bestTerm.sourceTerm.length)
+				) {
+					bestStart = found;
+					bestEnd = end;
+					bestTerm = term;
+				}
+			}
 
-      if (bestStart === -1) {
-        fragment.appendChild(doc.createTextNode(source.slice(cursor)));
-        break;
-      }
+			if (bestStart === -1) {
+				fragment.appendChild(doc.createTextNode(source.slice(cursor)));
+				break;
+			}
 
-      if (bestStart > cursor) {
-        fragment.appendChild(doc.createTextNode(source.slice(cursor, bestStart)));
-      }
+			if (bestStart > cursor) {
+				fragment.appendChild(
+					doc.createTextNode(source.slice(cursor, bestStart)),
+				);
+			}
 
-      const span = doc.createElement('span');
-      span.className = 'original-glossary-term';
-      span.setAttribute('data-source-term', bestTerm?.sourceTerm || '');
-      span.setAttribute('data-target-term', bestTerm?.targetTerm || '');
-      span.textContent = `${source.slice(bestStart, bestEnd)}(${bestTerm?.targetTerm || ''})`;
-      fragment.appendChild(span);
+			const span = doc.createElement("span");
+			span.className = "original-glossary-term";
+			span.setAttribute("data-source-term", bestTerm?.sourceTerm || "");
+			span.setAttribute("data-target-term", bestTerm?.targetTerm || "");
+			span.textContent = `${source.slice(bestStart, bestEnd)}(${bestTerm?.targetTerm || ""})`;
+			fragment.appendChild(span);
 
-      matched = true;
-      cursor = bestEnd;
-    }
+			matched = true;
+			cursor = bestEnd;
+		}
 
-    if (matched) {
-      textNode.replaceWith(fragment);
-    }
-  });
+		if (matched) {
+			textNode.replaceWith(fragment);
+		}
+	});
 };
 
 // 과거 버전에서 AI_DRAFT에 삽입된 glossary-term 마크업 제거
 const removeLegacyGlossaryMarkup = (html: string) => {
-  if (!html) return html;
-  try {
-    const parser = new DOMParser();
-    const doc = parser.parseFromString(html, 'text/html');
-    const glossaryNodes = doc.querySelectorAll('span.glossary-term');
+	if (!html) return html;
+	try {
+		const parser = new DOMParser();
+		const doc = parser.parseFromString(html, "text/html");
+		const glossaryNodes = doc.querySelectorAll("span.glossary-term");
 
-    glossaryNodes.forEach((node) => {
-      const original = node.getAttribute('data-original') || '';
-      const text = node.textContent || '';
-      const suffix = original ? `(${original})` : '';
-      const restored = suffix && text.endsWith(suffix) ? text.slice(0, -suffix.length) : text;
-      node.replaceWith(doc.createTextNode(restored));
-    });
+		glossaryNodes.forEach((node) => {
+			const original = node.getAttribute("data-original") || "";
+			const text = node.textContent || "";
+			const suffix = original ? `(${original})` : "";
+			const restored =
+				suffix && text.endsWith(suffix) ? text.slice(0, -suffix.length) : text;
+			node.replaceWith(doc.createTextNode(restored));
+		});
 
-    return doc.documentElement.outerHTML;
-  } catch {
-    return html;
-  }
+		return doc.documentElement.outerHTML;
+	} catch {
+		return html;
+	}
 };
 
 export default function DocumentDetail() {
-  const { id } = useParams<{ id: string }>();
-  const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
-  const from = searchParams.get('from');
-  const documentId = id ? parseInt(id, 10) : null;
+	const { id } = useParams<{ id: string }>();
+	const navigate = useNavigate();
+	const [searchParams] = useSearchParams();
+	const from = searchParams.get("from");
+	const documentId = id ? Number.parseInt(id, 10) : null;
 
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [document, setDocument] = useState<DocumentResponse | null>(null);
-  const [versions, setVersions] = useState<DocumentVersionResponse[]>([]);
-  
-  // 버전별 HTML 콘텐츠
-  const [originalHtml, setOriginalHtml] = useState<string>('');
-  const [aiDraftHtml, setAiDraftHtml] = useState<string>('');
-  const [currentVersionHtml, setCurrentVersionHtml] = useState<string>('');
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+	const [document, setDocument] = useState<DocumentResponse | null>(null);
+	const [versions, setVersions] = useState<DocumentVersionResponse[]>([]);
 
-  // 패널 접기/전체화면 상태
-  const [collapsedPanels, setCollapsedPanels] = useState<Set<string>>(new Set());
-  const [fullscreenPanel, setFullscreenPanel] = useState<string | null>(null);
-  
-  // 현재 버전 정보
-  const [currentVersionInfo, setCurrentVersionInfo] = useState<{
-    version: DocumentVersionResponse | null;
-    versionType: string;
-  }>({ version: null, versionType: '' });
+	// 버전별 HTML 콘텐츠
+	const [originalHtml, setOriginalHtml] = useState<string>("");
+	const [aiDraftHtml, setAiDraftHtml] = useState<string>("");
+	const [currentVersionHtml, setCurrentVersionHtml] = useState<string>("");
 
-  // 인계 메모 모달
-  const [showHandoverModal, setShowHandoverModal] = useState(false);
-  // 번역 대기로 전환 (from=handover 시)
-  const [convertingToPending, setConvertingToPending] = useState(false);
-  // 소통 채팅 패널 표시 여부
-  const [showChat, setShowChat] = useState(false);
-  const [showOriginalGlossary, setShowOriginalGlossary] = useState(false);
-  const [originalGlossaryTerms, setOriginalGlossaryTerms] = useState<GlossaryTermPair[]>([]);
-  /** 헤더 제목·원문 URL 길게/짧게 보기 */
-  const [headerMetaExpanded, setHeaderMetaExpanded] = useState(false);
+	// 패널 접기/전체화면 상태
+	const [collapsedPanels, setCollapsedPanels] = useState<Set<string>>(
+		new Set(),
+	);
+	const [fullscreenPanel, setFullscreenPanel] = useState<string | null>(null);
 
-  // iframe refs
-  const originalIframeRef = useRef<HTMLIFrameElement>(null);
-  const aiDraftIframeRef = useRef<HTMLIFrameElement>(null);
-  const currentWorkIframeRef = useRef<HTMLIFrameElement>(null);
+	// 현재 버전 정보
+	const [currentVersionInfo, setCurrentVersionInfo] = useState<{
+		version: DocumentVersionResponse | null;
+		versionType: string;
+	}>({ version: null, versionType: "" });
 
-  useEffect(() => {
-    setHeaderMetaExpanded(false);
-  }, [id]);
+	// 인계 메모 모달
+	const [showHandoverModal, setShowHandoverModal] = useState(false);
+	// 번역 대기로 전환 (from=handover 시)
+	const [convertingToPending, setConvertingToPending] = useState(false);
+	// 소통 채팅 패널 표시 여부
+	const [showChat, setShowChat] = useState(false);
+	const [showOriginalGlossary, setShowOriginalGlossary] = useState(false);
+	const [originalGlossaryTerms, setOriginalGlossaryTerms] = useState<
+		GlossaryTermPair[]
+	>([]);
+	/** 헤더 제목·원문 URL 길게/짧게 보기 */
+	const [headerMetaExpanded, setHeaderMetaExpanded] = useState(false);
 
-  // 패널 토글
-  const togglePanel = (panelId: string) => {
-    setCollapsedPanels(prev => {
-      const newSet = new Set(prev);
-      if (newSet.has(panelId)) {
-        newSet.delete(panelId);
-      } else {
-        newSet.add(panelId);
-      }
-      return newSet;
-    });
-  };
+	// iframe refs
+	const originalIframeRef = useRef<HTMLIFrameElement>(null);
+	const aiDraftIframeRef = useRef<HTMLIFrameElement>(null);
+	const currentWorkIframeRef = useRef<HTMLIFrameElement>(null);
 
-  // 전체화면 토글
-  const toggleFullscreen = (panelId: string) => {
-    setFullscreenPanel(prev => prev === panelId ? null : panelId);
-  };
+	useEffect(() => {
+		setHeaderMetaExpanded(false);
+	}, [id]);
 
-  // 번역 대기로 전환 (from=handover 시 관리자 액션)
-  const handleConvertToPending = async () => {
-    if (!documentId || !document) return;
-    if (!window.confirm(`"${document.title}" 문서를 번역 대기 상태로 전환하시겠습니까?`)) return;
-    try {
-      setConvertingToPending(true);
-      const versions = await documentApi.getDocumentVersions(documentId);
-      const latestTranslation = versions
-        .filter((v) => v.versionType === 'MANUAL_TRANSLATION' || v.versionType === 'AI_DRAFT')
-        .sort((a, b) => b.versionNumber - a.versionNumber)[0];
-      if (latestTranslation?.content) {
-        await documentApi.createDocumentVersion(documentId, {
-          versionType: 'MANUAL_TRANSLATION',
-          content: latestTranslation.content,
-        });
-      }
-      await documentApi.updateDocumentStatus(documentId, 'PENDING_TRANSLATION');
-      setDocument((prev) => prev ? { ...prev, status: 'PENDING_TRANSLATION' } : null);
-      // 새 버전 반영을 위해 버전 목록 다시 로드
-      const newVersions = await documentApi.getDocumentVersions(documentId);
-      setVersions(newVersions);
-      const aiDraft = newVersions.find((v) => v.versionType === 'AI_DRAFT');
-      const latestManual = newVersions
-        .filter((v) => v.versionType === 'MANUAL_TRANSLATION')
-        .sort((a, b) => b.versionNumber - a.versionNumber)[0];
-      const newCurrent = latestManual || aiDraft;
-      if (newCurrent) {
-        setCurrentVersionInfo({ version: newCurrent, versionType: newCurrent.versionType });
-        setCurrentVersionHtml(newCurrent.content);
-      }
-      alert('번역 대기 상태로 전환했습니다.');
-    } catch (err: any) {
-      console.error('번역 대기 전환 실패:', err);
-      alert('번역 대기로 전환에 실패했습니다.');
-    } finally {
-      setConvertingToPending(false);
-    }
-  };
+	// 패널 토글
+	const togglePanel = (panelId: string) => {
+		setCollapsedPanels((prev) => {
+			const newSet = new Set(prev);
+			if (newSet.has(panelId)) {
+				newSet.delete(panelId);
+			} else {
+				newSet.add(panelId);
+			}
+			return newSet;
+		});
+	};
 
-  // 초기 데이터 로드
-  useEffect(() => {
-    if (!documentId) {
-      setError('문서 ID가 없습니다.');
-      setLoading(false);
-      return;
-    }
+	// 전체화면 토글
+	const toggleFullscreen = (panelId: string) => {
+		setFullscreenPanel((prev) => (prev === panelId ? null : panelId));
+	};
 
-    const loadData = async () => {
-      try {
-        setLoading(true);
-        setError(null);
+	// 번역 대기로 전환 (from=handover 시 관리자 액션)
+	const handleConvertToPending = async () => {
+		if (!documentId || !document) return;
+		if (
+			!window.confirm(
+				`"${document.title}" 문서를 번역 대기 상태로 전환하시겠습니까?`,
+			)
+		)
+			return;
+		try {
+			setConvertingToPending(true);
+			const versions = await documentApi.getDocumentVersions(documentId);
+			const latestTranslation = versions
+				.filter(
+					(v) =>
+						v.versionType === "MANUAL_TRANSLATION" ||
+						v.versionType === "AI_DRAFT",
+				)
+				.sort((a, b) => b.versionNumber - a.versionNumber)[0];
+			if (latestTranslation?.content) {
+				await documentApi.createDocumentVersion(documentId, {
+					versionType: "MANUAL_TRANSLATION",
+					content: latestTranslation.content,
+				});
+			}
+			await documentApi.updateDocumentStatus(documentId, "PENDING_TRANSLATION");
+			setDocument((prev) =>
+				prev ? { ...prev, status: "PENDING_TRANSLATION" } : null,
+			);
+			// 새 버전 반영을 위해 버전 목록 다시 로드
+			const newVersions = await documentApi.getDocumentVersions(documentId);
+			setVersions(newVersions);
+			const aiDraft = newVersions.find((v) => v.versionType === "AI_DRAFT");
+			const latestManual = newVersions
+				.filter((v) => v.versionType === "MANUAL_TRANSLATION")
+				.sort((a, b) => b.versionNumber - a.versionNumber)[0];
+			const newCurrent = latestManual || aiDraft;
+			if (newCurrent) {
+				setCurrentVersionInfo({
+					version: newCurrent,
+					versionType: newCurrent.versionType,
+				});
+				setCurrentVersionHtml(newCurrent.content);
+			}
+			alert("번역 대기 상태로 전환했습니다.");
+		} catch (err: any) {
+			console.error("번역 대기 전환 실패:", err);
+			alert("번역 대기로 전환에 실패했습니다.");
+		} finally {
+			setConvertingToPending(false);
+		}
+	};
 
-        // 1. 문서 정보 가져오기
-        const doc = await documentApi.getDocument(documentId);
-        setDocument(doc);
+	// 초기 데이터 로드
+	useEffect(() => {
+		if (!documentId) {
+			setError("문서 ID가 없습니다.");
+			setLoading(false);
+			return;
+		}
 
-        // 원문(Version 0)용 용어집 sourceTerm 로드
-        try {
-          const sourceLangRaw = (doc.sourceLang || '').toUpperCase();
-          const sourceLang = sourceLangRaw === 'AUTO' ? 'EN' : sourceLangRaw;
-          const targetLang = (doc.targetLang || '').toUpperCase();
-          if (sourceLang && targetLang) {
-            const termRes = await termApi.getAllTerms({ sourceLang, targetLang, page: 0, size: 1000 });
-            setOriginalGlossaryTerms(
-              (termRes.content || [])
-                .filter((t) => t.sourceTerm && t.targetTerm)
-                .map((t) => ({ sourceTerm: t.sourceTerm, targetTerm: t.targetTerm }))
-            );
-          } else {
-            setOriginalGlossaryTerms([]);
-          }
-        } catch (e) {
-          console.warn('원문 용어집 로드 실패:', e);
-          setOriginalGlossaryTerms([]);
-        }
+		const loadData = async () => {
+			try {
+				setLoading(true);
+				setError(null);
 
-        // 2. 문서 버전 목록 가져오기
-        const versionList = await documentApi.getDocumentVersions(documentId);
-        setVersions(versionList);
+				// 1. 문서 정보 가져오기
+				const doc = await documentApi.getDocument(documentId);
+				setDocument(doc);
 
-        // 3. 버전별 HTML 콘텐츠 설정
-        const originalVersion = versionList.find(v => v.versionType === 'ORIGINAL');
-        const aiDraftVersion = versionList.find(v => v.versionType === 'AI_DRAFT');
-        
-        // 현재 버전 결정 (문서 상태에 따라)
-        let currentVersion: DocumentVersionResponse | undefined;
-        let currentVersionType = '';
-        const status = doc.status as DocumentState;
-        
-        if (status === DocumentState.PUBLISHED || status === DocumentState.APPROVED) {
-          // 게시 완료/승인 완료:
-          // 1) isFinal=true 인 버전 우선
-          // 2) 없으면 versionType === 'FINAL'
-          // 3) 그래도 없으면 가장 최신 MANUAL_TRANSLATION
-          const finalByFlag = versionList.find(v => v.isFinal === true);
-          const finalByType = versionList.find(v => v.versionType === 'FINAL');
-          const latestManual = versionList
-            .filter(v => v.versionType === 'MANUAL_TRANSLATION')
-            .sort((a, b) => b.versionNumber - a.versionNumber)[0];
-          
-          currentVersion = finalByFlag || finalByType || latestManual;
-          if (currentVersion) {
-            currentVersionType = currentVersion.isFinal ? 'FINAL' : currentVersion.versionType;
-          }
-        } else if (status === DocumentState.PENDING_REVIEW) {
-          // 검토 중: FINAL(플래그/타입) 또는 MANUAL_TRANSLATION
-          const finalByFlag = versionList.find(v => v.isFinal === true);
-          const finalByType = versionList.find(v => v.versionType === 'FINAL');
-          currentVersion = finalByFlag || finalByType ||
-                          versionList.find(v => v.versionType === 'MANUAL_TRANSLATION');
-          currentVersionType = currentVersion
-            ? (currentVersion.isFinal ? 'FINAL' : currentVersion.versionType)
-            : '';
-        } else if (status === DocumentState.IN_TRANSLATION) {
-          // 번역 중: MANUAL_TRANSLATION (있다면), 없으면 AI_DRAFT
-          currentVersion = versionList.find(v => v.versionType === 'MANUAL_TRANSLATION') ||
-                          aiDraftVersion;
-          currentVersionType = currentVersion?.versionType || '';
-        } else if (status === DocumentState.DRAFT || status === DocumentState.PENDING_TRANSLATION) {
-          // 초안/번역 대기: MANUAL_TRANSLATION 최신, 없으면 AI_DRAFT
-          const latestManual = versionList
-            .filter(v => v.versionType === 'MANUAL_TRANSLATION')
-            .sort((a, b) => b.versionNumber - a.versionNumber)[0];
-          currentVersion = latestManual || aiDraftVersion;
-          currentVersionType = currentVersion?.versionType || '';
-        }
+				// 원문(Version 0)용 용어집 sourceTerm 로드
+				try {
+					const sourceLangRaw = (doc.sourceLang || "").toUpperCase();
+					const sourceLang = sourceLangRaw === "AUTO" ? "EN" : sourceLangRaw;
+					const targetLang = (doc.targetLang || "").toUpperCase();
+					if (sourceLang && targetLang) {
+						const termRes = await termApi.getAllTerms({
+							sourceLang,
+							targetLang,
+							page: 0,
+							size: 1000,
+						});
+						setOriginalGlossaryTerms(
+							(termRes.content || [])
+								.filter((t) => t.sourceTerm && t.targetTerm)
+								.map((t) => ({
+									sourceTerm: t.sourceTerm,
+									targetTerm: t.targetTerm,
+								})),
+						);
+					} else {
+						setOriginalGlossaryTerms([]);
+					}
+				} catch (e) {
+					console.warn("원문 용어집 로드 실패:", e);
+					setOriginalGlossaryTerms([]);
+				}
 
-        setOriginalHtml(originalVersion?.content || '');
-        setAiDraftHtml(removeLegacyGlossaryMarkup(aiDraftVersion?.content || ''));
-        setCurrentVersionHtml(currentVersion?.content || '');
-        setCurrentVersionInfo({ 
-          version: currentVersion || null, 
-          versionType: currentVersionType 
-        });
+				// 2. 문서 버전 목록 가져오기
+				const versionList = await documentApi.getDocumentVersions(documentId);
+				setVersions(versionList);
 
-      } catch (err: any) {
-        console.error('문서 상세 정보 로드 실패:', err);
-        setError(err.response?.data?.message || '문서 정보를 불러오는데 실패했습니다.');
-      } finally {
-        setLoading(false);
-      }
-    };
+				// 3. 버전별 HTML 콘텐츠 설정
+				const originalVersion = versionList.find(
+					(v) => v.versionType === "ORIGINAL",
+				);
+				const aiDraftVersion = versionList.find(
+					(v) => v.versionType === "AI_DRAFT",
+				);
 
-    loadData();
-  }, [documentId]);
+				// 현재 버전 결정 (문서 상태에 따라)
+				let currentVersion: DocumentVersionResponse | undefined;
+				let currentVersionType = "";
+				const status = doc.status as DocumentState;
 
-  // 원문 iframe 렌더링
-  useEffect(() => {
-    const iframe = originalIframeRef.current;
-    if (!iframe || !originalHtml) return;
+				if (
+					status === DocumentState.PUBLISHED ||
+					status === DocumentState.APPROVED
+				) {
+					// 게시 완료/승인 완료:
+					// 1) isFinal=true 인 버전 우선
+					// 2) 없으면 versionType === 'FINAL'
+					// 3) 그래도 없으면 가장 최신 MANUAL_TRANSLATION
+					const finalByFlag = versionList.find((v) => v.isFinal === true);
+					const finalByType = versionList.find(
+						(v) => v.versionType === "FINAL",
+					);
+					const latestManual = versionList
+						.filter((v) => v.versionType === "MANUAL_TRANSLATION")
+						.sort((a, b) => b.versionNumber - a.versionNumber)[0];
 
-    const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-    if (iframeDoc) {
-      try {
-        iframeDoc.open();
-        iframeDoc.write(originalHtml);
-        iframeDoc.close();
+					currentVersion = finalByFlag || finalByType || latestManual;
+					if (currentVersion) {
+						currentVersionType = currentVersion.isFinal
+							? "FINAL"
+							: currentVersion.versionType;
+					}
+				} else if (status === DocumentState.PENDING_REVIEW) {
+					// 검토 중: FINAL(플래그/타입) 또는 MANUAL_TRANSLATION
+					const finalByFlag = versionList.find((v) => v.isFinal === true);
+					const finalByType = versionList.find(
+						(v) => v.versionType === "FINAL",
+					);
+					currentVersion =
+						finalByFlag ||
+						finalByType ||
+						versionList.find((v) => v.versionType === "MANUAL_TRANSLATION");
+					currentVersionType = currentVersion
+						? currentVersion.isFinal
+							? "FINAL"
+							: currentVersion.versionType
+						: "";
+				} else if (status === DocumentState.IN_TRANSLATION) {
+					// 번역 중: MANUAL_TRANSLATION (있다면), 없으면 AI_DRAFT
+					currentVersion =
+						versionList.find((v) => v.versionType === "MANUAL_TRANSLATION") ||
+						aiDraftVersion;
+					currentVersionType = currentVersion?.versionType || "";
+				} else if (
+					status === DocumentState.DRAFT ||
+					status === DocumentState.PENDING_TRANSLATION
+				) {
+					// 초안/번역 대기: MANUAL_TRANSLATION 최신, 없으면 AI_DRAFT
+					const latestManual = versionList
+						.filter((v) => v.versionType === "MANUAL_TRANSLATION")
+						.sort((a, b) => b.versionNumber - a.versionNumber)[0];
+					currentVersion = latestManual || aiDraftVersion;
+					currentVersionType = currentVersion?.versionType || "";
+				}
 
-        // 경계선 제거 + 원문 용어 표시 CSS 주입
-        const style = iframeDoc.createElement('style');
-        style.textContent = `
+				setOriginalHtml(originalVersion?.content || "");
+				setAiDraftHtml(
+					removeLegacyGlossaryMarkup(aiDraftVersion?.content || ""),
+				);
+				setCurrentVersionHtml(currentVersion?.content || "");
+				setCurrentVersionInfo({
+					version: currentVersion || null,
+					versionType: currentVersionType,
+				});
+			} catch (err: any) {
+				console.error("문서 상세 정보 로드 실패:", err);
+				setError(
+					err.response?.data?.message || "문서 정보를 불러오는데 실패했습니다.",
+				);
+			} finally {
+				setLoading(false);
+			}
+		};
+
+		loadData();
+	}, [documentId]);
+
+	// 원문 iframe 렌더링
+	useEffect(() => {
+		const iframe = originalIframeRef.current;
+		if (!iframe || !originalHtml) return;
+
+		const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
+		if (iframeDoc) {
+			try {
+				iframeDoc.open();
+				iframeDoc.write(originalHtml);
+				iframeDoc.close();
+
+				// 경계선 제거 + 원문 용어 표시 CSS 주입
+				const style = iframeDoc.createElement("style");
+				style.textContent = `
           * {
             border: none !important;
             outline: none !important;
@@ -355,38 +428,44 @@ export default function DocumentDetail() {
             padding: 0 2px;
           }
         `;
-        iframeDoc.head.appendChild(style);
+				iframeDoc.head.appendChild(style);
 
-        if (showOriginalGlossary) {
-          highlightGlossaryInOriginalIframe(iframeDoc, originalGlossaryTerms);
-        }
+				if (showOriginalGlossary) {
+					highlightGlossaryInOriginalIframe(iframeDoc, originalGlossaryTerms);
+				}
 
-        // 편집 불가능하게 설정
-        if (iframeDoc.body) {
-          iframeDoc.body.style.cursor = 'default';
-          iframeDoc.body.contentEditable = 'false';
-        }
-      } catch (error) {
-        console.error('❌ 원문 iframe 오류:', error);
-      }
-    }
-  }, [originalHtml, collapsedPanels, fullscreenPanel, showOriginalGlossary, originalGlossaryTerms]);
+				// 편집 불가능하게 설정
+				if (iframeDoc.body) {
+					iframeDoc.body.style.cursor = "default";
+					iframeDoc.body.contentEditable = "false";
+				}
+			} catch (error) {
+				console.error("❌ 원문 iframe 오류:", error);
+			}
+		}
+	}, [
+		originalHtml,
+		collapsedPanels,
+		fullscreenPanel,
+		showOriginalGlossary,
+		originalGlossaryTerms,
+	]);
 
-  // AI 초벌 번역 iframe 렌더링
-  useEffect(() => {
-    const iframe = aiDraftIframeRef.current;
-    if (!iframe || !aiDraftHtml) return;
+	// AI 초벌 번역 iframe 렌더링
+	useEffect(() => {
+		const iframe = aiDraftIframeRef.current;
+		if (!iframe || !aiDraftHtml) return;
 
-    const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-    if (iframeDoc) {
-      try {
-        iframeDoc.open();
-        iframeDoc.write(aiDraftHtml);
-        iframeDoc.close();
+		const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
+		if (iframeDoc) {
+			try {
+				iframeDoc.open();
+				iframeDoc.write(aiDraftHtml);
+				iframeDoc.close();
 
-        // 경계선 제거 CSS 주입
-        const style = iframeDoc.createElement('style');
-        style.textContent = `
+				// 경계선 제거 CSS 주입
+				const style = iframeDoc.createElement("style");
+				style.textContent = `
           * {
             border: none !important;
             outline: none !important;
@@ -395,34 +474,34 @@ export default function DocumentDetail() {
             cursor: default !important;
           }
         `;
-        iframeDoc.head.appendChild(style);
+				iframeDoc.head.appendChild(style);
 
-        // 편집 불가능하게 설정
-        if (iframeDoc.body) {
-          iframeDoc.body.style.cursor = 'default';
-          iframeDoc.body.contentEditable = 'false';
-        }
-      } catch (error) {
-        console.error('❌ AI 초벌 iframe 오류:', error);
-      }
-    }
-  }, [aiDraftHtml, collapsedPanels, fullscreenPanel]);
+				// 편집 불가능하게 설정
+				if (iframeDoc.body) {
+					iframeDoc.body.style.cursor = "default";
+					iframeDoc.body.contentEditable = "false";
+				}
+			} catch (error) {
+				console.error("❌ AI 초벌 iframe 오류:", error);
+			}
+		}
+	}, [aiDraftHtml, collapsedPanels, fullscreenPanel]);
 
-  // 현재 버전 iframe 렌더링
-  useEffect(() => {
-    const iframe = currentWorkIframeRef.current;
-    if (!iframe || !currentVersionHtml) return;
+	// 현재 버전 iframe 렌더링
+	useEffect(() => {
+		const iframe = currentWorkIframeRef.current;
+		if (!iframe || !currentVersionHtml) return;
 
-    const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-    if (iframeDoc) {
-      try {
-        iframeDoc.open();
-        iframeDoc.write(currentVersionHtml);
-        iframeDoc.close();
+		const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
+		if (iframeDoc) {
+			try {
+				iframeDoc.open();
+				iframeDoc.write(currentVersionHtml);
+				iframeDoc.close();
 
-        // 경계선 제거 CSS 주입
-        const style = iframeDoc.createElement('style');
-        style.textContent = `
+				// 경계선 제거 CSS 주입
+				const style = iframeDoc.createElement("style");
+				style.textContent = `
           * {
             border: none !important;
             outline: none !important;
@@ -431,686 +510,925 @@ export default function DocumentDetail() {
             cursor: default !important;
           }
         `;
-        iframeDoc.head.appendChild(style);
+				iframeDoc.head.appendChild(style);
 
-        // 편집 불가능하게 설정
-        if (iframeDoc.body) {
-          iframeDoc.body.style.cursor = 'default';
-          iframeDoc.body.contentEditable = 'false';
-        }
-      } catch (error) {
-        console.error('❌ 현재 버전 iframe 오류:', error);
-      }
-    }
-  }, [currentVersionHtml, collapsedPanels, fullscreenPanel]);
+				// 편집 불가능하게 설정
+				if (iframeDoc.body) {
+					iframeDoc.body.style.cursor = "default";
+					iframeDoc.body.contentEditable = "false";
+				}
+			} catch (error) {
+				console.error("❌ 현재 버전 iframe 오류:", error);
+			}
+		}
+	}, [currentVersionHtml, collapsedPanels, fullscreenPanel]);
 
-  if (loading) {
-    return (
-      <div
-        style={{
-          display: 'flex',
-          justifyContent: 'center',
-          alignItems: 'center',
-          height: '100vh',
-          color: colors.primaryText,
-        }}
-      >
-        로딩 중...
-      </div>
-    );
-  }
+	if (loading) {
+		return (
+			<div
+				style={{
+					display: "flex",
+					justifyContent: "center",
+					alignItems: "center",
+					height: "100vh",
+					color: colors.primaryText,
+				}}
+			>
+				로딩 중...
+			</div>
+		);
+	}
 
-  if (error) {
-    return (
-      <div
-        style={{
-          padding: '24px',
-          backgroundColor: colors.primaryBackground,
-          minHeight: '100vh',
-        }}
-      >
-        <div
-          style={{
-            maxWidth: '1600px',
-            margin: '0 auto',
-            padding: '24px',
-            backgroundColor: colors.surface,
-            border: `1px solid ${colors.border}`,
-            borderRadius: '8px',
-          }}
-        >
-          <h2 style={{ color: '#d32f2f', marginBottom: '16px' }}>오류</h2>
-          <p style={{ color: colors.primaryText, marginBottom: '16px' }}>{error}</p>
-          <Button variant="secondary" onClick={() => navigate(from === 'pending' ? '/translations/pending' : from === 'working' ? '/translations/working' : from === 'favorites' ? '/translations/favorites' : '/documents')}>
-            문서 목록으로 돌아가기
-          </Button>
-        </div>
-      </div>
-    );
-  }
+	if (error) {
+		return (
+			<div
+				style={{
+					padding: "24px",
+					backgroundColor: colors.primaryBackground,
+					minHeight: "100vh",
+				}}
+			>
+				<div
+					style={{
+						maxWidth: "1600px",
+						margin: "0 auto",
+						padding: "24px",
+						backgroundColor: colors.surface,
+						border: `1px solid ${colors.border}`,
+						borderRadius: "8px",
+					}}
+				>
+					<h2 style={{ color: "#d32f2f", marginBottom: "16px" }}>오류</h2>
+					<p style={{ color: colors.primaryText, marginBottom: "16px" }}>
+						{error}
+					</p>
+					<Button
+						variant="secondary"
+						onClick={() =>
+							navigate(
+								from === "pending"
+									? "/translations/pending"
+									: from === "working"
+										? "/translations/working"
+										: from === "favorites"
+											? "/translations/favorites"
+											: "/documents",
+							)
+						}
+					>
+						문서 목록으로 돌아가기
+					</Button>
+				</div>
+			</div>
+		);
+	}
 
-  if (!document) {
-    return (
-      <div
-        style={{
-          padding: '24px',
-          backgroundColor: colors.primaryBackground,
-          minHeight: '100vh',
-        }}
-      >
-        <div
-          style={{
-            maxWidth: '1600px',
-            margin: '0 auto',
-            padding: '24px',
-            backgroundColor: colors.surface,
-            border: `1px solid ${colors.border}`,
-            borderRadius: '8px',
-          }}
-        >
-          <p style={{ color: colors.primaryText }}>문서를 찾을 수 없습니다.</p>
-          <Button variant="secondary" onClick={() => navigate(from === 'pending' ? '/translations/pending' : from === 'working' ? '/translations/working' : from === 'favorites' ? '/translations/favorites' : '/documents')}>
-            문서 목록으로 돌아가기
-          </Button>
-        </div>
-      </div>
-    );
-  }
+	if (!document) {
+		return (
+			<div
+				style={{
+					padding: "24px",
+					backgroundColor: colors.primaryBackground,
+					minHeight: "100vh",
+				}}
+			>
+				<div
+					style={{
+						maxWidth: "1600px",
+						margin: "0 auto",
+						padding: "24px",
+						backgroundColor: colors.surface,
+						border: `1px solid ${colors.border}`,
+						borderRadius: "8px",
+					}}
+				>
+					<p style={{ color: colors.primaryText }}>문서를 찾을 수 없습니다.</p>
+					<Button
+						variant="secondary"
+						onClick={() =>
+							navigate(
+								from === "pending"
+									? "/translations/pending"
+									: from === "working"
+										? "/translations/working"
+										: from === "favorites"
+											? "/translations/favorites"
+											: "/documents",
+							)
+						}
+					>
+						문서 목록으로 돌아가기
+					</Button>
+				</div>
+			</div>
+		);
+	}
 
-  // 현재 버전 제목 결정 (버전 번호 + FINAL 여부 포함)
-  const getCurrentVersionTitle = (): string => {
-    if (currentVersionInfo.version) {
-      const isFinal =
-        currentVersionInfo.version.isFinal === true ||
-        currentVersionInfo.versionType === 'FINAL';
-      if (isFinal) {
-        return `현재 버전 (FINAL · Version ${currentVersionInfo.version.versionNumber})`;
-      }
-      return `현재 버전 (Version ${currentVersionInfo.version.versionNumber})`;
-    }
-    return '현재 버전';
-  };
+	// 현재 버전 제목 결정 (버전 번호 + FINAL 여부 포함)
+	const getCurrentVersionTitle = (): string => {
+		if (currentVersionInfo.version) {
+			const isFinal =
+				currentVersionInfo.version.isFinal === true ||
+				currentVersionInfo.versionType === "FINAL";
+			if (isFinal) {
+				return `현재 버전 (FINAL · Version ${currentVersionInfo.version.versionNumber})`;
+			}
+			return `현재 버전 (Version ${currentVersionInfo.version.versionNumber})`;
+		}
+		return "현재 버전";
+	};
 
-  const panels = [
-    { 
-      id: 'original', 
-      title: '원문 (Version 0)', 
-      ref: originalIframeRef, 
-      html: originalHtml,
-      hasContent: !!originalHtml,
-    },
-    { 
-      id: 'aiDraft', 
-      title: 'AI 초벌 번역 (Version 1)', 
-      ref: aiDraftIframeRef, 
-      html: aiDraftHtml,
-      hasContent: !!aiDraftHtml,
-    },
-    { 
-      id: 'currentVersion', 
-      title: getCurrentVersionTitle(), 
-      ref: currentWorkIframeRef, 
-      html: currentVersionHtml,
-      hasContent: !!currentVersionHtml,
-    },
-  ];
+	const panels = [
+		{
+			id: "original",
+			title: "원문 (Version 0)",
+			ref: originalIframeRef,
+			html: originalHtml,
+			hasContent: !!originalHtml,
+		},
+		{
+			id: "aiDraft",
+			title: "AI 초벌 번역 (Version 1)",
+			ref: aiDraftIframeRef,
+			html: aiDraftHtml,
+			hasContent: !!aiDraftHtml,
+		},
+		{
+			id: "currentVersion",
+			title: getCurrentVersionTitle(),
+			ref: currentWorkIframeRef,
+			html: currentVersionHtml,
+			hasContent: !!currentVersionHtml,
+		},
+	];
 
-  const visiblePanels = panels.filter(p => !collapsedPanels.has(p.id) && p.hasContent);
-  const hasFullscreen = fullscreenPanel !== null;
+	const visiblePanels = panels.filter(
+		(p) => !collapsedPanels.has(p.id) && p.hasContent,
+	);
+	const hasFullscreen = fullscreenPanel !== null;
 
-  return (
-    <ErrorBoundary>
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          height: '100vh',
-          backgroundColor: colors.primaryBackground,
-        }}
-      >
-        {/* 헤더 */}
-        <div
-          style={{
-            padding: '12px 24px',
-            backgroundColor: colors.surface,
-            borderBottom: `1px solid ${colors.border}`,
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-            gap: '16px',
-            minWidth: 0,
-            maxWidth: '100%',
-            boxSizing: 'border-box',
-          }}
-        >
-          {/* 왼쪽: 뒤로가기 + 문서 정보 (minWidth:0으로 flex 안에서 줄어들 수 있게) */}
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: '16px',
-              flex: 1,
-              minWidth: 0,
-              overflow: 'hidden',
-            }}
-          >
-            <Button
-              variant="secondary"
-              onClick={() => navigate(
-                from === 'pending' ? '/translations/pending'
-                : from === 'working' ? '/translations/working'
-                : from === 'favorites' ? '/translations/favorites'
-                : from === 'handover' ? '/documents/handovers'
-                : '/documents'
-              )}
-              style={{ fontSize: '12px', padding: '6px 12px', flexShrink: 0 }}
-            >
-              ← 뒤로가기
-            </Button>
+	return (
+		<ErrorBoundary>
+			<div
+				style={{
+					display: "flex",
+					flexDirection: "column",
+					height: "100vh",
+					backgroundColor: colors.primaryBackground,
+				}}
+			>
+				{/* 헤더 */}
+				<div
+					style={{
+						padding: "12px 24px",
+						backgroundColor: colors.surface,
+						borderBottom: `1px solid ${colors.border}`,
+						display: "flex",
+						justifyContent: "space-between",
+						alignItems: "center",
+						gap: "16px",
+						minWidth: 0,
+						maxWidth: "100%",
+						boxSizing: "border-box",
+					}}
+				>
+					{/* 왼쪽: 뒤로가기 + 문서 정보 (minWidth:0으로 flex 안에서 줄어들 수 있게) */}
+					<div
+						style={{
+							display: "flex",
+							alignItems: "center",
+							gap: "16px",
+							flex: 1,
+							minWidth: 0,
+							overflow: "hidden",
+						}}
+					>
+						<Button
+							variant="secondary"
+							onClick={() =>
+								navigate(
+									from === "pending"
+										? "/translations/pending"
+										: from === "working"
+											? "/translations/working"
+											: from === "favorites"
+												? "/translations/favorites"
+												: from === "handover"
+													? "/documents/handovers"
+													: "/documents",
+								)
+							}
+							style={{ fontSize: "12px", padding: "6px 12px", flexShrink: 0 }}
+						>
+							← 뒤로가기
+						</Button>
 
-            {document && (
-              <div
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: '12px',
-                  minWidth: 0,
-                  flex: 1,
-                  overflow: 'hidden',
-                }}
-              >
-                {document.latestHandover && from === 'handover' && (
-                  <Button
-                    variant="secondary"
-                    onClick={() => setShowHandoverModal(true)}
-                    style={{ fontSize: '12px', padding: '6px 12px', whiteSpace: 'nowrap', flexShrink: 0, borderColor: '#FFB300', color: '#B8860B', backgroundColor: '#FFFDE7' }}
-                  >
-                    📋 인계 메모 확인
-                  </Button>
-                )}
-                <div
-                  style={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    gap: '2px',
-                    minWidth: 0,
-                    flex: 1,
-                    overflow: 'hidden',
-                  }}
-                >
-                  <div
-                    style={{
-                      fontSize: '12px',
-                      color: colors.secondaryText,
-                      marginBottom: '2px',
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                      whiteSpace: 'nowrap',
-                    }}
-                  >
-                    최근 수정: {formatLastModifiedDateDisplay(document.updatedAt) || '-'}
-                  </div>
-                <div
-                  style={{
-                    display: 'flex',
-                    alignItems: 'flex-start',
-                    gap: '6px',
-                    minWidth: 0,
-                  }}
-                >
-                  <div
-                    id="document-detail-header-meta"
-                    style={{
-                      flex: 1,
-                      minWidth: 0,
-                      maxHeight: headerMetaExpanded ? 'min(32vh, 240px)' : undefined,
-                      overflowY: headerMetaExpanded ? 'auto' : 'hidden',
-                      overflowX: 'hidden',
-                    }}
-                  >
-                    <div
-                      style={{
-                        fontSize: '14px',
-                        fontWeight: 600,
-                        color: '#000000',
-                        minWidth: 0,
-                        ...(headerMetaExpanded
-                          ? {
-                              whiteSpace: 'normal',
-                              wordBreak: 'break-word',
-                            }
-                          : {
-                              overflow: 'hidden',
-                              textOverflow: 'ellipsis',
-                              whiteSpace: 'nowrap',
-                            }),
-                      }}
-                      title={headerMetaExpanded ? undefined : document.title}
-                    >
-                      {document.title}
-                    </div>
-                    {document.originalUrl?.trim() && (
-                      <div
-                        style={{
-                          marginTop: '6px',
-                          display: 'flex',
-                          alignItems: headerMetaExpanded ? 'flex-start' : 'center',
-                          gap: '6px',
-                          minWidth: 0,
-                          maxWidth: '100%',
-                          flexDirection: headerMetaExpanded ? 'column' : 'row',
-                        }}
-                      >
-                        <span
-                          style={{
-                            fontSize: '12px',
-                            color: colors.secondaryText,
-                            flexShrink: 0,
-                          }}
-                        >
-                          원문 URL:
-                        </span>
-                        <a
-                          href={document.originalUrl.trim()}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          title={
-                            headerMetaExpanded
-                              ? undefined
-                              : document.originalUrl.trim()
-                          }
-                          style={{
-                            fontSize: '12px',
-                            color: '#2563eb',
-                            textDecoration: 'none',
-                            minWidth: 0,
-                            ...(headerMetaExpanded
-                              ? {
-                                  wordBreak: 'break-all',
-                                  whiteSpace: 'normal',
-                                }
-                              : {
-                                  flex: 1,
-                                  overflow: 'hidden',
-                                  textOverflow: 'ellipsis',
-                                  whiteSpace: 'nowrap',
-                                }),
-                          }}
-                        >
-                          {document.originalUrl.trim()}
-                        </a>
-                      </div>
-                    )}
-                  </div>
-                  <button
-                    type="button"
-                    aria-expanded={headerMetaExpanded}
-                    aria-controls="document-detail-header-meta"
-                    title={headerMetaExpanded ? '짧게 보기' : '길게 보기'}
-                    onClick={() => setHeaderMetaExpanded((v) => !v)}
-                    style={{
-                      flexShrink: 0,
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      width: '28px',
-                      height: '28px',
-                      padding: 0,
-                      marginTop: '1px',
-                      border: `1px solid ${colors.border}`,
-                      borderRadius: '6px',
-                      backgroundColor: colors.surface,
-                      color: colors.primaryText,
-                      cursor: 'pointer',
-                    }}
-                  >
-                    {headerMetaExpanded ? (
-                      <ChevronUp size={18} strokeWidth={2} aria-hidden />
-                    ) : (
-                      <ChevronDown size={18} strokeWidth={2} aria-hidden />
-                    )}
-                  </button>
-                </div>
-                <div
-                  style={{
-                    display: 'flex',
-                    gap: '12px',
-                    alignItems: 'center',
-                    minWidth: 0,
-                    overflow: 'hidden',
-                  }}
-                >
-                  <span
-                    style={{
-                      fontSize: '11px',
-                      color: colors.secondaryText,
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                      whiteSpace: 'nowrap',
-                    }}
-                  >
-                    {document.categoryId ? `카테고리 ${document.categoryId}` : '미분류'} · {
-                      currentVersionInfo.version 
-                        ? currentVersionInfo.version.isFinal === true || currentVersionInfo.versionType === 'FINAL'
-                          ? `FINAL · Version ${currentVersionInfo.version.versionNumber}`
-                          : `Version ${currentVersionInfo.version.versionNumber}`
-                        : document.hasVersions === false 
-                          ? '버전 없음'
-                          : 'Version 1'
-                    }
-                  </span>
-                </div>
-                </div>
-              </div>
-            )}
-          </div>
-          
-          {/* 중앙: 문서 보기 옵션 (체크박스로 각 버전 표시/숨김) */}
-          <div style={{
-            display: 'flex', 
-            alignItems: 'center', 
-            gap: '24px',
-            padding: '6px 16px',
-            backgroundColor: '#F8F9FA',
-            borderRadius: '6px',
-            border: '1px solid #D3D3D3',
-            flexShrink: 0,
-          }}>
-            <span style={{ fontSize: '12px', fontWeight: 600, color: colors.primaryText }}>문서 보기:</span>
-            <label style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: '8px',
-              fontSize: '13px',
-              cursor: 'pointer',
-              fontWeight: 500,
-              color: '#7a4b00',
-            }}>
-              <input
-                type="checkbox"
-                checked={showOriginalGlossary}
-                onChange={(e) => setShowOriginalGlossary(e.target.checked)}
-                style={{ cursor: 'pointer', width: '16px', height: '16px' }}
-              />
-              <span>Version 0 용어집 적용 구간 보기</span>
-            </label>
-            <label style={{ 
-              display: 'flex', 
-              alignItems: 'center', 
-              gap: '8px', 
-              fontSize: '13px', 
-              cursor: 'pointer',
-              fontWeight: 500,
-            }}>
-              <input
-                type="checkbox"
-                checked={!collapsedPanels.has('original')}
-                onChange={() => togglePanel('original')}
-                style={{
-                  cursor: 'pointer',
-                  width: '16px',
-                  height: '16px',
-                }}
-              />
-              <span>원문 (Version 0)</span>
-            </label>
-            <label style={{ 
-              display: 'flex', 
-              alignItems: 'center', 
-              gap: '8px', 
-              fontSize: '13px', 
-              cursor: 'pointer',
-              fontWeight: 500,
-            }}>
-              <input
-                type="checkbox"
-                checked={!collapsedPanels.has('aiDraft')}
-                onChange={() => togglePanel('aiDraft')}
-                style={{ 
-                  cursor: 'pointer',
-                  width: '16px',
-                  height: '16px',
-                }}
-              />
-              <span>AI 초벌 번역 (Version 1)</span>
-            </label>
-            <label style={{ 
-              display: 'flex', 
-              alignItems: 'center', 
-              gap: '8px', 
-              fontSize: '13px', 
-              cursor: 'pointer',
-              fontWeight: 500,
-            }}>
-              <input
-                type="checkbox"
-                checked={!collapsedPanels.has('currentVersion')}
-                onChange={() => togglePanel('currentVersion')}
-                style={{ 
-                  cursor: 'pointer',
-                  width: '16px',
-                  height: '16px',
-                }}
-              />
-              <span>
-                {currentVersionInfo.version 
-                  ? (currentVersionInfo.version.isFinal === true || currentVersionInfo.versionType === 'FINAL'
-                      ? `현재 버전 (FINAL · Version ${currentVersionInfo.version.versionNumber})`
-                      : `현재 버전 (Version ${currentVersionInfo.version.versionNumber})`)
-                  : '현재 버전'}
-              </span>
-            </label>
-          </div>
+						{document && (
+							<div
+								style={{
+									display: "flex",
+									alignItems: "center",
+									gap: "12px",
+									minWidth: 0,
+									flex: 1,
+									overflow: "hidden",
+								}}
+							>
+								{document.latestHandover && from === "handover" && (
+									<Button
+										variant="secondary"
+										onClick={() => setShowHandoverModal(true)}
+										style={{
+											fontSize: "12px",
+											padding: "6px 12px",
+											whiteSpace: "nowrap",
+											flexShrink: 0,
+											borderColor: "#FFB300",
+											color: "#B8860B",
+											backgroundColor: "#FFFDE7",
+										}}
+									>
+										📋 인계 메모 확인
+									</Button>
+								)}
+								<div
+									style={{
+										display: "flex",
+										flexDirection: "column",
+										gap: "2px",
+										minWidth: 0,
+										flex: 1,
+										overflow: "hidden",
+									}}
+								>
+									<div
+										style={{
+											fontSize: "12px",
+											color: colors.secondaryText,
+											marginBottom: "2px",
+											overflow: "hidden",
+											textOverflow: "ellipsis",
+											whiteSpace: "nowrap",
+										}}
+									>
+										최근 수정:{" "}
+										{formatLastModifiedDateDisplay(document.updatedAt) || "-"}
+									</div>
+									<div
+										style={{
+											display: "flex",
+											alignItems: "flex-start",
+											gap: "6px",
+											minWidth: 0,
+										}}
+									>
+										<div
+											id="document-detail-header-meta"
+											style={{
+												flex: 1,
+												minWidth: 0,
+												maxHeight: headerMetaExpanded
+													? "min(32vh, 240px)"
+													: undefined,
+												overflowY: headerMetaExpanded ? "auto" : "hidden",
+												overflowX: "hidden",
+											}}
+										>
+											<div
+												style={{
+													fontSize: "14px",
+													fontWeight: 600,
+													color: "#000000",
+													minWidth: 0,
+													...(headerMetaExpanded
+														? {
+																whiteSpace: "normal",
+																wordBreak: "break-word",
+															}
+														: {
+																overflow: "hidden",
+																textOverflow: "ellipsis",
+																whiteSpace: "nowrap",
+															}),
+												}}
+												title={headerMetaExpanded ? undefined : document.title}
+											>
+												{document.title}
+											</div>
+											{document.originalUrl?.trim() && (
+												<div
+													style={{
+														marginTop: "6px",
+														display: "flex",
+														alignItems: headerMetaExpanded
+															? "flex-start"
+															: "center",
+														gap: "6px",
+														minWidth: 0,
+														maxWidth: "100%",
+														flexDirection: headerMetaExpanded
+															? "column"
+															: "row",
+													}}
+												>
+													<span
+														style={{
+															fontSize: "12px",
+															color: colors.secondaryText,
+															flexShrink: 0,
+														}}
+													>
+														원문 URL:
+													</span>
+													<a
+														href={document.originalUrl.trim()}
+														target="_blank"
+														rel="noopener noreferrer"
+														title={
+															headerMetaExpanded
+																? undefined
+																: document.originalUrl.trim()
+														}
+														style={{
+															fontSize: "12px",
+															color: "#2563eb",
+															textDecoration: "none",
+															minWidth: 0,
+															...(headerMetaExpanded
+																? {
+																		wordBreak: "break-all",
+																		whiteSpace: "normal",
+																	}
+																: {
+																		flex: 1,
+																		overflow: "hidden",
+																		textOverflow: "ellipsis",
+																		whiteSpace: "nowrap",
+																	}),
+														}}
+													>
+														{document.originalUrl.trim()}
+													</a>
+												</div>
+											)}
+										</div>
+										<button
+											type="button"
+											aria-expanded={headerMetaExpanded}
+											aria-controls="document-detail-header-meta"
+											title={headerMetaExpanded ? "짧게 보기" : "길게 보기"}
+											onClick={() => setHeaderMetaExpanded((v) => !v)}
+											style={{
+												flexShrink: 0,
+												display: "flex",
+												alignItems: "center",
+												justifyContent: "center",
+												width: "28px",
+												height: "28px",
+												padding: 0,
+												marginTop: "1px",
+												border: `1px solid ${colors.border}`,
+												borderRadius: "6px",
+												backgroundColor: colors.surface,
+												color: colors.primaryText,
+												cursor: "pointer",
+											}}
+										>
+											{headerMetaExpanded ? (
+												<ChevronUp size={18} strokeWidth={2} aria-hidden />
+											) : (
+												<ChevronDown size={18} strokeWidth={2} aria-hidden />
+											)}
+										</button>
+									</div>
+									<div
+										style={{
+											display: "flex",
+											gap: "12px",
+											alignItems: "center",
+											minWidth: 0,
+											overflow: "hidden",
+										}}
+									>
+										<span
+											style={{
+												fontSize: "11px",
+												color: colors.secondaryText,
+												overflow: "hidden",
+												textOverflow: "ellipsis",
+												whiteSpace: "nowrap",
+											}}
+										>
+											{document.categoryId
+												? `카테고리 ${document.categoryId}`
+												: "미분류"}{" "}
+											·{" "}
+											{currentVersionInfo.version
+												? currentVersionInfo.version.isFinal === true ||
+													currentVersionInfo.versionType === "FINAL"
+													? `FINAL · Version ${currentVersionInfo.version.versionNumber}`
+													: `Version ${currentVersionInfo.version.versionNumber}`
+												: document.hasVersions === false
+													? "버전 없음"
+													: "Version 1"}
+										</span>
+									</div>
+								</div>
+							</div>
+						)}
+					</div>
 
-          {/* 우측: 채팅 토글 + 액션 버튼 */}
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px', flexShrink: 0 }}>
-            {/* 소통 채팅 토글 */}
-            <button
-              onClick={() => setShowChat(prev => !prev)}
-              title="소통 채팅"
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: '5px',
-                padding: '7px 14px',
-                fontSize: '13px',
-                fontWeight: 500,
-                border: `1px solid ${showChat ? '#3B82F6' : '#D1D5DB'}`,
-                borderRadius: '6px',
-                backgroundColor: showChat ? '#EFF6FF' : '#FFFFFF',
-                color: showChat ? '#3B82F6' : '#374151',
-                cursor: 'pointer',
-                whiteSpace: 'nowrap',
-              }}
-            >
-              💬 채팅
-            </button>
+					{/* 중앙: 문서 보기 옵션 (체크박스로 각 버전 표시/숨김) */}
+					<div
+						style={{
+							display: "flex",
+							alignItems: "center",
+							gap: "24px",
+							padding: "6px 16px",
+							backgroundColor: "#F8F9FA",
+							borderRadius: "6px",
+							border: "1px solid #D3D3D3",
+							flexShrink: 0,
+						}}
+					>
+						<span
+							style={{
+								fontSize: "12px",
+								fontWeight: 600,
+								color: colors.primaryText,
+							}}
+						>
+							문서 보기:
+						</span>
+						<label
+							style={{
+								display: "flex",
+								alignItems: "center",
+								gap: "8px",
+								fontSize: "13px",
+								cursor: "pointer",
+								fontWeight: 500,
+								color: "#7a4b00",
+							}}
+						>
+							<input
+								type="checkbox"
+								checked={showOriginalGlossary}
+								onChange={(e) => setShowOriginalGlossary(e.target.checked)}
+								style={{ cursor: "pointer", width: "16px", height: "16px" }}
+							/>
+							<span>Version 0 용어집 적용 구간 보기</span>
+						</label>
+						<label
+							style={{
+								display: "flex",
+								alignItems: "center",
+								gap: "8px",
+								fontSize: "13px",
+								cursor: "pointer",
+								fontWeight: 500,
+							}}
+						>
+							<input
+								type="checkbox"
+								checked={!collapsedPanels.has("original")}
+								onChange={() => togglePanel("original")}
+								style={{
+									cursor: "pointer",
+									width: "16px",
+									height: "16px",
+								}}
+							/>
+							<span style={{ color: "black" }}>원문 (Version 0)</span>
+						</label>
+						<label
+							style={{
+								display: "flex",
+								alignItems: "center",
+								gap: "8px",
+								fontSize: "13px",
+								cursor: "pointer",
+								fontWeight: 500,
+							}}
+						>
+							<input
+								type="checkbox"
+								checked={!collapsedPanels.has("aiDraft")}
+								onChange={() => togglePanel("aiDraft")}
+								style={{
+									cursor: "pointer",
+									width: "16px",
+									height: "16px",
+								}}
+							/>
+							<span style={{ color: "black" }}>AI 초벌 번역 (Version 1)</span>
+						</label>
+						<label
+							style={{
+								display: "flex",
+								alignItems: "center",
+								gap: "8px",
+								fontSize: "13px",
+								cursor: "pointer",
+								fontWeight: 500,
+							}}
+						>
+							<input
+								type="checkbox"
+								checked={!collapsedPanels.has("currentVersion")}
+								onChange={() => togglePanel("currentVersion")}
+								style={{
+									cursor: "pointer",
+									width: "16px",
+									height: "16px",
+								}}
+							/>
+							<span style={{ color: "black" }}>
+								{currentVersionInfo.version
+									? currentVersionInfo.version.isFinal === true ||
+										currentVersionInfo.versionType === "FINAL"
+										? `현재 버전 (FINAL · Version ${currentVersionInfo.version.versionNumber})`
+										: `현재 버전 (Version ${currentVersionInfo.version.versionNumber})`
+									: "현재 버전"}
+							</span>
+						</label>
+					</div>
 
-            {from === 'handover' ? (
-              document?.status !== 'PENDING_TRANSLATION' ? (
-                <Button
-                  variant="primary"
-                  onClick={handleConvertToPending}
-                  disabled={convertingToPending}
-                  style={{ fontSize: '13px', padding: '8px 20px', whiteSpace: 'nowrap' }}
-                >
-                  {convertingToPending ? '전환 중...' : '번역 대기로 전환'}
-                </Button>
-              ) : (
-                <span style={{ fontSize: '13px', color: '#28A745', fontWeight: 600 }}>전환 완료</span>
-              )
-            ) : document?.status === 'PENDING_TRANSLATION' ? (
-              <Button
-                variant="primary"
-                onClick={() => navigate(`/translations/${documentId}/work`)}
-                style={{ fontSize: '13px', padding: '8px 20px', whiteSpace: 'nowrap' }}
-              >
-                번역하기
-              </Button>
-            ) : null}
-          </div>
-        </div>
+					{/* 우측: 채팅 토글 + 액션 버튼 */}
+					<div
+						style={{
+							display: "flex",
+							alignItems: "center",
+							gap: "8px",
+							flexShrink: 0,
+						}}
+					>
+						{/* 소통 채팅 토글 */}
+						<button
+							onClick={() => setShowChat((prev) => !prev)}
+							title="소통 채팅"
+							style={{
+								display: "flex",
+								alignItems: "center",
+								gap: "5px",
+								padding: "7px 14px",
+								fontSize: "13px",
+								fontWeight: 500,
+								border: `1px solid ${showChat ? "#3B82F6" : "#D1D5DB"}`,
+								borderRadius: "6px",
+								backgroundColor: showChat ? "#EFF6FF" : "#FFFFFF",
+								color: showChat ? "#3B82F6" : "#374151",
+								cursor: "pointer",
+								whiteSpace: "nowrap",
+							}}
+						>
+							💬 채팅
+						</button>
 
-        {/* 3단 레이아웃 + 채팅 사이드바 */}
-        <div style={{ display: 'flex', height: '100%', overflow: 'hidden' }}>
+						{from === "handover" ? (
+							document?.status !== "PENDING_TRANSLATION" ? (
+								<Button
+									variant="primary"
+									onClick={handleConvertToPending}
+									disabled={convertingToPending}
+									style={{
+										fontSize: "13px",
+										padding: "8px 20px",
+										whiteSpace: "nowrap",
+									}}
+								>
+									{convertingToPending ? "전환 중..." : "번역 대기로 전환"}
+								</Button>
+							) : (
+								<span
+									style={{
+										fontSize: "13px",
+										color: "#28A745",
+										fontWeight: 600,
+									}}
+								>
+									전환 완료
+								</span>
+							)
+						) : document?.status === "PENDING_TRANSLATION" ? (
+							<Button
+								variant="primary"
+								onClick={() => navigate(`/translations/${documentId}/work`)}
+								style={{
+									fontSize: "13px",
+									padding: "8px 20px",
+									whiteSpace: "nowrap",
+								}}
+							>
+								번역하기
+							</Button>
+						) : null}
+					</div>
+				</div>
 
-          {/* 문서 패널 영역 */}
-          <div style={{ flex: 1, display: 'flex', gap: '4px', padding: '4px', overflow: 'hidden' }}>
-            {panels.map(panel => {
-              const isCollapsed = collapsedPanels.has(panel.id);
-              const isFullscreen = fullscreenPanel === panel.id;
-              const isHidden = hasFullscreen && !isFullscreen;
+				{/* 3단 레이아웃 + 채팅 사이드바 */}
+				<div style={{ display: "flex", height: "100%", overflow: "hidden" }}>
+					{/* 문서 패널 영역 */}
+					<div
+						style={{
+							flex: 1,
+							display: "flex",
+							gap: "4px",
+							padding: "4px",
+							overflow: "hidden",
+						}}
+					>
+						{panels.map((panel) => {
+							const isCollapsed = collapsedPanels.has(panel.id);
+							const isFullscreen = fullscreenPanel === panel.id;
+							const isHidden = hasFullscreen && !isFullscreen;
 
-              // 콘텐츠가 없으면 패널 숨김
-              if (!panel.hasContent) return null;
-              if (isHidden) return null;
+							// 콘텐츠가 없으면 패널 숨김
+							if (!panel.hasContent) return null;
+							if (isHidden) return null;
 
-              return (
-                <div
-                  key={panel.id}
-                  style={{
-                    flex: isCollapsed ? '0 0 0' : isFullscreen ? '1' : `1 1 ${100 / visiblePanels.length}%`,
-                    display: isCollapsed ? 'none' : 'flex',
-                    flexDirection: 'column',
-                    transition: 'flex 0.2s ease',
-                    minWidth: isCollapsed ? '0' : '200px',
-                  }}
-                >
-                  {/* 패널 헤더 */}
-                  <div
-                    style={{
-                      display: 'flex',
-                      justifyContent: 'space-between',
-                      alignItems: 'center',
-                      padding: '8px 12px',
-                      backgroundColor: '#D3D3D3',
-                      borderRadius: '4px 4px 0 0',
-                      cursor: 'default',
-                      height: '36px',
-                    }}
-                  >
-                    <span style={{ fontSize: '12px', fontWeight: 600, color: '#000000' }}>
-                      {panel.title}
-                    </span>
-                    <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                      <button
-                        onClick={() => toggleFullscreen(panel.id)}
-                        style={{
-                          padding: '4px 8px',
-                          fontSize: '11px',
-                          border: '1px solid #A9A9A9',
-                          borderRadius: '3px',
-                          backgroundColor: '#FFFFFF',
-                          color: '#000000',
-                          cursor: 'pointer',
-                          fontWeight: 500,
-                        }}
-                        title={isFullscreen ? '확대 해제' : '전체화면 확대'}
-                      >
-                        {isFullscreen ? '축소' : '확대'}
-                      </button>
-                    </div>
-                  </div>
+							return (
+								<div
+									key={panel.id}
+									style={{
+										flex: isCollapsed
+											? "0 0 0"
+											: isFullscreen
+												? "1"
+												: `1 1 ${100 / visiblePanels.length}%`,
+										display: isCollapsed ? "none" : "flex",
+										flexDirection: "column",
+										transition: "flex 0.2s ease",
+										minWidth: isCollapsed ? "0" : "200px",
+									}}
+								>
+									{/* 패널 헤더 */}
+									<div
+										style={{
+											display: "flex",
+											justifyContent: "space-between",
+											alignItems: "center",
+											padding: "8px 12px",
+											backgroundColor: "#D3D3D3",
+											borderRadius: "4px 4px 0 0",
+											cursor: "default",
+											height: "36px",
+										}}
+									>
+										<span
+											style={{
+												fontSize: "12px",
+												fontWeight: 600,
+												color: "#000000",
+											}}
+										>
+											{panel.title}
+										</span>
+										<div
+											style={{
+												display: "flex",
+												alignItems: "center",
+												gap: "8px",
+											}}
+										>
+											<button
+												onClick={() => toggleFullscreen(panel.id)}
+												style={{
+													padding: "4px 8px",
+													fontSize: "11px",
+													border: "1px solid #A9A9A9",
+													borderRadius: "3px",
+													backgroundColor: "#FFFFFF",
+													color: "#000000",
+													cursor: "pointer",
+													fontWeight: 500,
+												}}
+												title={isFullscreen ? "확대 해제" : "전체화면 확대"}
+											>
+												{isFullscreen ? "축소" : "확대"}
+											</button>
+										</div>
+									</div>
 
-                  {/* 패널 내용 */}
-                  <div
-                    style={{
-                      flex: 1,
-                      border: '1px solid #C0C0C0',
-                      borderTop: 'none',
-                      borderRadius: '0 0 4px 4px',
-                      overflow: 'hidden',
-                      backgroundColor: '#FFFFFF',
-                      display: 'flex',
-                      flexDirection: 'column',
-                      position: 'relative',
-                    }}
-                  >
-                    <iframe
-                      ref={panel.ref}
-                      title={panel.title}
-                      style={{
-                        width: '100%',
-                        height: '100%',
-                        border: 'none',
-                      }}
-                      sandbox="allow-same-origin allow-scripts"
-                    />
-                  </div>
-                </div>
-              );
-            })}
-          </div>
+									{/* 패널 내용 */}
+									<div
+										style={{
+											flex: 1,
+											border: "1px solid #C0C0C0",
+											borderTop: "none",
+											borderRadius: "0 0 4px 4px",
+											overflow: "hidden",
+											backgroundColor: "#FFFFFF",
+											display: "flex",
+											flexDirection: "column",
+											position: "relative",
+										}}
+									>
+										<iframe
+											ref={panel.ref}
+											title={panel.title}
+											style={{
+												width: "100%",
+												height: "100%",
+												border: "none",
+											}}
+											sandbox="allow-same-origin allow-scripts"
+										/>
+									</div>
+								</div>
+							);
+						})}
+					</div>
 
-          {/* 소통 채팅 사이드바 */}
-          {showChat && documentId && (
-            <div
-              style={{
-                width: '320px',
-                flexShrink: 0,
-                padding: '4px 4px 4px 0',
-                display: 'flex',
-                flexDirection: 'column',
-              }}
-            >
-              <DocumentChat documentId={documentId} height="100%" />
-            </div>
-          )}
-        </div>
-      </div>
+					{/* 소통 채팅 사이드바 */}
+					{showChat && documentId && (
+						<div
+							style={{
+								width: "320px",
+								flexShrink: 0,
+								padding: "4px 4px 4px 0",
+								display: "flex",
+								flexDirection: "column",
+							}}
+						>
+							<DocumentChat documentId={documentId} height="100%" />
+						</div>
+					)}
+				</div>
+			</div>
 
-      {/* 인계 메모 확인 모달 */}
-      {showHandoverModal && document?.latestHandover && (
-        <div
-          style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0, backgroundColor: 'rgba(0,0,0,0.5)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000 }}
-          onClick={() => setShowHandoverModal(false)}
-        >
-          <div
-            style={{ backgroundColor: colors.surface, borderRadius: '8px', padding: '28px', maxWidth: '500px', width: '90%', boxShadow: '0 4px 16px rgba(0,0,0,0.15)', maxHeight: '90vh', overflowY: 'auto' }}
-            onClick={(e) => e.stopPropagation()}
-          >
-            <h2 style={{ fontSize: '17px', fontWeight: 600, color: '#000000', marginBottom: '20px' }}>
-              인계 메모 확인
-            </h2>
-            <div style={{ backgroundColor: '#FFF9EC', border: '1px solid #FFE082', borderRadius: '6px', padding: '16px', display: 'flex', flexDirection: 'column', gap: '12px' }}>
-              {(() => {
-                const h = document.latestHandover!;
-                return (
-                  <>
-                    <div style={{ display: 'flex', gap: '8px', alignItems: 'baseline' }}>
-                      <span style={{ fontSize: '12px', color: colors.secondaryText, minWidth: '80px', flexShrink: 0 }}>인계자</span>
-                      <span style={{ fontSize: '13px', color: '#000000' }}>{h.handedOverBy?.name || '-'}</span>
-                    </div>
-                    <div style={{ display: 'flex', gap: '8px', alignItems: 'baseline' }}>
-                      <span style={{ fontSize: '12px', color: colors.secondaryText, minWidth: '80px', flexShrink: 0 }}>인계 시각</span>
-                      <span style={{ fontSize: '13px', color: '#000000' }}>{formatLastModifiedDateDisplay(h.handedOverAt)}</span>
-                    </div>
-                    <div>
-                      <span style={{ fontSize: '12px', color: colors.secondaryText, display: 'block', marginBottom: '6px' }}>남은 작업 메모</span>
-                      <div style={{ fontSize: '13px', color: '#000000', whiteSpace: 'pre-wrap', lineHeight: '1.6', padding: '10px', backgroundColor: '#fff', borderRadius: '4px', border: `1px solid ${colors.border}` }}>
-                        {h.memo || '-'}
-                      </div>
-                    </div>
-                    {h.terms && (
-                      <div>
-                        <span style={{ fontSize: '12px', color: colors.secondaryText, display: 'block', marginBottom: '6px' }}>주의 용어/표현</span>
-                        <div style={{ fontSize: '13px', color: '#000000', whiteSpace: 'pre-wrap', lineHeight: '1.6', padding: '10px', backgroundColor: '#fff', borderRadius: '4px', border: `1px solid ${colors.border}` }}>
-                          {h.terms}
-                        </div>
-                      </div>
-                    )}
-                  </>
-                );
-              })()}
-            </div>
-            <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: '20px' }}>
-              <Button variant="secondary" onClick={() => setShowHandoverModal(false)}>
-                닫기
-              </Button>
-            </div>
-          </div>
-        </div>
-      )}
-    </ErrorBoundary>
-  );
+			{/* 인계 메모 확인 모달 */}
+			{showHandoverModal && document?.latestHandover && (
+				<div
+					style={{
+						position: "fixed",
+						top: 0,
+						left: 0,
+						right: 0,
+						bottom: 0,
+						backgroundColor: "rgba(0,0,0,0.5)",
+						display: "flex",
+						alignItems: "center",
+						justifyContent: "center",
+						zIndex: 1000,
+					}}
+					onClick={() => setShowHandoverModal(false)}
+				>
+					<div
+						style={{
+							backgroundColor: colors.surface,
+							borderRadius: "8px",
+							padding: "28px",
+							maxWidth: "500px",
+							width: "90%",
+							boxShadow: "0 4px 16px rgba(0,0,0,0.15)",
+							maxHeight: "90vh",
+							overflowY: "auto",
+						}}
+						onClick={(e) => e.stopPropagation()}
+					>
+						<h2
+							style={{
+								fontSize: "17px",
+								fontWeight: 600,
+								color: "#000000",
+								marginBottom: "20px",
+							}}
+						>
+							인계 메모 확인
+						</h2>
+						<div
+							style={{
+								backgroundColor: "#FFF9EC",
+								border: "1px solid #FFE082",
+								borderRadius: "6px",
+								padding: "16px",
+								display: "flex",
+								flexDirection: "column",
+								gap: "12px",
+							}}
+						>
+							{(() => {
+								const h = document.latestHandover!;
+								return (
+									<>
+										<div
+											style={{
+												display: "flex",
+												gap: "8px",
+												alignItems: "baseline",
+											}}
+										>
+											<span
+												style={{
+													fontSize: "12px",
+													color: colors.secondaryText,
+													minWidth: "80px",
+													flexShrink: 0,
+												}}
+											>
+												인계자
+											</span>
+											<span style={{ fontSize: "13px", color: "#000000" }}>
+												{h.handedOverBy?.name || "-"}
+											</span>
+										</div>
+										<div
+											style={{
+												display: "flex",
+												gap: "8px",
+												alignItems: "baseline",
+											}}
+										>
+											<span
+												style={{
+													fontSize: "12px",
+													color: colors.secondaryText,
+													minWidth: "80px",
+													flexShrink: 0,
+												}}
+											>
+												인계 시각
+											</span>
+											<span style={{ fontSize: "13px", color: "#000000" }}>
+												{formatLastModifiedDateDisplay(h.handedOverAt)}
+											</span>
+										</div>
+										<div>
+											<span
+												style={{
+													fontSize: "12px",
+													color: colors.secondaryText,
+													display: "block",
+													marginBottom: "6px",
+												}}
+											>
+												남은 작업 메모
+											</span>
+											<div
+												style={{
+													fontSize: "13px",
+													color: "#000000",
+													whiteSpace: "pre-wrap",
+													lineHeight: "1.6",
+													padding: "10px",
+													backgroundColor: "#fff",
+													borderRadius: "4px",
+													border: `1px solid ${colors.border}`,
+												}}
+											>
+												{h.memo || "-"}
+											</div>
+										</div>
+										{h.terms && (
+											<div>
+												<span
+													style={{
+														fontSize: "12px",
+														color: colors.secondaryText,
+														display: "block",
+														marginBottom: "6px",
+													}}
+												>
+													주의 용어/표현
+												</span>
+												<div
+													style={{
+														fontSize: "13px",
+														color: "#000000",
+														whiteSpace: "pre-wrap",
+														lineHeight: "1.6",
+														padding: "10px",
+														backgroundColor: "#fff",
+														borderRadius: "4px",
+														border: `1px solid ${colors.border}`,
+													}}
+												>
+													{h.terms}
+												</div>
+											</div>
+										)}
+									</>
+								);
+							})()}
+						</div>
+						<div
+							style={{
+								display: "flex",
+								justifyContent: "flex-end",
+								marginTop: "20px",
+							}}
+						>
+							<Button
+								variant="secondary"
+								onClick={() => setShowHandoverModal(false)}
+							>
+								닫기
+							</Button>
+						</div>
+					</div>
+				</div>
+			)}
+		</ErrorBoundary>
+	);
 }

--- a/src/pages/DocumentReview.tsx
+++ b/src/pages/DocumentReview.tsx
@@ -1,215 +1,286 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
-import { documentApi, DocumentResponse } from '../services/documentApi';
-import { documentApi as docApi, DocumentVersionResponse } from '../services/documentApi';
-import { reviewApi, ReviewResponse } from '../services/reviewApi';
-import { colors } from '../constants/designTokens';
-import { Button } from '../components/Button';
+import type React from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
+import { useParams, useNavigate, useSearchParams } from "react-router-dom";
+import { documentApi, type DocumentResponse } from "../services/documentApi";
 import {
-  extractParagraphs,
-  getParagraphs,
-  getParagraphAtScrollPosition,
-  highlightParagraph,
-  clearAllHighlights,
-  Paragraph,
-} from '../utils/paragraphUtils';
-import ErrorBoundary from '../components/ErrorBoundary';
-import { AlignLeft, AlignCenter, AlignRight, List, ListOrdered, Palette, Quote, Minus, Link2, Highlighter, Image, Table, Code, Superscript, Subscript, MoreVertical, Undo2, Redo2 } from 'lucide-react';
-import './TranslationWork.css';
+	documentApi as docApi,
+	DocumentVersionResponse,
+} from "../services/documentApi";
+import { reviewApi, type ReviewResponse } from "../services/reviewApi";
+import { colors } from "../constants/designTokens";
+import { Button } from "../components/Button";
+import {
+	extractParagraphs,
+	getParagraphs,
+	getParagraphAtScrollPosition,
+	highlightParagraph,
+	clearAllHighlights,
+	Paragraph,
+} from "../utils/paragraphUtils";
+import ErrorBoundary from "../components/ErrorBoundary";
+import {
+	AlignLeft,
+	AlignCenter,
+	AlignRight,
+	List,
+	ListOrdered,
+	Palette,
+	Quote,
+	Minus,
+	Link2,
+	Highlighter,
+	Image,
+	Table,
+	Code,
+	Superscript,
+	Subscript,
+	MoreVertical,
+	Undo2,
+	Redo2,
+} from "lucide-react";
+import "./TranslationWork.css";
 
 export default function DocumentReview() {
-  const { id } = useParams<{ id: string }>();
-  const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
-  const documentId = id ? parseInt(id, 10) : null;
-  const reviewIdParam = searchParams.get('reviewId');
+	const { id } = useParams<{ id: string }>();
+	const navigate = useNavigate();
+	const [searchParams] = useSearchParams();
+	const documentId = id ? Number.parseInt(id, 10) : null;
+	const reviewIdParam = searchParams.get("reviewId");
 
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [document, setDocument] = useState<DocumentResponse | null>(null);
-  const [review, setReview] = useState<ReviewResponse | null>(null);
-  const [originalContent, setOriginalContent] = useState<string>('');
-  const [aiDraftContent, setAiDraftContent] = useState<string>('');
-  const [translationContent, setTranslationContent] = useState<string>('');
-  const [highlightedParagraphIndex, setHighlightedParagraphIndex] = useState<number | null>(null);
-  const [showRejectModal, setShowRejectModal] = useState(false);
-  const [rejectMessage, setRejectMessage] = useState('');
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+	const [document, setDocument] = useState<DocumentResponse | null>(null);
+	const [review, setReview] = useState<ReviewResponse | null>(null);
+	const [originalContent, setOriginalContent] = useState<string>("");
+	const [aiDraftContent, setAiDraftContent] = useState<string>("");
+	const [translationContent, setTranslationContent] = useState<string>("");
+	const [highlightedParagraphIndex, setHighlightedParagraphIndex] = useState<
+		number | null
+	>(null);
+	const [showRejectModal, setShowRejectModal] = useState(false);
+	const [rejectMessage, setRejectMessage] = useState("");
 
-  // 패널 접기/전체화면 상태
-  const [collapsedPanels, setCollapsedPanels] = useState<Set<string>>(new Set());
-  const [fullscreenPanel, setFullscreenPanel] = useState<string | null>(null);
+	// 패널 접기/전체화면 상태
+	const [collapsedPanels, setCollapsedPanels] = useState<Set<string>>(
+		new Set(),
+	);
+	const [fullscreenPanel, setFullscreenPanel] = useState<string | null>(null);
 
-  // 패널 refs (iframe으로 변경)
-  const originalIframeRef = useRef<HTMLIFrameElement>(null);
-  const aiDraftIframeRef = useRef<HTMLIFrameElement>(null);
-  const translationIframeRef = useRef<HTMLIFrameElement>(null);
-  const isScrollingRef = useRef(false);
+	// 패널 refs (iframe으로 변경)
+	const originalIframeRef = useRef<HTMLIFrameElement>(null);
+	const aiDraftIframeRef = useRef<HTMLIFrameElement>(null);
+	const translationIframeRef = useRef<HTMLIFrameElement>(null);
+	const isScrollingRef = useRef(false);
 
-  // 원본 HTML 저장 (iframe 렌더링용)
-  const [originalHtml, setOriginalHtml] = useState<string>('');
-  const [aiDraftHtml, setAiDraftHtml] = useState<string>('');
-  const [translationHtml, setTranslationHtml] = useState<string>('');
-  
-  // 에디터 상태 추가
-  const [editorMode, setEditorMode] = useState<'text' | 'component'>('text');
-  const [selectedElements, setSelectedElements] = useState<HTMLElement[]>([]);
-  const [showLinkModal, setShowLinkModal] = useState(false);
-  const [editingLink, setEditingLink] = useState<HTMLAnchorElement | null>(null);
-  const [linkUrl, setLinkUrl] = useState('');
-  const [showMoreMenu, setShowMoreMenu] = useState(false);
-  
-  // Undo/Redo Stack for editing
-  const undoStackRef = useRef<string[]>([]);
-  const redoStackRef = useRef<string[]>([]);
-  const currentEditorHtmlRef = useRef<string>('');
-  
-  // 이벤트 핸들러 저장 (제거를 위해)
-  const componentClickHandlersRef = useRef<Map<HTMLElement, (e: Event) => void>>(new Map());
-  const linkClickHandlersRef = useRef<Map<HTMLElement, (e: Event) => void>>(new Map());
-  const windowKeydownHandlerRef = useRef<((e: KeyboardEvent) => void) | null>(null);
-  const iframeKeydownHandlerRef = useRef<((e: KeyboardEvent) => void) | null>(null);
+	// 원본 HTML 저장 (iframe 렌더링용)
+	const [originalHtml, setOriginalHtml] = useState<string>("");
+	const [aiDraftHtml, setAiDraftHtml] = useState<string>("");
+	const [translationHtml, setTranslationHtml] = useState<string>("");
 
-  // 초기 데이터 로드
-  useEffect(() => {
-    if (!documentId) {
-      setError('문서 ID가 없습니다.');
-      setLoading(false);
-      return;
-    }
+	// 에디터 상태 추가
+	const [editorMode, setEditorMode] = useState<"text" | "component">("text");
+	const [selectedElements, setSelectedElements] = useState<HTMLElement[]>([]);
+	const [showLinkModal, setShowLinkModal] = useState(false);
+	const [editingLink, setEditingLink] = useState<HTMLAnchorElement | null>(
+		null,
+	);
+	const [linkUrl, setLinkUrl] = useState("");
+	const [showMoreMenu, setShowMoreMenu] = useState(false);
 
-    const loadData = async () => {
-      try {
-        setLoading(true);
-        setError(null);
+	// Undo/Redo Stack for editing
+	const undoStackRef = useRef<string[]>([]);
+	const redoStackRef = useRef<string[]>([]);
+	const currentEditorHtmlRef = useRef<string>("");
 
-        // 1. 문서 정보 가져오기
-        console.log('📄 문서 조회 시작:', documentId);
-        const doc = await documentApi.getDocument(documentId);
-        console.log('✅ 문서 조회 성공:', doc);
-        setDocument(doc);
+	// 이벤트 핸들러 저장 (제거를 위해)
+	const componentClickHandlersRef = useRef<
+		Map<HTMLElement, (e: Event) => void>
+	>(new Map());
+	const linkClickHandlersRef = useRef<Map<HTMLElement, (e: Event) => void>>(
+		new Map(),
+	);
+	const windowKeydownHandlerRef = useRef<((e: KeyboardEvent) => void) | null>(
+		null,
+	);
+	const iframeKeydownHandlerRef = useRef<((e: KeyboardEvent) => void) | null>(
+		null,
+	);
 
-        // 2. 리뷰 정보 가져오기
-        try {
-          if (reviewIdParam) {
-            // reviewId가 있으면 직접 조회
-            const reviewId = parseInt(reviewIdParam, 10);
-            const review = await reviewApi.getReviewById(reviewId);
-            setReview(review);
-            console.log('✅ 리뷰 조회 성공 (ID로):', review);
-          } else {
-            // reviewId가 없으면 documentId로 조회
-            const reviews = await reviewApi.getAllReviews({ documentId, status: 'PENDING' });
-            if (reviews && reviews.length > 0) {
-              setReview(reviews[0]); // 첫 번째 PENDING 리뷰 사용
-              console.log('✅ 리뷰 조회 성공:', reviews[0]);
-            } else {
-              console.warn('⚠️ PENDING 상태의 리뷰가 없습니다.');
-            }
-          }
-        } catch (reviewError: any) {
-          console.error('리뷰 조회 실패:', reviewError);
-          setError('리뷰 정보를 불러오는데 실패했습니다: ' + (reviewError.response?.data?.message || reviewError.message));
-        }
+	// 초기 데이터 로드
+	useEffect(() => {
+		if (!documentId) {
+			setError("문서 ID가 없습니다.");
+			setLoading(false);
+			return;
+		}
 
-        // 3. 버전 정보 가져오기
-        try {
-          const versions = await docApi.getDocumentVersions(documentId);
-          console.log('📦 문서 버전 목록:', versions.map(v => ({ type: v.versionType, number: v.versionNumber })));
-          
-          if (!versions || versions.length === 0) {
-            console.warn('⚠️ 문서 버전이 없습니다.');
-            setError('문서 버전 정보를 찾을 수 없습니다.');
-            setLoading(false);
-            return;
-          }
-          
-          // ORIGINAL 버전 찾기
-          const originalVersion = versions.find(v => v.versionType === 'ORIGINAL');
-          if (originalVersion) {
-            const processedOriginal = extractParagraphs(originalVersion.content, 'original');
-            setOriginalHtml(processedOriginal);
-            setOriginalContent(processedOriginal);
-            console.log('✅ 원문 버전 로드 완료');
-          } else {
-            console.warn('⚠️ ORIGINAL 버전이 없습니다.');
-          }
+		const loadData = async () => {
+			try {
+				setLoading(true);
+				setError(null);
 
-          // AI_DRAFT 버전 찾기
-          const aiDraftVersion = versions.find(v => v.versionType === 'AI_DRAFT');
-          if (aiDraftVersion) {
-            const processedAiDraft = extractParagraphs(aiDraftVersion.content, 'ai-draft');
-            setAiDraftHtml(processedAiDraft);
-            setAiDraftContent(processedAiDraft);
-            console.log('✅ AI 초벌 번역 버전 로드 완료');
-          } else {
-            console.warn('⚠️ AI_DRAFT 버전이 없습니다.');
-          }
+				// 1. 문서 정보 가져오기
+				console.log("📄 문서 조회 시작:", documentId);
+				const doc = await documentApi.getDocument(documentId);
+				console.log("✅ 문서 조회 성공:", doc);
+				setDocument(doc);
 
-          // MANUAL_TRANSLATION 버전 찾기 (검토 대상)
-          const manualTranslationVersion = versions
-            .filter(v => v.versionType === 'MANUAL_TRANSLATION')
-            .sort((a, b) => (b.versionNumber || 0) - (a.versionNumber || 0))[0]; // 최신 버전
-          
-          if (manualTranslationVersion) {
-            console.log('✅ 검토 대상 번역 발견:', manualTranslationVersion.versionNumber, '버전');
-            const processedManual = extractParagraphs(manualTranslationVersion.content, 'manual');
-            setTranslationHtml(processedManual);
-            setTranslationContent(processedManual);
-          } else if (aiDraftVersion) {
-            console.log('ℹ️ 수동 번역이 없어 AI 초벌 번역 사용');
-            const processedAiDraft = extractParagraphs(aiDraftVersion.content, 'ai-draft-editor');
-            setTranslationHtml(processedAiDraft);
-            setTranslationContent(processedAiDraft);
-          } else {
-            console.warn('⚠️ 검토할 번역이 없습니다.');
-            setError('검토할 번역 내용이 없습니다.');
-            setLoading(false);
-            return;
-          }
-        } catch (versionError: any) {
-          console.error('버전 정보 조회 실패:', versionError);
-          setError('문서 버전 정보를 불러오는데 실패했습니다: ' + (versionError.message || '알 수 없는 오류'));
-          setLoading(false);
-          return;
-        }
+				// 2. 리뷰 정보 가져오기
+				try {
+					if (reviewIdParam) {
+						// reviewId가 있으면 직접 조회
+						const reviewId = Number.parseInt(reviewIdParam, 10);
+						const review = await reviewApi.getReviewById(reviewId);
+						setReview(review);
+						console.log("✅ 리뷰 조회 성공 (ID로):", review);
+					} else {
+						// reviewId가 없으면 documentId로 조회
+						const reviews = await reviewApi.getAllReviews({
+							documentId,
+							status: "PENDING",
+						});
+						if (reviews && reviews.length > 0) {
+							setReview(reviews[0]); // 첫 번째 PENDING 리뷰 사용
+							console.log("✅ 리뷰 조회 성공:", reviews[0]);
+						} else {
+							console.warn("⚠️ PENDING 상태의 리뷰가 없습니다.");
+						}
+					}
+				} catch (reviewError: any) {
+					console.error("리뷰 조회 실패:", reviewError);
+					setError(
+						"리뷰 정보를 불러오는데 실패했습니다: " +
+							(reviewError.response?.data?.message || reviewError.message),
+					);
+				}
 
-      } catch (err: any) {
-        console.error('데이터 로드 실패:', err);
-        let errorMessage = '데이터를 불러오는데 실패했습니다.';
-        
-        if (err.response?.data) {
-          if (typeof err.response.data === 'string') {
-            errorMessage = err.response.data;
-          } else if (err.response.data.message) {
-            errorMessage = err.response.data.message;
-          }
-        } else if (err.message) {
-          errorMessage = err.message;
-        }
-        
-        setError(errorMessage);
-      } finally {
-        setLoading(false);
-      }
-    };
+				// 3. 버전 정보 가져오기
+				try {
+					const versions = await docApi.getDocumentVersions(documentId);
+					console.log(
+						"📦 문서 버전 목록:",
+						versions.map((v) => ({
+							type: v.versionType,
+							number: v.versionNumber,
+						})),
+					);
 
-    loadData();
-  }, [documentId]);
+					if (!versions || versions.length === 0) {
+						console.warn("⚠️ 문서 버전이 없습니다.");
+						setError("문서 버전 정보를 찾을 수 없습니다.");
+						setLoading(false);
+						return;
+					}
 
-  // 원문 iframe 렌더링 + 문단 클릭/호버 이벤트
-  useEffect(() => {
-    const iframe = originalIframeRef.current;
-    if (!iframe || !originalHtml) return;
-    
-    const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-    if (iframeDoc) {
-      try {
-        iframeDoc.open();
-        iframeDoc.write(originalHtml);
-        iframeDoc.close();
-        
-        const style = iframeDoc.createElement('style');
-        style.textContent = `
+					// ORIGINAL 버전 찾기
+					const originalVersion = versions.find(
+						(v) => v.versionType === "ORIGINAL",
+					);
+					if (originalVersion) {
+						const processedOriginal = extractParagraphs(
+							originalVersion.content,
+							"original",
+						);
+						setOriginalHtml(processedOriginal);
+						setOriginalContent(processedOriginal);
+						console.log("✅ 원문 버전 로드 완료");
+					} else {
+						console.warn("⚠️ ORIGINAL 버전이 없습니다.");
+					}
+
+					// AI_DRAFT 버전 찾기
+					const aiDraftVersion = versions.find(
+						(v) => v.versionType === "AI_DRAFT",
+					);
+					if (aiDraftVersion) {
+						const processedAiDraft = extractParagraphs(
+							aiDraftVersion.content,
+							"ai-draft",
+						);
+						setAiDraftHtml(processedAiDraft);
+						setAiDraftContent(processedAiDraft);
+						console.log("✅ AI 초벌 번역 버전 로드 완료");
+					} else {
+						console.warn("⚠️ AI_DRAFT 버전이 없습니다.");
+					}
+
+					// MANUAL_TRANSLATION 버전 찾기 (검토 대상)
+					const manualTranslationVersion = versions
+						.filter((v) => v.versionType === "MANUAL_TRANSLATION")
+						.sort((a, b) => (b.versionNumber || 0) - (a.versionNumber || 0))[0]; // 최신 버전
+
+					if (manualTranslationVersion) {
+						console.log(
+							"✅ 검토 대상 번역 발견:",
+							manualTranslationVersion.versionNumber,
+							"버전",
+						);
+						const processedManual = extractParagraphs(
+							manualTranslationVersion.content,
+							"manual",
+						);
+						setTranslationHtml(processedManual);
+						setTranslationContent(processedManual);
+					} else if (aiDraftVersion) {
+						console.log("ℹ️ 수동 번역이 없어 AI 초벌 번역 사용");
+						const processedAiDraft = extractParagraphs(
+							aiDraftVersion.content,
+							"ai-draft-editor",
+						);
+						setTranslationHtml(processedAiDraft);
+						setTranslationContent(processedAiDraft);
+					} else {
+						console.warn("⚠️ 검토할 번역이 없습니다.");
+						setError("검토할 번역 내용이 없습니다.");
+						setLoading(false);
+						return;
+					}
+				} catch (versionError: any) {
+					console.error("버전 정보 조회 실패:", versionError);
+					setError(
+						"문서 버전 정보를 불러오는데 실패했습니다: " +
+							(versionError.message || "알 수 없는 오류"),
+					);
+					setLoading(false);
+					return;
+				}
+			} catch (err: any) {
+				console.error("데이터 로드 실패:", err);
+				let errorMessage = "데이터를 불러오는데 실패했습니다.";
+
+				if (err.response?.data) {
+					if (typeof err.response.data === "string") {
+						errorMessage = err.response.data;
+					} else if (err.response.data.message) {
+						errorMessage = err.response.data.message;
+					}
+				} else if (err.message) {
+					errorMessage = err.message;
+				}
+
+				setError(errorMessage);
+			} finally {
+				setLoading(false);
+			}
+		};
+
+		loadData();
+	}, [documentId]);
+
+	// 원문 iframe 렌더링 + 문단 클릭/호버 이벤트
+	useEffect(() => {
+		const iframe = originalIframeRef.current;
+		if (!iframe || !originalHtml) return;
+
+		const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
+		if (iframeDoc) {
+			try {
+				iframeDoc.open();
+				iframeDoc.write(originalHtml);
+				iframeDoc.close();
+
+				const style = iframeDoc.createElement("style");
+				style.textContent = `
           * {
             border: none !important;
             outline: none !important;
@@ -218,47 +289,47 @@ export default function DocumentReview() {
             cursor: default !important;
           }
         `;
-        iframeDoc.head.appendChild(style);
-        
-        if (iframeDoc.body) {
-          iframeDoc.body.style.cursor = 'default';
-          iframeDoc.body.contentEditable = 'false';
-        }
-        
-        const paragraphs = iframeDoc.querySelectorAll('[data-paragraph-index]');
-        paragraphs.forEach((para) => {
-          const element = para as HTMLElement;
-          const indexAttr = element.getAttribute('data-paragraph-index');
-          const index = parseInt(indexAttr || '0', 10);
-          
-          element.addEventListener('mouseenter', () => {
-            setHighlightedParagraphIndex(index);
-          });
-          
-          element.addEventListener('click', () => {
-            setHighlightedParagraphIndex(index);
-          });
-        });
-      } catch (error) {
-        console.error('❌ 원문 iframe 오류:', error);
-      }
-    }
-  }, [originalHtml, collapsedPanels, fullscreenPanel]);
+				iframeDoc.head.appendChild(style);
 
-  // AI 초벌 번역 iframe 렌더링 + 문단 클릭/호버 이벤트
-  useEffect(() => {
-    const iframe = aiDraftIframeRef.current;
-    if (!iframe || !aiDraftHtml) return;
-    
-    const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-    if (iframeDoc) {
-      try {
-        iframeDoc.open();
-        iframeDoc.write(aiDraftHtml);
-        iframeDoc.close();
-        
-        const style = iframeDoc.createElement('style');
-        style.textContent = `
+				if (iframeDoc.body) {
+					iframeDoc.body.style.cursor = "default";
+					iframeDoc.body.contentEditable = "false";
+				}
+
+				const paragraphs = iframeDoc.querySelectorAll("[data-paragraph-index]");
+				paragraphs.forEach((para) => {
+					const element = para as HTMLElement;
+					const indexAttr = element.getAttribute("data-paragraph-index");
+					const index = Number.parseInt(indexAttr || "0", 10);
+
+					element.addEventListener("mouseenter", () => {
+						setHighlightedParagraphIndex(index);
+					});
+
+					element.addEventListener("click", () => {
+						setHighlightedParagraphIndex(index);
+					});
+				});
+			} catch (error) {
+				console.error("❌ 원문 iframe 오류:", error);
+			}
+		}
+	}, [originalHtml, collapsedPanels, fullscreenPanel]);
+
+	// AI 초벌 번역 iframe 렌더링 + 문단 클릭/호버 이벤트
+	useEffect(() => {
+		const iframe = aiDraftIframeRef.current;
+		if (!iframe || !aiDraftHtml) return;
+
+		const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
+		if (iframeDoc) {
+			try {
+				iframeDoc.open();
+				iframeDoc.write(aiDraftHtml);
+				iframeDoc.close();
+
+				const style = iframeDoc.createElement("style");
+				style.textContent = `
           * {
             border: none !important;
             outline: none !important;
@@ -267,63 +338,63 @@ export default function DocumentReview() {
             cursor: default !important;
           }
         `;
-        iframeDoc.head.appendChild(style);
-        
-        if (iframeDoc.body) {
-          iframeDoc.body.style.cursor = 'default';
-          iframeDoc.body.contentEditable = 'false';
-        }
-        
-        const paragraphs = iframeDoc.querySelectorAll('[data-paragraph-index]');
-        paragraphs.forEach((para) => {
-          const element = para as HTMLElement;
-          const indexAttr = element.getAttribute('data-paragraph-index');
-          const index = parseInt(indexAttr || '0', 10);
-          
-          element.addEventListener('mouseenter', () => {
-            setHighlightedParagraphIndex(index);
-          });
-          
-          element.addEventListener('click', () => {
-            setHighlightedParagraphIndex(index);
-          });
-        });
-      } catch (error) {
-        console.error('❌ AI 초벌 iframe 오류:', error);
-      }
-    }
-  }, [aiDraftHtml, collapsedPanels, fullscreenPanel]);
+				iframeDoc.head.appendChild(style);
 
-  // 번역 iframe 렌더링 및 에디터 모드 설정
-  useEffect(() => {
-    const iframe = translationIframeRef.current;
-    if (!iframe || !translationHtml) return;
-    
-    const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-    if (!iframeDoc) return;
+				if (iframeDoc.body) {
+					iframeDoc.body.style.cursor = "default";
+					iframeDoc.body.contentEditable = "false";
+				}
 
-      try {
-        iframeDoc.open();
-        iframeDoc.write(translationHtml);
-        iframeDoc.close();
-        
-      // currentEditorHtmlRef 초기화
-      currentEditorHtmlRef.current = translationHtml;
-      
-      if (editorMode === 'text') {
-        // 텍스트 편집 모드
-        console.log('📝 [DocumentReview] 텍스트 편집 모드 활성화');
-        
-        // 기존 컴포넌트 편집 관련 핸들러 제거
-        componentClickHandlersRef.current.forEach((handler, el) => {
-          el.removeEventListener('click', handler, true);
-        });
-        componentClickHandlersRef.current.clear();
-        
-        // Outline 스타일 제거
-        const textEditOverrideStyle = iframeDoc.createElement('style');
-        textEditOverrideStyle.id = 'text-edit-override-styles';
-        textEditOverrideStyle.textContent = `
+				const paragraphs = iframeDoc.querySelectorAll("[data-paragraph-index]");
+				paragraphs.forEach((para) => {
+					const element = para as HTMLElement;
+					const indexAttr = element.getAttribute("data-paragraph-index");
+					const index = Number.parseInt(indexAttr || "0", 10);
+
+					element.addEventListener("mouseenter", () => {
+						setHighlightedParagraphIndex(index);
+					});
+
+					element.addEventListener("click", () => {
+						setHighlightedParagraphIndex(index);
+					});
+				});
+			} catch (error) {
+				console.error("❌ AI 초벌 iframe 오류:", error);
+			}
+		}
+	}, [aiDraftHtml, collapsedPanels, fullscreenPanel]);
+
+	// 번역 iframe 렌더링 및 에디터 모드 설정
+	useEffect(() => {
+		const iframe = translationIframeRef.current;
+		if (!iframe || !translationHtml) return;
+
+		const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
+		if (!iframeDoc) return;
+
+		try {
+			iframeDoc.open();
+			iframeDoc.write(translationHtml);
+			iframeDoc.close();
+
+			// currentEditorHtmlRef 초기화
+			currentEditorHtmlRef.current = translationHtml;
+
+			if (editorMode === "text") {
+				// 텍스트 편집 모드
+				console.log("📝 [DocumentReview] 텍스트 편집 모드 활성화");
+
+				// 기존 컴포넌트 편집 관련 핸들러 제거
+				componentClickHandlersRef.current.forEach((handler, el) => {
+					el.removeEventListener("click", handler, true);
+				});
+				componentClickHandlersRef.current.clear();
+
+				// Outline 스타일 제거
+				const textEditOverrideStyle = iframeDoc.createElement("style");
+				textEditOverrideStyle.id = "text-edit-override-styles";
+				textEditOverrideStyle.textContent = `
           * {
             outline: none !important;
           }
@@ -331,87 +402,94 @@ export default function DocumentReview() {
             outline: none !important;
           }
         `;
-        const existingOverride = iframeDoc.getElementById('text-edit-override-styles');
-        if (existingOverride) {
-          existingOverride.remove();
-        }
-        iframeDoc.head.appendChild(textEditOverrideStyle);
+				const existingOverride = iframeDoc.getElementById(
+					"text-edit-override-styles",
+				);
+				if (existingOverride) {
+					existingOverride.remove();
+				}
+				iframeDoc.head.appendChild(textEditOverrideStyle);
 
-        // contentEditable 설정
-        if (iframeDoc.body) {
-          iframeDoc.body.contentEditable = 'true';
-          iframeDoc.body.style.cursor = 'text';
-        }
+				// contentEditable 설정
+				if (iframeDoc.body) {
+					iframeDoc.body.contentEditable = "true";
+					iframeDoc.body.style.cursor = "text";
+				}
 
-        // 모든 텍스트 요소를 편집 가능하게
-        const editableElements = iframeDoc.querySelectorAll('p, h1, h2, h3, h4, h5, h6, span, div, li, td, th, label, a, button, article, section, header, footer, main, aside');
-        editableElements.forEach((el) => {
-          if (el.tagName && !['SCRIPT', 'STYLE', 'NOSCRIPT'].includes(el.tagName)) {
-            (el as HTMLElement).contentEditable = 'true';
-            (el as HTMLElement).style.cursor = 'text';
-          }
-        });
+				// 모든 텍스트 요소를 편집 가능하게
+				const editableElements = iframeDoc.querySelectorAll(
+					"p, h1, h2, h3, h4, h5, h6, span, div, li, td, th, label, a, button, article, section, header, footer, main, aside",
+				);
+				editableElements.forEach((el) => {
+					if (
+						el.tagName &&
+						!["SCRIPT", "STYLE", "NOSCRIPT"].includes(el.tagName)
+					) {
+						(el as HTMLElement).contentEditable = "true";
+						(el as HTMLElement).style.cursor = "text";
+					}
+				});
 
-        // 스크립트, 스타일 태그는 편집 불가능하게
-        const scripts = iframeDoc.querySelectorAll('script, style, noscript');
-        scripts.forEach((el) => {
-          (el as HTMLElement).contentEditable = 'false';
-        });
+				// 스크립트, 스타일 태그는 편집 불가능하게
+				const scripts = iframeDoc.querySelectorAll("script, style, noscript");
+				scripts.forEach((el) => {
+					(el as HTMLElement).contentEditable = "false";
+				});
 
-        // user-select 스타일 추가
-        const textEditStyle = iframeDoc.createElement('style');
-        textEditStyle.id = 'text-edit-styles';
-        textEditStyle.textContent = `
+				// user-select 스타일 추가
+				const textEditStyle = iframeDoc.createElement("style");
+				textEditStyle.id = "text-edit-styles";
+				textEditStyle.textContent = `
           body, * {
             user-select: text !important;
             -webkit-user-select: text !important;
             cursor: text !important;
           }
         `;
-        const existingTextStyle = iframeDoc.getElementById('text-edit-styles');
-        if (existingTextStyle) {
-          existingTextStyle.remove();
-        }
-        iframeDoc.head.appendChild(textEditStyle);
+				const existingTextStyle = iframeDoc.getElementById("text-edit-styles");
+				if (existingTextStyle) {
+					existingTextStyle.remove();
+				}
+				iframeDoc.head.appendChild(textEditStyle);
 
-        // 링크 클릭 핸들러 (편집 모달)
-        linkClickHandlersRef.current.forEach((handler, link) => {
-          link.removeEventListener('click', handler, true);
-        });
-        linkClickHandlersRef.current.clear();
+				// 링크 클릭 핸들러 (편집 모달)
+				linkClickHandlersRef.current.forEach((handler, link) => {
+					link.removeEventListener("click", handler, true);
+				});
+				linkClickHandlersRef.current.clear();
 
-        const allLinks = iframeDoc.querySelectorAll('a');
-        const handleLinkClick = (e: Event) => {
-          const mouseEvent = e as MouseEvent;
-          
-          if (mouseEvent.ctrlKey || mouseEvent.metaKey) {
-            return true;
-          }
-          
-          e.preventDefault();
-          e.stopPropagation();
-          e.stopImmediatePropagation();
-          
-          const linkElement = e.currentTarget as HTMLAnchorElement;
-          setEditingLink(linkElement);
-          setLinkUrl(linkElement.href || '');
-          setShowLinkModal(true);
-          
-          return false;
-        };
+				const allLinks = iframeDoc.querySelectorAll("a");
+				const handleLinkClick = (e: Event) => {
+					const mouseEvent = e as MouseEvent;
 
-        allLinks.forEach(link => {
-          const htmlLink = link as HTMLElement;
-          htmlLink.addEventListener('click', handleLinkClick, true);
-          linkClickHandlersRef.current.set(htmlLink, handleLinkClick);
-          htmlLink.style.cursor = 'pointer';
-          htmlLink.style.textDecoration = 'underline';
-        });
+					if (mouseEvent.ctrlKey || mouseEvent.metaKey) {
+						return true;
+					}
 
-        // 링크 스타일 CSS
-        const linkStyle = iframeDoc.createElement('style');
-        linkStyle.id = 'text-edit-link-style';
-        linkStyle.textContent = `
+					e.preventDefault();
+					e.stopPropagation();
+					e.stopImmediatePropagation();
+
+					const linkElement = e.currentTarget as HTMLAnchorElement;
+					setEditingLink(linkElement);
+					setLinkUrl(linkElement.href || "");
+					setShowLinkModal(true);
+
+					return false;
+				};
+
+				allLinks.forEach((link) => {
+					const htmlLink = link as HTMLElement;
+					htmlLink.addEventListener("click", handleLinkClick, true);
+					linkClickHandlersRef.current.set(htmlLink, handleLinkClick);
+					htmlLink.style.cursor = "pointer";
+					htmlLink.style.textDecoration = "underline";
+				});
+
+				// 링크 스타일 CSS
+				const linkStyle = iframeDoc.createElement("style");
+				linkStyle.id = "text-edit-link-style";
+				linkStyle.textContent = `
           a {
             cursor: text !important;
             pointer-events: auto !important;
@@ -420,103 +498,114 @@ export default function DocumentReview() {
             text-decoration: underline !important;
           }
         `;
-        const existingLinkStyle = iframeDoc.getElementById('text-edit-link-style');
-        if (existingLinkStyle) {
-          existingLinkStyle.remove();
-        }
-        iframeDoc.head.appendChild(linkStyle);
+				const existingLinkStyle = iframeDoc.getElementById(
+					"text-edit-link-style",
+				);
+				if (existingLinkStyle) {
+					existingLinkStyle.remove();
+				}
+				iframeDoc.head.appendChild(linkStyle);
 
-        // 키보드 이벤트 처리 (Undo/Redo)
-        const handleKeyDown = (e: KeyboardEvent) => {
-          if ((e.ctrlKey || e.metaKey) && e.key === 'z' && !e.shiftKey) {
-            e.preventDefault();
-            e.stopImmediatePropagation();
-            iframeDoc.execCommand('undo', false);
-            const updatedHtml = iframeDoc.documentElement.outerHTML;
-            currentEditorHtmlRef.current = updatedHtml;
-            console.log('↩️ Undo (DocumentReview 텍스트 편집)');
-          } else if ((e.ctrlKey || e.metaKey) && (e.key === 'y' || (e.key === 'z' && e.shiftKey))) {
-            e.preventDefault();
-            e.stopImmediatePropagation();
-            iframeDoc.execCommand('redo', false);
-            const updatedHtml = iframeDoc.documentElement.outerHTML;
-            currentEditorHtmlRef.current = updatedHtml;
-            console.log('↪️ Redo (DocumentReview 텍스트 편집)');
-          }
-        };
+				// 키보드 이벤트 처리 (Undo/Redo)
+				const handleKeyDown = (e: KeyboardEvent) => {
+					if ((e.ctrlKey || e.metaKey) && e.key === "z" && !e.shiftKey) {
+						e.preventDefault();
+						e.stopImmediatePropagation();
+						iframeDoc.execCommand("undo", false);
+						const updatedHtml = iframeDoc.documentElement.outerHTML;
+						currentEditorHtmlRef.current = updatedHtml;
+						console.log("↩️ Undo (DocumentReview 텍스트 편집)");
+					} else if (
+						(e.ctrlKey || e.metaKey) &&
+						(e.key === "y" || (e.key === "z" && e.shiftKey))
+					) {
+						e.preventDefault();
+						e.stopImmediatePropagation();
+						iframeDoc.execCommand("redo", false);
+						const updatedHtml = iframeDoc.documentElement.outerHTML;
+						currentEditorHtmlRef.current = updatedHtml;
+						console.log("↪️ Redo (DocumentReview 텍스트 편집)");
+					}
+				};
 
-        if (iframeKeydownHandlerRef.current && iframeDoc) {
-          iframeDoc.removeEventListener('keydown', iframeKeydownHandlerRef.current, true);
-        }
-        iframeKeydownHandlerRef.current = handleKeyDown;
-        iframeDoc.addEventListener('keydown', handleKeyDown, true);
-        console.log('✅ DocumentReview 텍스트 모드 키보드 단축키 등록 완료');
+				if (iframeKeydownHandlerRef.current && iframeDoc) {
+					iframeDoc.removeEventListener(
+						"keydown",
+						iframeKeydownHandlerRef.current,
+						true,
+					);
+				}
+				iframeKeydownHandlerRef.current = handleKeyDown;
+				iframeDoc.addEventListener("keydown", handleKeyDown, true);
+				console.log("✅ DocumentReview 텍스트 모드 키보드 단축키 등록 완료");
 
-        // input 이벤트 처리 (변경 사항 추적)
-        let inputTimeoutId: ReturnType<typeof setTimeout> | null = null;
-        const handleInput = () => {
-          if (inputTimeoutId) {
-            clearTimeout(inputTimeoutId);
-          }
-          inputTimeoutId = setTimeout(() => {
-            const updatedHtml = iframeDoc.documentElement.outerHTML;
-            setTranslationHtml(updatedHtml);
-            currentEditorHtmlRef.current = updatedHtml;
-            inputTimeoutId = null;
-          }, 500);
-        };
-        iframeDoc.body.addEventListener('input', handleInput);
+				// input 이벤트 처리 (변경 사항 추적)
+				let inputTimeoutId: ReturnType<typeof setTimeout> | null = null;
+				const handleInput = () => {
+					if (inputTimeoutId) {
+						clearTimeout(inputTimeoutId);
+					}
+					inputTimeoutId = setTimeout(() => {
+						const updatedHtml = iframeDoc.documentElement.outerHTML;
+						setTranslationHtml(updatedHtml);
+						currentEditorHtmlRef.current = updatedHtml;
+						inputTimeoutId = null;
+					}, 500);
+				};
+				iframeDoc.body.addEventListener("input", handleInput);
+			} else if (editorMode === "component") {
+				// 컴포넌트 편집 모드
+				console.log("🧩 [DocumentReview] 컴포넌트 편집 모드 활성화");
 
-      } else if (editorMode === 'component') {
-        // 컴포넌트 편집 모드
-        console.log('🧩 [DocumentReview] 컴포넌트 편집 모드 활성화');
-        
-        // 브라우저 텍스트 선택 초기화
-        const selection = iframeDoc.defaultView?.getSelection();
-        if (selection) {
-          selection.removeAllRanges();
-        }
+				// 브라우저 텍스트 선택 초기화
+				const selection = iframeDoc.defaultView?.getSelection();
+				if (selection) {
+					selection.removeAllRanges();
+				}
 
-        // selectedElements state 초기화
-        setSelectedElements([]);
+				// selectedElements state 초기화
+				setSelectedElements([]);
 
-        // 기존 컴포넌트 핸들러 제거
-        componentClickHandlersRef.current.forEach((handler, el) => {
-          el.removeEventListener('click', handler, true);
-        });
-        componentClickHandlersRef.current.clear();
+				// 기존 컴포넌트 핸들러 제거
+				componentClickHandlersRef.current.forEach((handler, el) => {
+					el.removeEventListener("click", handler, true);
+				});
+				componentClickHandlersRef.current.clear();
 
-        // 기존 스타일 제거
-        const textEditOverrideStyle = iframeDoc.getElementById('text-edit-override-styles');
-        if (textEditOverrideStyle) {
-          textEditOverrideStyle.remove();
-        }
-        const textEditStyle = iframeDoc.getElementById('text-edit-styles');
-        if (textEditStyle) {
-          textEditStyle.remove();
-        }
+				// 기존 스타일 제거
+				const textEditOverrideStyle = iframeDoc.getElementById(
+					"text-edit-override-styles",
+				);
+				if (textEditOverrideStyle) {
+					textEditOverrideStyle.remove();
+				}
+				const textEditStyle = iframeDoc.getElementById("text-edit-styles");
+				if (textEditStyle) {
+					textEditStyle.remove();
+				}
 
-        // 링크 클릭 핸들러 제거
-        linkClickHandlersRef.current.forEach((handler, link) => {
-          link.removeEventListener('click', handler, true);
-        });
-        linkClickHandlersRef.current.clear();
+				// 링크 클릭 핸들러 제거
+				linkClickHandlersRef.current.forEach((handler, link) => {
+					link.removeEventListener("click", handler, true);
+				});
+				linkClickHandlersRef.current.clear();
 
-        const linkStyle = iframeDoc.getElementById('text-edit-link-style');
-        if (linkStyle) {
-          linkStyle.remove();
-        }
+				const linkStyle = iframeDoc.getElementById("text-edit-link-style");
+				if (linkStyle) {
+					linkStyle.remove();
+				}
 
-        // contentEditable 비활성화
-        const allEditableElements = iframeDoc.querySelectorAll('[contenteditable]');
-        allEditableElements.forEach(el => {
-          (el as HTMLElement).contentEditable = 'false';
-        });
+				// contentEditable 비활성화
+				const allEditableElements =
+					iframeDoc.querySelectorAll("[contenteditable]");
+				allEditableElements.forEach((el) => {
+					(el as HTMLElement).contentEditable = "false";
+				});
 
-        // 컴포넌트 편집 모드 스타일 추가
-        const style = iframeDoc.createElement('style');
-        style.id = 'editor-styles';
-        style.textContent = `
+				// 컴포넌트 편집 모드 스타일 추가
+				const style = iframeDoc.createElement("style");
+				style.id = "editor-styles";
+				style.textContent = `
           div[data-component-editable],
           section[data-component-editable],
           article[data-component-editable],
@@ -555,1885 +644,2466 @@ export default function DocumentReview() {
             transition: all 0.2s ease !important;
           }
         `;
-        iframeDoc.head.appendChild(style);
-
-        // 클릭 가능한 컴포넌트 표시
-        const componentElements = iframeDoc.querySelectorAll('div, section, article, header, footer, main, aside, nav, p, h1, h2, h3, h4, h5, h6, a');
-
-        // 키보드 단축키 (컴포넌트 모드 Undo/Redo)
-        const handleKeydown = (e: KeyboardEvent) => {
-          if ((e.ctrlKey || e.metaKey) && e.key === 'z' && !e.shiftKey) {
-            e.preventDefault();
-            e.stopImmediatePropagation();
-
-            if (undoStackRef.current.length > 0) {
-              console.log('↩️ Undo (컴포넌트 편집) - stack:', undoStackRef.current.length);
-
-              redoStackRef.current.push(currentEditorHtmlRef.current);
-              const previousHtml = undoStackRef.current.pop()!;
-              currentEditorHtmlRef.current = previousHtml;
-
-              iframeDoc.open();
-              iframeDoc.write(previousHtml);
-              iframeDoc.close();
-
-              setTranslationHtml(previousHtml);
-              setSelectedElements([]);
-
-              setTimeout(() => {
-                const newIframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-                if (newIframeDoc?.body) {
-                  newIframeDoc.body.setAttribute('tabindex', '-1');
-                  newIframeDoc.body.focus();
-                }
-              }, 50);
-            } else {
-              console.log('⚠️ Undo stack이 비어있습니다');
-            }
-          } else if ((e.ctrlKey || e.metaKey) && (e.key === 'y' || (e.key === 'z' && e.shiftKey))) {
-            e.preventDefault();
-            e.stopImmediatePropagation();
-
-            if (redoStackRef.current.length > 0) {
-              console.log('↪️ Redo (컴포넌트 편집) - stack:', redoStackRef.current.length);
-
-              undoStackRef.current.push(currentEditorHtmlRef.current);
-              const nextHtml = redoStackRef.current.pop()!;
-              currentEditorHtmlRef.current = nextHtml;
-
-              iframeDoc.open();
-              iframeDoc.write(nextHtml);
-              iframeDoc.close();
-
-              setTranslationHtml(nextHtml);
-              setSelectedElements([]);
-
-              setTimeout(() => {
-                const newIframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-                if (newIframeDoc?.body) {
-                  newIframeDoc.body.setAttribute('tabindex', '-1');
-                  newIframeDoc.body.focus();
-                }
-              }, 50);
-            } else {
-              console.log('⚠️ Redo stack이 비어있습니다');
-            }
-          }
-        };
-
-        if (iframeKeydownHandlerRef.current && iframeDoc) {
-          iframeDoc.removeEventListener('keydown', iframeKeydownHandlerRef.current, true);
-        }
-        iframeKeydownHandlerRef.current = handleKeydown;
-        iframeDoc.addEventListener('keydown', handleKeydown, true);
-        console.log('✅ DocumentReview 컴포넌트 모드 키보드 단축키 등록 완료');
-
-        // window 키보드 이벤트도 처리
-        const handleWindowKeydown = (e: KeyboardEvent) => {
-          if ((e.ctrlKey || e.metaKey) && e.key === 'z' && !e.shiftKey) {
-            e.preventDefault();
-            e.stopImmediatePropagation();
-
-            if (undoStackRef.current.length > 0 && iframeDoc) {
-              console.log('↩️ Undo (DocumentReview 컴포넌트 편집 - window)');
-
-              redoStackRef.current.push(currentEditorHtmlRef.current);
-              const previousHtml = undoStackRef.current.pop()!;
-              currentEditorHtmlRef.current = previousHtml;
-
-              iframeDoc.open();
-              iframeDoc.write(previousHtml);
-              iframeDoc.close();
-
-              setTranslationHtml(previousHtml);
-              setSelectedElements([]);
-
-              setTimeout(() => {
-                const newIframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-                if (newIframeDoc?.body) {
-                  newIframeDoc.body.setAttribute('tabindex', '-1');
-                  newIframeDoc.body.focus();
-                }
-              }, 50);
-            }
-          } else if ((e.ctrlKey || e.metaKey) && (e.key === 'y' || (e.key === 'z' && e.shiftKey))) {
-            e.preventDefault();
-            e.stopImmediatePropagation();
-
-            if (redoStackRef.current.length > 0 && iframeDoc) {
-              console.log('↪️ Redo (DocumentReview 컴포넌트 편집 - window)');
-
-              undoStackRef.current.push(currentEditorHtmlRef.current);
-              const nextHtml = redoStackRef.current.pop()!;
-              currentEditorHtmlRef.current = nextHtml;
-
-              iframeDoc.open();
-              iframeDoc.write(nextHtml);
-              iframeDoc.close();
-
-              setTranslationHtml(nextHtml);
-              setSelectedElements([]);
-
-              setTimeout(() => {
-                const newIframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-                if (newIframeDoc?.body) {
-                  newIframeDoc.body.setAttribute('tabindex', '-1');
-                  newIframeDoc.body.focus();
-                }
-              }, 50);
-            }
-          }
-        };
-
-        if (windowKeydownHandlerRef.current) {
-          window.removeEventListener('keydown', windowKeydownHandlerRef.current, true);
-        }
-        windowKeydownHandlerRef.current = handleWindowKeydown;
-        window.addEventListener('keydown', handleWindowKeydown, true);
-        console.log('✅ DocumentReview window 키보드 이벤트 리스너 등록 완료');
-
-        // 컴포넌트 클릭 핸들러 (다중 선택 + 토글)
-        const handleComponentClick = (e: Event) => {
-          e.stopPropagation();
-          e.preventDefault();
-
-          const target = e.target as HTMLElement;
-          if (!target || ['SCRIPT', 'STYLE', 'NOSCRIPT', 'HTML', 'HEAD', 'BODY'].includes(target.tagName)) return;
-
-          const editableElement = target.closest('[data-component-editable]') as HTMLElement;
-          if (!editableElement) {
-            console.log('⚠️ 편집 가능한 요소를 찾을 수 없습니다:', target.tagName);
-            return;
-          }
-
-          const isSelected = editableElement.classList.contains('component-selected');
-
-          if (isSelected) {
-            editableElement.classList.remove('component-selected');
-            editableElement.style.outline = '1px dashed #C0C0C0';
-            editableElement.style.boxShadow = 'none';
-            setSelectedElements(prev => prev.filter(el => el !== editableElement));
-          } else {
-            editableElement.classList.add('component-selected');
-            editableElement.style.outline = '3px solid #000000';
-            editableElement.style.boxShadow = 'none';
-            setSelectedElements(prev => [...prev, editableElement]);
-          }
-        };
-
-        // 이벤트 리스너 등록
-        componentElements.forEach((el) => {
-          if (el.tagName && !['SCRIPT', 'STYLE', 'NOSCRIPT', 'HTML', 'HEAD', 'BODY'].includes(el.tagName)) {
-            const htmlEl = el as HTMLElement;
-            htmlEl.setAttribute('data-component-editable', 'true');
-            htmlEl.style.cursor = 'pointer';
-            htmlEl.style.outline = '1px dashed #C0C0C0';
-
-            htmlEl.addEventListener('click', handleComponentClick, true);
-            componentClickHandlersRef.current.set(htmlEl, handleComponentClick);
-          }
-        });
-
-        // contentEditable 비활성화
-        const allElements = iframeDoc.querySelectorAll('*');
-        allElements.forEach(el => {
-          (el as HTMLElement).contentEditable = 'false';
-        });
-      }
-      } catch (error) {
-        console.error('❌ 번역 iframe 오류:', error);
-      }
-
-    // Cleanup
-    return () => {
-      if (windowKeydownHandlerRef.current) {
-        window.removeEventListener('keydown', windowKeydownHandlerRef.current, true);
-    }
-    };
-  }, [translationHtml, collapsedPanels, fullscreenPanel, editorMode]);
-
-  // 더보기 메뉴 외부 클릭 시 닫기
-  useEffect(() => {
-    const handleWindowClick = (e: MouseEvent) => {
-      const target = e.target as HTMLElement;
-      if (!target.closest('[data-more-menu]')) {
-        setShowMoreMenu(false);
-      }
-    };
-
-    if (showMoreMenu) {
-      window.addEventListener('click', handleWindowClick);
-    }
-
-    return () => {
-      window.removeEventListener('click', handleWindowClick);
-    };
-  }, [showMoreMenu]);
-
-  // 문단 하이라이트 동기화
-  useEffect(() => {
-    const applyParagraphStyles = (panel: HTMLElement | null, panelName: string) => {
-      if (!panel) return;
-      clearAllHighlights(panel);
-      
-      const paragraphs = getParagraphs(panel);
-      paragraphs.forEach((para) => {
-        const isHighlighted = para.index === highlightedParagraphIndex;
-        if (isHighlighted) {
-          highlightParagraph(para.element, true);
-        }
-      });
-    };
-
-    if (originalIframeRef.current?.contentDocument?.body) {
-      applyParagraphStyles(originalIframeRef.current.contentDocument.body as HTMLElement, '원문');
-    }
-    
-    if (aiDraftIframeRef.current?.contentDocument?.body) {
-      applyParagraphStyles(aiDraftIframeRef.current.contentDocument.body as HTMLElement, 'AI 초벌');
-    }
-    
-    if (translationIframeRef.current?.contentDocument?.body) {
-      applyParagraphStyles(translationIframeRef.current.contentDocument.body as HTMLElement, '번역');
-    }
-  }, [highlightedParagraphIndex]);
-
-  // 패널 접기/펼치기
-  const togglePanel = (panelId: string) => {
-    setCollapsedPanels(prev => {
-      const newSet = new Set(prev);
-      if (newSet.has(panelId)) {
-        newSet.delete(panelId);
-      } else {
-        newSet.add(panelId);
-      }
-      return newSet;
-    });
-  };
-
-  // 전체화면 토글
-  const toggleFullscreen = (panelId: string) => {
-    setFullscreenPanel(prev => prev === panelId ? null : panelId);
-  };
-
-  // 승인 처리
-  const handleApprove = async () => {
-      if (!documentId) {
-        alert('문서 ID가 없습니다.');
-        return;
-      }
-
-    // iframe에서 최신 HTML 가져오기
-    const iframe = translationIframeRef.current;
-    let editedHtml = translationHtml;
-    
-    if (iframe) {
-      const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-      if (iframeDoc && iframeDoc.documentElement) {
-        editedHtml = iframeDoc.documentElement.outerHTML;
-        console.log('💾 승인 시 수정된 HTML 사용');
-      }
-    }
-    
-    if (!review) {
-      // 리뷰가 없으면 먼저 리뷰를 생성해야 함
-      // 버전 정보를 다시 가져와서 최신 MANUAL_TRANSLATION 버전 찾기
-      try {
-        const versions = await docApi.getDocumentVersions(documentId);
-        let manualTranslationVersion = versions
-          .filter(v => v.versionType === 'MANUAL_TRANSLATION')
-          .sort((a, b) => (b.versionNumber || 0) - (a.versionNumber || 0))[0];
-
-        if (!manualTranslationVersion) {
-          alert('검토할 번역 버전을 찾을 수 없습니다.');
-          return;
-        }
-        
-        // 수정된 내용이 있으면 새 버전으로 저장
-        if (editedHtml !== translationContent) {
-          console.log('✅ 수정된 내용을 새 버전으로 저장');
-          const newVersion = await docApi.createDocumentVersion(documentId, {
-            versionType: 'MANUAL_TRANSLATION',
-            content: editedHtml,
-          });
-          manualTranslationVersion = newVersion;
-        }
-
-        // 리뷰 생성
-        const newReview = await reviewApi.createReview({
-          documentId,
-          documentVersionId: manualTranslationVersion.id,
-          isComplete: true, // 기본값으로 완전 번역으로 설정
-        });
-        setReview(newReview);
-
-        if (!window.confirm('이 문서를 승인하시겠습니까? 승인 후 문서 상태가 변경됩니다.')) {
-          return;
-        }
-
-        await reviewApi.approveReview(newReview.id);
-        alert('문서가 승인되었습니다.');
-        navigate('/reviews');
-      } catch (error: any) {
-        console.error('리뷰 생성 또는 승인 실패:', error);
-        alert('승인 처리에 실패했습니다: ' + (error.response?.data?.message || error.message));
-      }
-      return;
-    }
-
-    // 리뷰가 이미 있는 경우
-    try {
-      // 수정된 내용이 있으면 새 버전으로 저장
-      if (editedHtml !== translationContent) {
-        console.log('✅ 수정된 내용을 새 버전으로 저장');
-        const newVersion = await docApi.createDocumentVersion(documentId, {
-          versionType: 'MANUAL_TRANSLATION',
-          content: editedHtml,
-        });
-        
-        // 리뷰 업데이트 (새 버전으로 교체)
-        await reviewApi.updateReview(review.id, {
-          documentVersionId: newVersion.id,
-        });
-    }
-
-    if (!window.confirm('이 문서를 승인하시겠습니까? 승인 후 문서 상태가 변경됩니다.')) {
-      return;
-    }
-
-      await reviewApi.approveReview(review.id);
-      alert('문서가 승인되었습니다.');
-      navigate('/reviews');
-    } catch (error: any) {
-      console.error('승인 실패:', error);
-      alert('승인 처리에 실패했습니다: ' + (error.response?.data?.message || error.message));
-    }
-  };
-
-  // 반려 처리
-  const handleReject = async () => {
-    if (!rejectMessage.trim()) {
-      alert('반려 사유를 입력해주세요.');
-      return;
-    }
-
-    if (!review) {
-      // 리뷰가 없으면 먼저 리뷰를 생성해야 함
-      if (!documentId) {
-        alert('문서 ID가 없습니다.');
-        return;
-      }
-
-      // 버전 정보를 다시 가져와서 최신 MANUAL_TRANSLATION 버전 찾기
-      try {
-        const versions = await docApi.getDocumentVersions(documentId);
-        const manualTranslationVersion = versions
-          .filter(v => v.versionType === 'MANUAL_TRANSLATION')
-          .sort((a, b) => (b.versionNumber || 0) - (a.versionNumber || 0))[0];
-
-        if (!manualTranslationVersion) {
-          alert('검토할 번역 버전을 찾을 수 없습니다.');
-          return;
-        }
-
-        // 리뷰 생성 (반려 메시지 포함)
-        const newReview = await reviewApi.createReview({
-          documentId,
-          documentVersionId: manualTranslationVersion.id,
-          comment: rejectMessage,
-          isComplete: false,
-        });
-        setReview(newReview);
-
-        // 반려 처리
-        await reviewApi.rejectReview(newReview.id);
-        
-        alert('문서가 반려되었습니다. 문서가 다시 번역 대기 상태로 변경됩니다.');
-        navigate('/reviews');
-      } catch (error: any) {
-        console.error('리뷰 생성 또는 반려 실패:', error);
-        alert('반려 처리에 실패했습니다: ' + (error.response?.data?.message || error.message));
-      }
-      return;
-    }
-
-    try {
-      // 먼저 리뷰에 코멘트 추가
-      await reviewApi.updateReview(review.id, { comment: rejectMessage });
-      
-      // 그 다음 반려 처리
-      await reviewApi.rejectReview(review.id);
-      
-      alert('문서가 반려되었습니다. 문서가 다시 번역 대기 상태로 변경됩니다.');
-      navigate('/reviews');
-    } catch (error: any) {
-      console.error('반려 실패:', error);
-      alert('반려 처리에 실패했습니다: ' + (error.response?.data?.message || error.message));
-    }
-  };
-
-  if (loading) {
-    return (
-      <div style={{ padding: '48px', textAlign: 'center', color: colors.primaryText }}>
-        로딩 중...
-      </div>
-    );
-  }
-
-  if (error || !document) {
-    return (
-      <div style={{ padding: '48px' }}>
-        <div
-          style={{
-            padding: '16px',
-            backgroundColor: '#F5F5F5',
-            border: `1px solid ${colors.border}`,
-            borderRadius: '8px',
-            color: colors.primaryText,
-            marginBottom: '16px',
-          }}
-        >
-          ⚠️ {error || '문서를 불러올 수 없습니다.'}
-        </div>
-        <div>
-          <Button variant="secondary" onClick={() => navigate('/reviews')}>
-            목록으로 돌아가기
-          </Button>
-        </div>
-      </div>
-    );
-  }
-
-  // 상태 텍스트 변환
-  const getStatusText = (status: string) => {
-    const statusMap: Record<string, string> = {
-      'DRAFT': '초안',
-      'PENDING_TRANSLATION': '번역 대기',
-      'IN_TRANSLATION': '번역 중',
-      'PENDING_REVIEW': '검토 대기',
-      'APPROVED': '번역 완료',
-      'PUBLISHED': '공개됨',
-    };
-    return statusMap[status] || status;
-  };
-
-  return (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        height: '100vh',
-        backgroundColor: colors.primaryBackground,
-      }}
-    >
-      {/* 상단 고정 바 */}
-      <div
-        style={{
-          padding: '12px 24px',
-          backgroundColor: colors.surface,
-          borderBottom: `1px solid ${colors.border}`,
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          gap: '16px',
-        }}
-      >
-        {/* 왼쪽: 뒤로가기 + 문서 정보 */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: '16px', flex: 1 }}>
-          <Button 
-            variant="secondary" 
-            onClick={() => navigate('/reviews')} 
-            style={{ fontSize: '12px', padding: '6px 12px' }}
-          >
-            ← 뒤로가기
-          </Button>
-          
-          {document && (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
-              <div style={{ fontSize: '14px', fontWeight: 600, color: '#000000' }}>
-                {document.title}
-              </div>
-              <div style={{ display: 'flex', gap: '12px', alignItems: 'center' }}>
-                <span style={{ fontSize: '11px', color: colors.secondaryText }}>
-                  {document.categoryId ? `카테고리 ${document.categoryId}` : '미분류'} · {getStatusText(document.status)}
-                </span>
-                {review && (
-                  <span style={{ fontSize: '11px', color: colors.secondaryText }}>
-                    검토자: {review.reviewer?.name || '-'}
-                  </span>
-                )}
-              </div>
-            </div>
-          )}
-        </div>
-        
-        {/* 중앙: 문서 보기 옵션 */}
-        <div style={{ 
-          display: 'flex', 
-          alignItems: 'center', 
-          gap: '24px',
-          padding: '6px 16px',
-          backgroundColor: '#F8F9FA',
-          borderRadius: '6px',
-          border: '1px solid #D3D3D3',
-        }}>
-          <span style={{ fontSize: '12px', fontWeight: 600, color: colors.primaryText }}>문서 보기:</span>
-          <label style={{ 
-            display: 'flex', 
-            alignItems: 'center', 
-            gap: '8px', 
-            fontSize: '13px', 
-            cursor: 'pointer',
-            fontWeight: 500,
-          }}>
-            <input
-              type="checkbox"
-              checked={!collapsedPanels.has('original')}
-              onChange={() => togglePanel('original')}
-              style={{
-                cursor: 'pointer',
-                width: '16px',
-                height: '16px',
-              }}
-            />
-            <span>원문 (Version 0)</span>
-          </label>
-          <label style={{ 
-            display: 'flex', 
-            alignItems: 'center', 
-            gap: '8px', 
-            fontSize: '13px', 
-            cursor: 'pointer',
-            fontWeight: 500,
-          }}>
-            <input
-              type="checkbox"
-              checked={!collapsedPanels.has('aiDraft')}
-              onChange={() => togglePanel('aiDraft')}
-              style={{ 
-                cursor: 'pointer',
-                width: '16px',
-                height: '16px',
-              }}
-            />
-            <span>AI 초벌 번역 (Version 1)</span>
-          </label>
-          <label style={{ 
-            display: 'flex', 
-            alignItems: 'center', 
-            gap: '8px', 
-            fontSize: '13px', 
-            cursor: 'pointer',
-            fontWeight: 500,
-          }}>
-            <input
-              type="checkbox"
-              checked={!collapsedPanels.has('translation')}
-              onChange={() => togglePanel('translation')}
-              style={{ 
-                cursor: 'pointer',
-                width: '16px',
-                height: '16px',
-              }}
-            />
-            <span>번역본 (검토 대상)</span>
-          </label>
-        </div>
-
-        {/* 오른쪽: HTML 다운로드, 승인/반려 버튼 */}
-        <div style={{ display: 'flex', gap: '8px' }}>
-          <Button 
-            variant="secondary" 
-            onClick={() => {
-              const iframe = translationIframeRef.current;
-              if (!iframe) return;
-              
-              const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-              if (!iframeDoc) return;
-              
-              const html = iframeDoc.documentElement.outerHTML;
-              const blob = new Blob([html], { type: 'text/html' });
-              const url = URL.createObjectURL(blob);
-              const a = document.createElement('a');
-              a.href = url;
-              a.download = `${document?.title || 'document'}_edited.html`;
-              a.click();
-              URL.revokeObjectURL(url);
-            }}
-            style={{ fontSize: '12px' }}
-          >
-            💾 HTML 다운로드
-          </Button>
-          <Button 
-            variant="secondary" 
-            onClick={() => setShowRejectModal(true)}
-            style={{ fontSize: '12px' }}
-          >
-            반려
-          </Button>
-          <Button 
-            variant="primary" 
-            onClick={handleApprove}
-            style={{ fontSize: '12px' }}
-          >
-            승인
-          </Button>
-        </div>
-      </div>
-
-      {/* 3단 레이아웃 */}
-      <div style={{ display: 'flex', height: '100%', gap: '4px', padding: '4px' }}>
-        {[
-          { id: 'original', title: '원문', ref: originalIframeRef, html: originalHtml },
-          { id: 'aiDraft', title: 'AI 초벌 번역', ref: aiDraftIframeRef, html: aiDraftHtml },
-          { id: 'translation', title: '번역본 (검토 대상)', ref: translationIframeRef, html: translationHtml },
-        ].map(panel => {
-          const isCollapsed = collapsedPanels.has(panel.id);
-          const isFullscreen = fullscreenPanel === panel.id;
-          const visiblePanels = ['original', 'aiDraft', 'translation'].filter(id => !collapsedPanels.has(id));
-          const hasFullscreen = fullscreenPanel !== null;
-          const isHidden = hasFullscreen && !isFullscreen;
-
-          if (isHidden) return null;
-
-          return (
-            <div
-              key={panel.id}
-              style={{
-                flex: isCollapsed ? '0 0 0' : isFullscreen ? '1' : `1 1 ${100 / visiblePanels.length}%`,
-                display: isCollapsed ? 'none' : 'flex',
-                flexDirection: 'column',
-                transition: 'flex 0.2s ease',
-                minWidth: isCollapsed ? '0' : '200px',
-              }}
-            >
-              {/* 패널 헤더 */}
-              <div
-                style={{
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  alignItems: 'center',
-                  padding: '8px 12px',
-                  backgroundColor: '#D3D3D3',
-                  borderRadius: '4px 4px 0 0',
-                  cursor: 'default',
-                  height: '36px',
-                }}
-              >
-                <span style={{ fontSize: '12px', fontWeight: 600, color: '#000000' }}>
-                  {panel.title}
-                </span>
-                <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                  <button
-                    onClick={() => toggleFullscreen(panel.id)}
-                    style={{
-                      padding: '4px 8px',
-                      fontSize: '11px',
-                      border: '1px solid #A9A9A9',
-                      borderRadius: '3px',
-                      backgroundColor: '#FFFFFF',
-                      color: '#000000',
-                      cursor: 'pointer',
-                      fontWeight: 500,
-                    }}
-                    title={isFullscreen ? '확대 해제' : '전체화면 확대'}
-                  >
-                    {isFullscreen ? '축소' : '확대'}
-                  </button>
-                </div>
-              </div>
-
-              {/* 패널 내용 */}
-              <div
-                style={{
-                  flex: 1,
-                  border: '1px solid #C0C0C0',
-                  borderTop: 'none',
-                  borderRadius: '0 0 4px 4px',
-                  overflow: 'hidden',
-                  backgroundColor: '#FFFFFF',
-                  display: 'flex',
-                  flexDirection: 'column',
-                  position: 'relative',
-                }}
-              >
-                {panel.id === 'translation' ? (
-                  // 번역본 패널 - 에디터 툴바 포함
-                  <>
-                    {/* 편집 툴바 */}
-                    <div style={{ padding: '8px 12px', borderBottom: '1px solid #C0C0C0', display: 'flex', justifyContent: 'flex-start', alignItems: 'center', backgroundColor: '#F8F9FA', flexWrap: 'wrap', gap: '8px' }}>
-                      <div style={{ display: 'flex', gap: '4px', alignItems: 'center', flexWrap: 'wrap' }}>
-                        {/* 모드 선택 */}
-                        <Button
-                          variant={editorMode === 'text' ? 'primary' : 'secondary'}
-                          onClick={() => setEditorMode('text')}
-                          style={{ fontSize: '11px', padding: '4px 8px' }}
-                        >
-                          텍스트 편집
-                        </Button>
-                        <Button
-                          variant={editorMode === 'component' ? 'primary' : 'secondary'}
-                          onClick={() => setEditorMode('component')}
-                          style={{ fontSize: '11px', padding: '4px 8px' }}
-                        >
-                          컴포넌트 편집
-                        </Button>
-
-                        {/* Rich Text 기능 (텍스트 모드일 때만) */}
-                        {editorMode === 'text' && (
-                          <>
-                            <div style={{ width: '1px', height: '20px', backgroundColor: '#C0C0C0', margin: '0 4px' }} />
-                            
-                            {/* 실행 취소/다시 실행 버튼 */}
-                            <button
-                              onClick={() => {
-                                const iframeDoc = translationIframeRef.current?.contentDocument;
-                                if (iframeDoc) {
-                                  iframeDoc.execCommand('undo', false);
-                                }
-                              }}
-                              style={{
-                                padding: '4px 8px',
-                                fontSize: '11px',
-                                border: '1px solid #A9A9A9',
-                                borderRadius: '3px',
-                                backgroundColor: '#FFFFFF',
-                                color: '#000000',
-                                cursor: 'pointer',
-                                display: 'flex',
-                                alignItems: 'center',
-                                justifyContent: 'center',
-                              }}
-                              title="실행 취소 (Ctrl/Cmd+Z)"
-                            >
-                              <Undo2 size={16} color="#000000" />
-                            </button>
-                            <button
-                              onClick={() => {
-                                const iframeDoc = translationIframeRef.current?.contentDocument;
-                                if (iframeDoc) {
-                                  iframeDoc.execCommand('redo', false);
-                                }
-                              }}
-                              style={{
-                                padding: '4px 8px',
-                                fontSize: '11px',
-                                border: '1px solid #A9A9A9',
-                                borderRadius: '3px',
-                                backgroundColor: '#FFFFFF',
-                                color: '#000000',
-                                cursor: 'pointer',
-                                display: 'flex',
-                                alignItems: 'center',
-                                justifyContent: 'center',
-                              }}
-                              title="다시 실행 (Ctrl/Cmd+Y)"
-                            >
-                              <Redo2 size={16} color="#000000" />
-                            </button>
-                            
-                            <div style={{ width: '1px', height: '20px', backgroundColor: '#C0C0C0', margin: '0 4px' }} />
-                            
-                            <button
-                              onClick={() => {
-                                const iframeDoc = translationIframeRef.current?.contentDocument;
-                                if (iframeDoc) iframeDoc.execCommand('bold', false);
-                              }}
-                              style={{
-                                padding: '4px 8px',
-                                fontSize: '11px',
-                                fontWeight: 'bold',
-                                border: '1px solid #A9A9A9',
-                                borderRadius: '3px',
-                                backgroundColor: '#FFFFFF',
-                                color: '#000000',
-                                cursor: 'pointer',
-                              }}
-                              title="굵게 (Ctrl+B)"
-                            >
-                              B
-                            </button>
-                            <button
-                              onClick={() => {
-                                const iframeDoc = translationIframeRef.current?.contentDocument;
-                                if (iframeDoc) iframeDoc.execCommand('italic', false);
-                              }}
-                              style={{
-                                padding: '4px 8px',
-                                fontSize: '11px',
-                                fontStyle: 'italic',
-                                border: '1px solid #A9A9A9',
-                                borderRadius: '3px',
-                                backgroundColor: '#FFFFFF',
-                                color: '#000000',
-                                cursor: 'pointer',
-                              }}
-                              title="기울임 (Ctrl+I)"
-                            >
-                              I
-                            </button>
-                            <button
-                              onClick={() => {
-                                const iframeDoc = translationIframeRef.current?.contentDocument;
-                                if (iframeDoc) iframeDoc.execCommand('underline', false);
-                              }}
-                              style={{
-                                padding: '4px 8px',
-                                fontSize: '11px',
-                                textDecoration: 'underline',
-                                border: '1px solid #A9A9A9',
-                                borderRadius: '3px',
-                                backgroundColor: '#FFFFFF',
-                                color: '#000000',
-                                cursor: 'pointer',
-                              }}
-                              title="밑줄 (Ctrl+U)"
-                            >
-                              U
-                            </button>
-                            <button
-                              onClick={() => {
-                                const iframeDoc = translationIframeRef.current?.contentDocument;
-                                if (iframeDoc) iframeDoc.execCommand('strikeThrough', false);
-                              }}
-                              style={{
-                                padding: '4px 8px',
-                                fontSize: '11px',
-                                textDecoration: 'line-through',
-                                border: '1px solid #A9A9A9',
-                                borderRadius: '3px',
-                                backgroundColor: '#FFFFFF',
-                                color: '#000000',
-                                cursor: 'pointer',
-                              }}
-                              title="취소선"
-                            >
-                              S
-                            </button>
-                            
-                            <div style={{ width: '1px', height: '20px', backgroundColor: '#C0C0C0', margin: '0 4px' }} />
-                            
-                            <select
-                              onChange={(e) => {
-                                const iframeDoc = translationIframeRef.current?.contentDocument;
-                                if (iframeDoc && e.target.value) {
-                                  const fontSize = e.target.value;
-                                  const selection = iframeDoc.getSelection();
-                                  
-                                  if (selection && selection.rangeCount > 0 && !selection.getRangeAt(0).collapsed) {
-                                    const range = selection.getRangeAt(0);
-                                    const selectedText = range.toString();
-                                    const spanHtml = `<span style="font-size: ${fontSize}pt;">${selectedText}</span>`;
-                                    try {
-                                      iframeDoc.execCommand('insertHTML', false, spanHtml);
-                                    } catch (err) {
-                                      range.deleteContents();
-                                      const tempDiv = iframeDoc.createElement('div');
-                                      tempDiv.innerHTML = spanHtml;
-                                      const fragment = iframeDoc.createDocumentFragment();
-                                      while (tempDiv.firstChild) {
-                                        fragment.appendChild(tempDiv.firstChild);
-                                      }
-                                      range.insertNode(fragment);
-                                      range.setStartAfter(fragment.lastChild || range.startContainer);
-                                      range.collapse(false);
-                                      selection.removeAllRanges();
-                                      selection.addRange(range);
-                                    }
-                                  }
-                                  e.target.value = '';
-                                }
-                              }}
-                              style={{
-                                fontSize: '11px',
-                                padding: '4px 8px',
-                                border: '1px solid #A9A9A9',
-                                borderRadius: '3px',
-                                backgroundColor: '#FFFFFF',
-                                color: '#000000',
-                                cursor: 'pointer',
-                              }}
-                              title="글자 크기 (pt)"
-                            >
-                              <option value="">크기</option>
-                              <option value="10">10pt</option>
-                              <option value="12">12pt</option>
-                              <option value="14">14pt</option>
-                              <option value="16">16pt</option>
-                              <option value="18">18pt</option>
-                              <option value="20">20pt</option>
-                              <option value="24">24pt</option>
-                            </select>
-                            
-                            <select
-                              onChange={(e) => {
-                                const iframeDoc = translationIframeRef.current?.contentDocument;
-                                if (iframeDoc && e.target.value) {
-                                  const lineHeight = e.target.value;
-                                  const selection = iframeDoc.getSelection();
-                                  
-                                  if (selection && selection.rangeCount > 0) {
-                                    const range = selection.getRangeAt(0);
-                                    let blockElement: HTMLElement | null = null;
-                                    
-                                    if (range.commonAncestorContainer.nodeType === 1) {
-                                      blockElement = (range.commonAncestorContainer as HTMLElement).closest('p, div, h1, h2, h3, h4, h5, h6, li, blockquote, pre');
-                                    } else {
-                                      blockElement = range.commonAncestorContainer.parentElement?.closest('p, div, h1, h2, h3, h4, h5, h6, li, blockquote, pre') || null;
-                                    }
-                                    
-                                    if (blockElement) {
-                                      try {
-                                        const blockRange = iframeDoc.createRange();
-                                        blockRange.selectNodeContents(blockElement);
-                                        selection.removeAllRanges();
-                                        selection.addRange(blockRange);
-                                        
-                                        const originalHtml = blockElement.innerHTML;
-                                        const tagName = blockElement.tagName.toLowerCase();
-                                        const newHtml = `<${tagName} style="line-height: ${lineHeight};">${originalHtml}</${tagName}>`;
-                                        
-                                        iframeDoc.execCommand('insertHTML', false, newHtml);
-                                      } catch (err) {
-                                        blockElement.style.lineHeight = lineHeight;
-                                      }
-                                    }
-                                  }
-                                  e.target.value = '';
-                                }
-                              }}
-                              style={{
-                                fontSize: '11px',
-                                padding: '4px 8px',
-                                border: '1px solid #A9A9A9',
-                                borderRadius: '3px',
-                                backgroundColor: '#FFFFFF',
-                                color: '#000000',
-                                cursor: 'pointer',
-                                marginLeft: '4px',
-                              }}
-                              title="줄간격"
-                            >
-                              <option value="">줄간격</option>
-                              <option value="1.0">1.0 (단일)</option>
-                              <option value="1.15">1.15</option>
-                              <option value="1.5">1.5 (기본)</option>
-                              <option value="1.75">1.75</option>
-                              <option value="2.0">2.0 (2배)</option>
-                              <option value="2.5">2.5</option>
-                              <option value="3.0">3.0</option>
-                            </select>
-                            <div style={{ position: 'relative', display: 'inline-block', width: '30px', height: '26px', marginLeft: '4px' }}>
-                              <input
-                                type="color"
-                                onChange={(e) => {
-                                  const iframeDoc = translationIframeRef.current?.contentDocument;
-                                  if (iframeDoc) iframeDoc.execCommand('foreColor', false, e.target.value);
-                                }}
-                                style={{
-                                  position: 'absolute',
-                                  width: '100%',
-                                  height: '100%',
-                                  opacity: 0,
-                                  cursor: 'pointer',
-                                  zIndex: 2,
-                                }}
-                                title="글자 색상"
-                              />
-                              <button
-                                style={{
-                                  position: 'absolute',
-                                  width: '100%',
-                                  height: '100%',
-                                  border: '1px solid #A9A9A9',
-                                  borderRadius: '3px',
-                                  backgroundColor: '#FFFFFF',
-                                  display: 'flex',
-                                  alignItems: 'center',
-                                  justifyContent: 'center',
-                                  cursor: 'pointer',
-                                  padding: 0,
-                                  pointerEvents: 'none',
-                                }}
-                                title="글자 색상"
-                                disabled
-                              >
-                                <Palette size={16} color="#000000" />
-                              </button>
-                            </div>
-                            <div style={{ position: 'relative', display: 'inline-block', width: '30px', height: '26px', marginLeft: '4px' }}>
-                              <input
-                                type="color"
-                                onChange={(e) => {
-                                  const iframeDoc = translationIframeRef.current?.contentDocument;
-                                  if (iframeDoc) iframeDoc.execCommand('backColor', false, e.target.value);
-                                }}
-                                style={{
-                                  position: 'absolute',
-                                  width: '100%',
-                                  height: '100%',
-                                  opacity: 0,
-                                  cursor: 'pointer',
-                                  zIndex: 2,
-                                }}
-                                title="배경 색상"
-                              />
-                              <button
-                                style={{
-                                  position: 'absolute',
-                                  width: '100%',
-                                  height: '100%',
-                                  border: '1px solid #A9A9A9',
-                                  borderRadius: '3px',
-                                  backgroundColor: '#FFFFFF',
-                                  display: 'flex',
-                                  alignItems: 'center',
-                                  justifyContent: 'center',
-                                  cursor: 'pointer',
-                                  padding: 0,
-                                  pointerEvents: 'none',
-                                }}
-                                title="배경 색상"
-                                disabled
-                              >
-                                <Highlighter size={16} color="#000000" />
-                              </button>
-                            </div>
-                            
-                            <div style={{ width: '1px', height: '20px', backgroundColor: '#C0C0C0', margin: '0 4px' }} />
-                            <button
-                              onClick={() => {
-                                const iframeDoc = translationIframeRef.current?.contentDocument;
-                                if (iframeDoc) iframeDoc.execCommand('justifyLeft', false);
-                              }}
-                              style={{
-                                padding: '4px 8px',
-                                fontSize: '11px',
-                                border: '1px solid #A9A9A9',
-                                borderRadius: '3px',
-                                backgroundColor: '#FFFFFF',
-                                color: '#000000',
-                                cursor: 'pointer',
-                                display: 'flex',
-                                alignItems: 'center',
-                                justifyContent: 'center',
-                              }}
-                              title="왼쪽 정렬"
-                            >
-                              <AlignLeft size={16} />
-                            </button>
-                            <button
-                              onClick={() => {
-                                const iframeDoc = translationIframeRef.current?.contentDocument;
-                                if (iframeDoc) iframeDoc.execCommand('justifyCenter', false);
-                              }}
-                              style={{
-                                padding: '4px 8px',
-                                fontSize: '11px',
-                                border: '1px solid #A9A9A9',
-                                borderRadius: '3px',
-                                backgroundColor: '#FFFFFF',
-                                color: '#000000',
-                                cursor: 'pointer',
-                                display: 'flex',
-                                alignItems: 'center',
-                                justifyContent: 'center',
-                              }}
-                              title="가운데 정렬"
-                            >
-                              <AlignCenter size={16} />
-                            </button>
-                            <button
-                              onClick={() => {
-                                const iframeDoc = translationIframeRef.current?.contentDocument;
-                                if (iframeDoc) iframeDoc.execCommand('justifyRight', false);
-                              }}
-                              style={{
-                                padding: '4px 8px',
-                                fontSize: '11px',
-                                border: '1px solid #A9A9A9',
-                                borderRadius: '3px',
-                                backgroundColor: '#FFFFFF',
-                                color: '#000000',
-                                cursor: 'pointer',
-                                display: 'flex',
-                                alignItems: 'center',
-                                justifyContent: 'center',
-                              }}
-                              title="오른쪽 정렬"
-                            >
-                              <AlignRight size={16} />
-                            </button>
-                            <div style={{ width: '1px', height: '20px', backgroundColor: '#C0C0C0', margin: '0 4px' }} />
-                            <button
-                              onClick={() => {
-                                const iframeDoc = translationIframeRef.current?.contentDocument;
-                                if (iframeDoc) iframeDoc.execCommand('insertUnorderedList', false);
-                              }}
-                              style={{
-                                padding: '4px 8px',
-                                fontSize: '11px',
-                                border: '1px solid #A9A9A9',
-                                borderRadius: '3px',
-                                backgroundColor: '#FFFFFF',
-                                color: '#000000',
-                                cursor: 'pointer',
-                                display: 'flex',
-                                alignItems: 'center',
-                                justifyContent: 'center',
-                              }}
-                              title="글머리 기호 목록"
-                            >
-                              <List size={16} />
-                            </button>
-                            <button
-                              onClick={() => {
-                                const iframeDoc = translationIframeRef.current?.contentDocument;
-                                if (iframeDoc) iframeDoc.execCommand('insertOrderedList', false);
-                              }}
-                              style={{
-                                padding: '4px 8px',
-                                fontSize: '11px',
-                                border: '1px solid #A9A9A9',
-                                borderRadius: '3px',
-                                backgroundColor: '#FFFFFF',
-                                color: '#000000',
-                                cursor: 'pointer',
-                                display: 'flex',
-                                alignItems: 'center',
-                                justifyContent: 'center',
-                              }}
-                              title="번호 매기기 목록"
-                            >
-                              <ListOrdered size={16} />
-                            </button>
-                            <button
-                              onClick={() => {
-                                const iframeDoc = translationIframeRef.current?.contentDocument;
-                                if (iframeDoc) {
-                                  const url = prompt('링크 URL을 입력하세요:');
-                                  if (url) iframeDoc.execCommand('createLink', false, url);
-                                }
-                              }}
-                              style={{
-                                padding: '4px 8px',
-                                fontSize: '11px',
-                                border: '1px solid #A9A9A9',
-                                borderRadius: '3px',
-                                backgroundColor: '#FFFFFF',
-                                color: '#000000',
-                                cursor: 'pointer',
-                                display: 'flex',
-                                alignItems: 'center',
-                                justifyContent: 'center',
-                              }}
-                              title="링크 삽입"
-                            >
-                              <Link2 size={16} />
-                            </button>
-                            <div style={{ width: '1px', height: '20px', backgroundColor: '#C0C0C0', margin: '0 4px' }} />
-                            <div style={{ position: 'relative', display: 'inline-block' }}>
-                              <input
-                                type="file"
-                                accept="image/*"
-                                onChange={(e) => {
-                                  const file = e.target.files?.[0];
-                                  if (file) {
-                                    const reader = new FileReader();
-                                    reader.onload = (event) => {
-                                      const imageUrl = event.target?.result as string;
-                                      const iframeDoc = translationIframeRef.current?.contentDocument;
-                                      if (iframeDoc && imageUrl) {
-                                        try {
-                                          iframeDoc.execCommand('insertHTML', false, `<img src="${imageUrl}" alt="" style="max-width: 100%; height: auto;" />`);
-                                        } catch (err) {
-                                          const selection = iframeDoc.getSelection();
-                                          if (selection && selection.rangeCount > 0) {
-                                            const range = selection.getRangeAt(0);
-                                            const img = iframeDoc.createElement('img');
-                                            img.src = imageUrl;
-                                            img.alt = '';
-                                            img.style.maxWidth = '100%';
-                                            img.style.height = 'auto';
-                                            range.insertNode(img);
-                                          }
-                                        }
-                                      }
-                                    };
-                                    reader.readAsDataURL(file);
-                                  }
-                                  e.target.value = '';
-                                }}
-                                style={{
-                                  position: 'absolute',
-                                  width: '100%',
-                                  height: '100%',
-                                  opacity: 0,
-                                  cursor: 'pointer',
-                                  zIndex: 2,
-                                }}
-                                title="이미지 삽입"
-                              />
-                              <button
-                                style={{
-                                  padding: '4px 8px',
-                                  fontSize: '11px',
-                                  border: '1px solid #A9A9A9',
-                                  borderRadius: '3px',
-                                  backgroundColor: '#FFFFFF',
-                                  color: '#000000',
-                                  cursor: 'pointer',
-                                  display: 'flex',
-                                  alignItems: 'center',
-                                  justifyContent: 'center',
-                                  pointerEvents: 'none',
-                                }}
-                                title="이미지 삽입"
-                                disabled
-                              >
-                                <Image size={16} />
-                              </button>
-                            </div>
-                            <button
-                              onClick={() => {
-                                const iframeDoc = translationIframeRef.current?.contentDocument;
-                                if (iframeDoc) {
-                                  try {
-                                    iframeDoc.execCommand('insertHTML', false, '<pre style="background-color: #f4f4f4; padding: 10px; border-radius: 4px; overflow-x: auto;"><code></code></pre>');
-                                  } catch (err) {
-                                    iframeDoc.execCommand('formatBlock', false, 'pre');
-                                  }
-                                }
-                              }}
-                              style={{
-                                padding: '4px 8px',
-                                fontSize: '11px',
-                                border: '1px solid #A9A9A9',
-                                borderRadius: '3px',
-                                backgroundColor: '#FFFFFF',
-                                color: '#000000',
-                                cursor: 'pointer',
-                                display: 'flex',
-                                alignItems: 'center',
-                                justifyContent: 'center',
-                              }}
-                              title="코드 블록"
-                            >
-                              <Code size={16} />
-                            </button>
-                            <div style={{ position: 'relative', display: 'inline-block' }} data-more-menu>
-                              <button
-                                onClick={() => setShowMoreMenu(!showMoreMenu)}
-                                style={{
-                                  padding: '4px 8px',
-                                  fontSize: '11px',
-                                  border: '1px solid #A9A9A9',
-                                  borderRadius: '3px',
-                                  backgroundColor: showMoreMenu ? '#E0E0E0' : '#FFFFFF',
-                                  color: '#000000',
-                                  cursor: 'pointer',
-                                  display: 'flex',
-                                  alignItems: 'center',
-                                  justifyContent: 'center',
-                                }}
-                                title="더보기"
-                              >
-                                <MoreVertical size={16} />
-                              </button>
-                              {showMoreMenu && (
-                                <div
-                                  style={{
-                                    position: 'absolute',
-                                    top: '100%',
-                                    right: 0,
-                                    marginTop: '4px',
-                                    backgroundColor: '#FFFFFF',
-                                    border: '1px solid #A9A9A9',
-                                    borderRadius: '4px',
-                                    boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
-                                    zIndex: 1000,
-                                    display: 'flex',
-                                    flexDirection: 'row',
-                                    gap: '4px',
-                                    padding: '4px',
-                                  }}
-                                  onClick={(e) => e.stopPropagation()}
-                                  data-more-menu
-                                >
-                                  <button
-                                    onClick={() => {
-                                      const iframeDoc = translationIframeRef.current?.contentDocument;
-                                      if (iframeDoc) {
-                                        iframeDoc.execCommand('formatBlock', false, 'blockquote');
-                                      }
-                                      setShowMoreMenu(false);
-                                    }}
-                                    style={{
-                                      padding: '4px 8px',
-                                      fontSize: '11px',
-                                      border: '1px solid #A9A9A9',
-                                      borderRadius: '3px',
-                                      backgroundColor: '#FFFFFF',
-                                      color: '#000000',
-                                      cursor: 'pointer',
-                                      display: 'flex',
-                                      alignItems: 'center',
-                                      justifyContent: 'center',
-                                    }}
-                                    title="인용문"
-                                  >
-                                    <Quote size={16} />
-                                  </button>
-                                  <button
-                                    onClick={() => {
-                                      const iframeDoc = translationIframeRef.current?.contentDocument;
-                                      if (iframeDoc) {
-                                        iframeDoc.execCommand('insertHorizontalRule', false);
-                                      }
-                                      setShowMoreMenu(false);
-                                    }}
-                                    style={{
-                                      padding: '4px 8px',
-                                      fontSize: '11px',
-                                      border: '1px solid #A9A9A9',
-                                      borderRadius: '3px',
-                                      backgroundColor: '#FFFFFF',
-                                      color: '#000000',
-                                      cursor: 'pointer',
-                                      display: 'flex',
-                                      alignItems: 'center',
-                                      justifyContent: 'center',
-                                    }}
-                                    title="구분선"
-                                  >
-                                    <Minus size={16} />
-                                  </button>
-                                  <button
-                                    onClick={() => {
-                                      const iframeDoc = translationIframeRef.current?.contentDocument;
-                                      if (iframeDoc) {
-                                        const rows = prompt('행 수를 입력하세요 (기본값: 3):', '3');
-                                        const cols = prompt('열 수를 입력하세요 (기본값: 3):', '3');
-                                        const rowCount = parseInt(rows || '3', 10);
-                                        const colCount = parseInt(cols || '3', 10);
-                                        
-                                        if (rowCount > 0 && colCount > 0) {
-                                          let tableHtml = '<table border="1" style="border-collapse: collapse; width: 100%;">';
-                                          for (let i = 0; i < rowCount; i++) {
-                                            tableHtml += '<tr>';
-                                            for (let j = 0; j < colCount; j++) {
-                                              tableHtml += '<td style="padding: 8px; border: 1px solid #000;">&nbsp;</td>';
-                                            }
-                                            tableHtml += '</tr>';
-                                          }
-                                          tableHtml += '</table>';
-                                          
-                                          try {
-                                            iframeDoc.execCommand('insertHTML', false, tableHtml);
-                                          } catch (err) {
-                                            const selection = iframeDoc.getSelection();
-                                            if (selection && selection.rangeCount > 0) {
-                                              const range = selection.getRangeAt(0);
-                                              const tempDiv = iframeDoc.createElement('div');
-                                              tempDiv.innerHTML = tableHtml;
-                                              const fragment = iframeDoc.createDocumentFragment();
-                                              while (tempDiv.firstChild) {
-                                                fragment.appendChild(tempDiv.firstChild);
-                                              }
-                                              range.insertNode(fragment);
-                                            }
-                                          }
-                                        }
-                                      }
-                                      setShowMoreMenu(false);
-                                    }}
-                                    style={{
-                                      padding: '4px 8px',
-                                      fontSize: '11px',
-                                      border: '1px solid #A9A9A9',
-                                      borderRadius: '3px',
-                                      backgroundColor: '#FFFFFF',
-                                      color: '#000000',
-                                      cursor: 'pointer',
-                                      display: 'flex',
-                                      alignItems: 'center',
-                                      justifyContent: 'center',
-                                    }}
-                                    title="표"
-                                  >
-                                    <Table size={16} />
-                                  </button>
-                                  <button
-                                    onClick={() => {
-                                      const iframeDoc = translationIframeRef.current?.contentDocument;
-                                      if (iframeDoc) {
-                                        const selection = iframeDoc.getSelection();
-                                        if (selection && selection.rangeCount > 0 && !selection.getRangeAt(0).collapsed) {
-                                          const range = selection.getRangeAt(0);
-                                          const selectedText = range.toString();
-                                          try {
-                                            iframeDoc.execCommand('insertHTML', false, `<sup>${selectedText}</sup>`);
-                                          } catch (err) {
-                                            const sup = iframeDoc.createElement('sup');
-                                            sup.textContent = selectedText;
-                                            range.deleteContents();
-                                            range.insertNode(sup);
-                                          }
-                                        }
-                                      }
-                                      setShowMoreMenu(false);
-                                    }}
-                                    style={{
-                                      padding: '4px 8px',
-                                      fontSize: '11px',
-                                      border: '1px solid #A9A9A9',
-                                      borderRadius: '3px',
-                                      backgroundColor: '#FFFFFF',
-                                      color: '#000000',
-                                      cursor: 'pointer',
-                                      display: 'flex',
-                                      alignItems: 'center',
-                                      justifyContent: 'center',
-                                    }}
-                                    title="위 첨자"
-                                  >
-                                    <Superscript size={16} />
-                                  </button>
-                                  <button
-                                    onClick={() => {
-                                      const iframeDoc = translationIframeRef.current?.contentDocument;
-                                      if (iframeDoc) {
-                                        const selection = iframeDoc.getSelection();
-                                        if (selection && selection.rangeCount > 0 && !selection.getRangeAt(0).collapsed) {
-                                          const range = selection.getRangeAt(0);
-                                          const selectedText = range.toString();
-                                          try {
-                                            iframeDoc.execCommand('insertHTML', false, `<sub>${selectedText}</sub>`);
-                                          } catch (err) {
-                                            const sub = iframeDoc.createElement('sub');
-                                            sub.textContent = selectedText;
-                                            range.deleteContents();
-                                            range.insertNode(sub);
-                                          }
-                                        }
-                                      }
-                                      setShowMoreMenu(false);
-                                    }}
-                                    style={{
-                                      padding: '4px 8px',
-                                      fontSize: '11px',
-                                      border: '1px solid #A9A9A9',
-                                      borderRadius: '3px',
-                                      backgroundColor: '#FFFFFF',
-                                      color: '#000000',
-                                      cursor: 'pointer',
-                                      display: 'flex',
-                                      alignItems: 'center',
-                                      justifyContent: 'center',
-                                    }}
-                                    title="아래 첨자"
-                                  >
-                                    <Subscript size={16} />
-                                  </button>
-                                </div>
-                              )}
-                            </div>
-                          </>
-                        )}
-                        
-                        {/* 컴포넌트 편집 모드 */}
-                        {editorMode === 'component' && selectedElements.length > 0 && (
-                          <>
-                            <div style={{ width: '1px', height: '20px', backgroundColor: '#C0C0C0', margin: '0 4px' }} />
-                            
-                            {/* 실행 취소/다시 실행 버튼 */}
-                            <button
-                              onClick={() => {
-                                const iframeDoc = translationIframeRef.current?.contentDocument;
-                                if (!iframeDoc) return;
-
-                                if (undoStackRef.current.length > 0) {
-                                  redoStackRef.current.push(currentEditorHtmlRef.current);
-                                  const previousHtml = undoStackRef.current.pop()!;
-                                  currentEditorHtmlRef.current = previousHtml;
-
-                                  iframeDoc.open();
-                                  iframeDoc.write(previousHtml);
-                                  iframeDoc.close();
-
-                                  setTranslationHtml(previousHtml);
-                                  setSelectedElements([]);
-                                }
-                              }}
-                              style={{
-                                padding: '4px 8px',
-                                fontSize: '11px',
-                                border: '1px solid #A9A9A9',
-                                borderRadius: '3px',
-                                backgroundColor: '#FFFFFF',
-                                color: '#000000',
-                                cursor: 'pointer',
-                                display: 'flex',
-                                alignItems: 'center',
-                                justifyContent: 'center',
-                              }}
-                              title="실행 취소 (Ctrl/Cmd+Z)"
-                            >
-                              <Undo2 size={16} color="#000000" />
-                            </button>
-                            <button
-                              onClick={() => {
-                                const iframeDoc = translationIframeRef.current?.contentDocument;
-                                if (!iframeDoc) return;
-
-                                if (redoStackRef.current.length > 0) {
-                                  undoStackRef.current.push(currentEditorHtmlRef.current);
-                                  const nextHtml = redoStackRef.current.pop()!;
-                                  currentEditorHtmlRef.current = nextHtml;
-
-                                  iframeDoc.open();
-                                  iframeDoc.write(nextHtml);
-                                  iframeDoc.close();
-
-                                  setTranslationHtml(nextHtml);
-                                  setSelectedElements([]);
-                                }
-                              }}
-                              style={{
-                                padding: '4px 8px',
-                                fontSize: '11px',
-                                border: '1px solid #A9A9A9',
-                                borderRadius: '3px',
-                                backgroundColor: '#FFFFFF',
-                                color: '#000000',
-                                cursor: 'pointer',
-                                display: 'flex',
-                                alignItems: 'center',
-                                justifyContent: 'center',
-                              }}
-                              title="다시 실행 (Ctrl/Cmd+Y)"
-                            >
-                              <Redo2 size={16} color="#000000" />
-                            </button>
-                            
-                            <div style={{ width: '1px', height: '20px', backgroundColor: '#C0C0C0', margin: '0 4px' }} />
-                            
-                            <span style={{ fontSize: '11px', color: '#696969', marginRight: '4px' }}>
-                              {selectedElements.length}개 선택됨
-                            </span>
-                            <Button
-                              variant="secondary"
-                              onClick={() => {
-                                if (!translationIframeRef.current) return;
-                                const iframeDoc = translationIframeRef.current.contentDocument || translationIframeRef.current.contentWindow?.document;
-                                if (iframeDoc) {
-                                  selectedElements.forEach(el => {
-                                    el.classList.remove('component-selected');
-                                    el.style.outline = '';
-                                    el.style.boxShadow = '';
-                                    el.style.backgroundColor = '';
-                                    el.style.outlineOffset = '';
-                                  });
-                                }
-                                setSelectedElements([]);
-                              }}
-                              style={{ fontSize: '11px', padding: '4px 8px' }}
-                            >
-                              선택 취소
-                            </Button>
-                            <Button
-                              variant="primary"
-                              onClick={() => {
-                                if (!translationIframeRef.current) return;
-                                const iframeDoc = translationIframeRef.current.contentDocument;
-                                if (!iframeDoc) return;
-
-                                // Undo Stack에 현재 상태 저장
-                                undoStackRef.current.push(currentEditorHtmlRef.current);
-                                redoStackRef.current = [];
-
-                                // 선택된 요소 삭제
-                                selectedElements.forEach(el => el.remove());
-                                setSelectedElements([]);
-
-                                // 변경된 HTML 저장
-                                const updatedHtml = iframeDoc.documentElement.outerHTML;
-                                currentEditorHtmlRef.current = updatedHtml;
-                                setTranslationHtml(updatedHtml);
-                                console.log('🗑️ 선택된 요소 삭제:', selectedElements.length, '개');
-                              }}
-                              style={{ fontSize: '11px', padding: '4px 8px' }}
-                            >
-                              삭제
-                            </Button>
-                          </>
-                        )}
-                      </div>
-                    </div>
-                    
-                    {/* iframe 에디터 */}
-                    <iframe
-                      ref={panel.ref as React.RefObject<HTMLIFrameElement>}
-                      style={{
-                        width: '100%',
-                        height: '100%',
-                        border: 'none',
-                        display: 'block',
-                      }}
-                      title={panel.title}
-                    />
-                  </>
-                ) : panel.html ? (
-                  // 원문, AI 초벌 번역 패널
-                  <iframe
-                    ref={panel.ref as React.RefObject<HTMLIFrameElement>}
-                    srcDoc={panel.html}
-                    style={{
-                      width: '100%',
-                      height: '100%',
-                      border: 'none',
-                      backgroundColor: '#FFFFFF',
-                    }}
-                    title={panel.title}
-                  />
-                ) : (
-                  <div style={{ 
-                    display: 'flex', 
-                    alignItems: 'center', 
-                    justifyContent: 'center', 
-                    height: '100%',
-                    color: colors.secondaryText,
-                    fontSize: '13px'
-                  }}>
-                    {panel.id === 'original' ? '원문이 없습니다.' : panel.id === 'aiDraft' ? 'AI 초벌 번역이 없습니다.' : '번역본이 없습니다.'}
-                  </div>
-                )}
-              </div>
-            </div>
-          );
-        })}
-      </div>
-
-      {/* 반려 모달 */}
-      {showRejectModal && (
-        <div
-          style={{
-            position: 'fixed',
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            backgroundColor: 'rgba(0, 0, 0, 0.5)',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            zIndex: 1000,
-          }}
-          onClick={() => setShowRejectModal(false)}
-        >
-          <div
-            style={{
-              backgroundColor: colors.surface,
-              padding: '24px',
-              borderRadius: '8px',
-              width: '500px',
-              maxWidth: '90vw',
-              border: `1px solid ${colors.border}`,
-            }}
-            onClick={(e) => e.stopPropagation()}
-          >
-            <h3 style={{ fontSize: '16px', fontWeight: 600, marginBottom: '16px' }}>
-              문서 반려
-            </h3>
-            
-            <div style={{ marginBottom: '16px' }}>
-              <label style={{ display: 'block', fontSize: '13px', marginBottom: '8px', color: colors.primaryText }}>
-                반려 사유 *
-              </label>
-              <textarea
-                value={rejectMessage}
-                onChange={(e) => setRejectMessage(e.target.value)}
-                placeholder="예: 번역 품질이 부족합니다. 전문 용어 번역이 정확하지 않습니다."
-                style={{
-                  width: '100%',
-                  minHeight: '120px',
-                  padding: '8px',
-                  border: `1px solid ${colors.border}`,
-                  borderRadius: '4px',
-                  fontSize: '13px',
-                  fontFamily: 'inherit',
-                  resize: 'vertical',
-                }}
-              />
-              <div style={{ fontSize: '12px', color: colors.secondaryText, marginTop: '8px' }}>
-                반려 시 문서가 다시 번역 대기 상태로 변경됩니다.
-              </div>
-            </div>
-
-            <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
-              <Button
-                variant="secondary"
-                onClick={() => {
-                  setShowRejectModal(false);
-                  setRejectMessage('');
-                }}
-                style={{ fontSize: '12px' }}
-              >
-                취소
-              </Button>
-              <Button
-                variant="primary"
-                onClick={handleReject}
-                style={{ fontSize: '12px' }}
-              >
-                반려 처리
-              </Button>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* 링크 편집 모달 */}
-      {showLinkModal && (
-        <div
-          style={{
-            position: 'fixed',
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            backgroundColor: 'rgba(0, 0, 0, 0.5)',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            zIndex: 1000,
-          }}
-          onClick={() => {
-            setShowLinkModal(false);
-            setEditingLink(null);
-            setLinkUrl('');
-          }}
-        >
-          <div
-            style={{
-              backgroundColor: colors.surface,
-              padding: '24px',
-              borderRadius: '8px',
-              width: '400px',
-              maxWidth: '90vw',
-              border: `1px solid ${colors.border}`,
-            }}
-            onClick={(e) => e.stopPropagation()}
-          >
-            <h3 style={{ fontSize: '16px', fontWeight: 600, marginBottom: '16px' }}>
-              링크 편집
-            </h3>
-            
-            <div style={{ marginBottom: '16px' }}>
-              <label style={{ display: 'block', fontSize: '13px', marginBottom: '8px', color: colors.primaryText }}>
-                URL
-              </label>
-              <input
-                type="text"
-                value={linkUrl}
-                onChange={(e) => setLinkUrl(e.target.value)}
-                placeholder="https://example.com"
-                style={{
-                  width: '100%',
-                  padding: '8px',
-                  border: `1px solid ${colors.border}`,
-                  borderRadius: '4px',
-                  fontSize: '13px',
-                  fontFamily: 'inherit',
-                }}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') {
-                    e.preventDefault();
-                    const iframeDoc = translationIframeRef.current?.contentDocument;
-                    if (iframeDoc && editingLink && linkUrl.trim()) {
-                      const selection = iframeDoc.getSelection();
-                      if (selection) {
-                        const range = iframeDoc.createRange();
-                        range.selectNodeContents(editingLink);
-                        selection.removeAllRanges();
-                        selection.addRange(range);
-                        
-                        iframeDoc.execCommand('unlink', false);
-                        iframeDoc.execCommand('createLink', false, linkUrl.trim());
-                      }
-                    }
-                    setShowLinkModal(false);
-                    setEditingLink(null);
-                    setLinkUrl('');
-                  }
-                }}
-                autoFocus
-              />
-            </div>
-
-            <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
-              <Button
-                variant="secondary"
-                onClick={() => {
-                  setShowLinkModal(false);
-                  setEditingLink(null);
-                  setLinkUrl('');
-                }}
-                style={{ fontSize: '12px' }}
-              >
-                취소
-              </Button>
-              <Button
-                variant="secondary"
-                onClick={() => {
-                  const iframeDoc = translationIframeRef.current?.contentDocument;
-                  if (iframeDoc && editingLink) {
-                    const selection = iframeDoc.getSelection();
-                    if (selection) {
-                      const range = iframeDoc.createRange();
-                      range.selectNodeContents(editingLink);
-                      selection.removeAllRanges();
-                      selection.addRange(range);
-                      iframeDoc.execCommand('unlink', false);
-                    }
-                  }
-                  setShowLinkModal(false);
-                  setEditingLink(null);
-                  setLinkUrl('');
-                }}
-                style={{ fontSize: '12px' }}
-              >
-                삭제
-              </Button>
-              <Button
-                variant="primary"
-                onClick={() => {
-                  const iframeDoc = translationIframeRef.current?.contentDocument;
-                  if (iframeDoc && editingLink && linkUrl.trim()) {
-                    const selection = iframeDoc.getSelection();
-                    if (selection) {
-                      const range = iframeDoc.createRange();
-                      range.selectNodeContents(editingLink);
-                      selection.removeAllRanges();
-                      selection.addRange(range);
-                      
-                      iframeDoc.execCommand('unlink', false);
-                      iframeDoc.execCommand('createLink', false, linkUrl.trim());
-                    }
-                  }
-                  setShowLinkModal(false);
-                  setEditingLink(null);
-                  setLinkUrl('');
-                }}
-                style={{ fontSize: '12px' }}
-              >
-                저장
-              </Button>
-            </div>
-          </div>
-        </div>
-      )}
-    </div>
-  );
+				iframeDoc.head.appendChild(style);
+
+				// 클릭 가능한 컴포넌트 표시
+				const componentElements = iframeDoc.querySelectorAll(
+					"div, section, article, header, footer, main, aside, nav, p, h1, h2, h3, h4, h5, h6, a",
+				);
+
+				// 키보드 단축키 (컴포넌트 모드 Undo/Redo)
+				const handleKeydown = (e: KeyboardEvent) => {
+					if ((e.ctrlKey || e.metaKey) && e.key === "z" && !e.shiftKey) {
+						e.preventDefault();
+						e.stopImmediatePropagation();
+
+						if (undoStackRef.current.length > 0) {
+							console.log(
+								"↩️ Undo (컴포넌트 편집) - stack:",
+								undoStackRef.current.length,
+							);
+
+							redoStackRef.current.push(currentEditorHtmlRef.current);
+							const previousHtml = undoStackRef.current.pop()!;
+							currentEditorHtmlRef.current = previousHtml;
+
+							iframeDoc.open();
+							iframeDoc.write(previousHtml);
+							iframeDoc.close();
+
+							setTranslationHtml(previousHtml);
+							setSelectedElements([]);
+
+							setTimeout(() => {
+								const newIframeDoc =
+									iframe.contentDocument || iframe.contentWindow?.document;
+								if (newIframeDoc?.body) {
+									newIframeDoc.body.setAttribute("tabindex", "-1");
+									newIframeDoc.body.focus();
+								}
+							}, 50);
+						} else {
+							console.log("⚠️ Undo stack이 비어있습니다");
+						}
+					} else if (
+						(e.ctrlKey || e.metaKey) &&
+						(e.key === "y" || (e.key === "z" && e.shiftKey))
+					) {
+						e.preventDefault();
+						e.stopImmediatePropagation();
+
+						if (redoStackRef.current.length > 0) {
+							console.log(
+								"↪️ Redo (컴포넌트 편집) - stack:",
+								redoStackRef.current.length,
+							);
+
+							undoStackRef.current.push(currentEditorHtmlRef.current);
+							const nextHtml = redoStackRef.current.pop()!;
+							currentEditorHtmlRef.current = nextHtml;
+
+							iframeDoc.open();
+							iframeDoc.write(nextHtml);
+							iframeDoc.close();
+
+							setTranslationHtml(nextHtml);
+							setSelectedElements([]);
+
+							setTimeout(() => {
+								const newIframeDoc =
+									iframe.contentDocument || iframe.contentWindow?.document;
+								if (newIframeDoc?.body) {
+									newIframeDoc.body.setAttribute("tabindex", "-1");
+									newIframeDoc.body.focus();
+								}
+							}, 50);
+						} else {
+							console.log("⚠️ Redo stack이 비어있습니다");
+						}
+					}
+				};
+
+				if (iframeKeydownHandlerRef.current && iframeDoc) {
+					iframeDoc.removeEventListener(
+						"keydown",
+						iframeKeydownHandlerRef.current,
+						true,
+					);
+				}
+				iframeKeydownHandlerRef.current = handleKeydown;
+				iframeDoc.addEventListener("keydown", handleKeydown, true);
+				console.log("✅ DocumentReview 컴포넌트 모드 키보드 단축키 등록 완료");
+
+				// window 키보드 이벤트도 처리
+				const handleWindowKeydown = (e: KeyboardEvent) => {
+					if ((e.ctrlKey || e.metaKey) && e.key === "z" && !e.shiftKey) {
+						e.preventDefault();
+						e.stopImmediatePropagation();
+
+						if (undoStackRef.current.length > 0 && iframeDoc) {
+							console.log("↩️ Undo (DocumentReview 컴포넌트 편집 - window)");
+
+							redoStackRef.current.push(currentEditorHtmlRef.current);
+							const previousHtml = undoStackRef.current.pop()!;
+							currentEditorHtmlRef.current = previousHtml;
+
+							iframeDoc.open();
+							iframeDoc.write(previousHtml);
+							iframeDoc.close();
+
+							setTranslationHtml(previousHtml);
+							setSelectedElements([]);
+
+							setTimeout(() => {
+								const newIframeDoc =
+									iframe.contentDocument || iframe.contentWindow?.document;
+								if (newIframeDoc?.body) {
+									newIframeDoc.body.setAttribute("tabindex", "-1");
+									newIframeDoc.body.focus();
+								}
+							}, 50);
+						}
+					} else if (
+						(e.ctrlKey || e.metaKey) &&
+						(e.key === "y" || (e.key === "z" && e.shiftKey))
+					) {
+						e.preventDefault();
+						e.stopImmediatePropagation();
+
+						if (redoStackRef.current.length > 0 && iframeDoc) {
+							console.log("↪️ Redo (DocumentReview 컴포넌트 편집 - window)");
+
+							undoStackRef.current.push(currentEditorHtmlRef.current);
+							const nextHtml = redoStackRef.current.pop()!;
+							currentEditorHtmlRef.current = nextHtml;
+
+							iframeDoc.open();
+							iframeDoc.write(nextHtml);
+							iframeDoc.close();
+
+							setTranslationHtml(nextHtml);
+							setSelectedElements([]);
+
+							setTimeout(() => {
+								const newIframeDoc =
+									iframe.contentDocument || iframe.contentWindow?.document;
+								if (newIframeDoc?.body) {
+									newIframeDoc.body.setAttribute("tabindex", "-1");
+									newIframeDoc.body.focus();
+								}
+							}, 50);
+						}
+					}
+				};
+
+				if (windowKeydownHandlerRef.current) {
+					window.removeEventListener(
+						"keydown",
+						windowKeydownHandlerRef.current,
+						true,
+					);
+				}
+				windowKeydownHandlerRef.current = handleWindowKeydown;
+				window.addEventListener("keydown", handleWindowKeydown, true);
+				console.log("✅ DocumentReview window 키보드 이벤트 리스너 등록 완료");
+
+				// 컴포넌트 클릭 핸들러 (다중 선택 + 토글)
+				const handleComponentClick = (e: Event) => {
+					e.stopPropagation();
+					e.preventDefault();
+
+					const target = e.target as HTMLElement;
+					if (
+						!target ||
+						["SCRIPT", "STYLE", "NOSCRIPT", "HTML", "HEAD", "BODY"].includes(
+							target.tagName,
+						)
+					)
+						return;
+
+					const editableElement = target.closest(
+						"[data-component-editable]",
+					) as HTMLElement;
+					if (!editableElement) {
+						console.log(
+							"⚠️ 편집 가능한 요소를 찾을 수 없습니다:",
+							target.tagName,
+						);
+						return;
+					}
+
+					const isSelected =
+						editableElement.classList.contains("component-selected");
+
+					if (isSelected) {
+						editableElement.classList.remove("component-selected");
+						editableElement.style.outline = "1px dashed #C0C0C0";
+						editableElement.style.boxShadow = "none";
+						setSelectedElements((prev) =>
+							prev.filter((el) => el !== editableElement),
+						);
+					} else {
+						editableElement.classList.add("component-selected");
+						editableElement.style.outline = "3px solid #000000";
+						editableElement.style.boxShadow = "none";
+						setSelectedElements((prev) => [...prev, editableElement]);
+					}
+				};
+
+				// 이벤트 리스너 등록
+				componentElements.forEach((el) => {
+					if (
+						el.tagName &&
+						!["SCRIPT", "STYLE", "NOSCRIPT", "HTML", "HEAD", "BODY"].includes(
+							el.tagName,
+						)
+					) {
+						const htmlEl = el as HTMLElement;
+						htmlEl.setAttribute("data-component-editable", "true");
+						htmlEl.style.cursor = "pointer";
+						htmlEl.style.outline = "1px dashed #C0C0C0";
+
+						htmlEl.addEventListener("click", handleComponentClick, true);
+						componentClickHandlersRef.current.set(htmlEl, handleComponentClick);
+					}
+				});
+
+				// contentEditable 비활성화
+				const allElements = iframeDoc.querySelectorAll("*");
+				allElements.forEach((el) => {
+					(el as HTMLElement).contentEditable = "false";
+				});
+			}
+		} catch (error) {
+			console.error("❌ 번역 iframe 오류:", error);
+		}
+
+		// Cleanup
+		return () => {
+			if (windowKeydownHandlerRef.current) {
+				window.removeEventListener(
+					"keydown",
+					windowKeydownHandlerRef.current,
+					true,
+				);
+			}
+		};
+	}, [translationHtml, collapsedPanels, fullscreenPanel, editorMode]);
+
+	// 더보기 메뉴 외부 클릭 시 닫기
+	useEffect(() => {
+		const handleWindowClick = (e: MouseEvent) => {
+			const target = e.target as HTMLElement;
+			if (!target.closest("[data-more-menu]")) {
+				setShowMoreMenu(false);
+			}
+		};
+
+		if (showMoreMenu) {
+			window.addEventListener("click", handleWindowClick);
+		}
+
+		return () => {
+			window.removeEventListener("click", handleWindowClick);
+		};
+	}, [showMoreMenu]);
+
+	// 문단 하이라이트 동기화
+	useEffect(() => {
+		const applyParagraphStyles = (
+			panel: HTMLElement | null,
+			panelName: string,
+		) => {
+			if (!panel) return;
+			clearAllHighlights(panel);
+
+			const paragraphs = getParagraphs(panel);
+			paragraphs.forEach((para) => {
+				const isHighlighted = para.index === highlightedParagraphIndex;
+				if (isHighlighted) {
+					highlightParagraph(para.element, true);
+				}
+			});
+		};
+
+		if (originalIframeRef.current?.contentDocument?.body) {
+			applyParagraphStyles(
+				originalIframeRef.current.contentDocument.body as HTMLElement,
+				"원문",
+			);
+		}
+
+		if (aiDraftIframeRef.current?.contentDocument?.body) {
+			applyParagraphStyles(
+				aiDraftIframeRef.current.contentDocument.body as HTMLElement,
+				"AI 초벌",
+			);
+		}
+
+		if (translationIframeRef.current?.contentDocument?.body) {
+			applyParagraphStyles(
+				translationIframeRef.current.contentDocument.body as HTMLElement,
+				"번역",
+			);
+		}
+	}, [highlightedParagraphIndex]);
+
+	// 패널 접기/펼치기
+	const togglePanel = (panelId: string) => {
+		setCollapsedPanels((prev) => {
+			const newSet = new Set(prev);
+			if (newSet.has(panelId)) {
+				newSet.delete(panelId);
+			} else {
+				newSet.add(panelId);
+			}
+			return newSet;
+		});
+	};
+
+	// 전체화면 토글
+	const toggleFullscreen = (panelId: string) => {
+		setFullscreenPanel((prev) => (prev === panelId ? null : panelId));
+	};
+
+	// 번역본(검토 대상) 패널의 현재 수정 내용을 새 버전으로 저장
+	const handleSaveTranslationPanel = async () => {
+		if (!documentId) {
+			alert("문서 ID가 없습니다.");
+			return;
+		}
+
+		const iframe = translationIframeRef.current;
+		const iframeDoc = iframe?.contentDocument || iframe?.contentWindow?.document;
+		if (!iframeDoc?.documentElement) {
+			alert("번역본 내용을 읽을 수 없습니다.");
+			return;
+		}
+
+		const editedHtml = iframeDoc.documentElement.outerHTML;
+		if (!editedHtml || editedHtml === translationContent) {
+			alert("저장할 변경사항이 없습니다.");
+			return;
+		}
+
+		try {
+			await docApi.createDocumentVersion(documentId, {
+				versionType: "MANUAL_TRANSLATION",
+				content: editedHtml,
+			});
+
+			setTranslationHtml(editedHtml);
+			setTranslationContent(editedHtml);
+			currentEditorHtmlRef.current = editedHtml;
+
+			alert("번역본 수정사항이 저장되었습니다.");
+		} catch (error: any) {
+			console.error("번역본 저장 실패:", error);
+			alert(
+				"저장에 실패했습니다: " +
+					(error.response?.data?.message || error.message || "알 수 없는 오류"),
+			);
+		}
+	};
+
+	// 승인 처리
+	const handleApprove = async () => {
+		if (!documentId) {
+			alert("문서 ID가 없습니다.");
+			return;
+		}
+
+		// iframe에서 최신 HTML 가져오기
+		const iframe = translationIframeRef.current;
+		let editedHtml = translationHtml;
+
+		if (iframe) {
+			const iframeDoc =
+				iframe.contentDocument || iframe.contentWindow?.document;
+			if (iframeDoc && iframeDoc.documentElement) {
+				editedHtml = iframeDoc.documentElement.outerHTML;
+				console.log("💾 승인 시 수정된 HTML 사용");
+			}
+		}
+
+		if (!review) {
+			// 리뷰가 없으면 먼저 리뷰를 생성해야 함
+			// 버전 정보를 다시 가져와서 최신 MANUAL_TRANSLATION 버전 찾기
+			try {
+				const versions = await docApi.getDocumentVersions(documentId);
+				let manualTranslationVersion = versions
+					.filter((v) => v.versionType === "MANUAL_TRANSLATION")
+					.sort((a, b) => (b.versionNumber || 0) - (a.versionNumber || 0))[0];
+
+				if (!manualTranslationVersion) {
+					alert("검토할 번역 버전을 찾을 수 없습니다.");
+					return;
+				}
+
+				// 수정된 내용이 있으면 새 버전으로 저장
+				if (editedHtml !== translationContent) {
+					console.log("✅ 수정된 내용을 새 버전으로 저장");
+					const newVersion = await docApi.createDocumentVersion(documentId, {
+						versionType: "MANUAL_TRANSLATION",
+						content: editedHtml,
+					});
+					manualTranslationVersion = newVersion;
+				}
+
+				// 리뷰 생성
+				const newReview = await reviewApi.createReview({
+					documentId,
+					documentVersionId: manualTranslationVersion.id,
+					isComplete: true, // 기본값으로 완전 번역으로 설정
+				});
+				setReview(newReview);
+
+				if (
+					!window.confirm(
+						"이 문서를 승인하시겠습니까? 승인 후 문서 상태가 변경됩니다.",
+					)
+				) {
+					return;
+				}
+
+				await reviewApi.approveReview(newReview.id);
+				alert("문서가 승인되었습니다.");
+				navigate("/reviews");
+			} catch (error: any) {
+				console.error("리뷰 생성 또는 승인 실패:", error);
+				alert(
+					"승인 처리에 실패했습니다: " +
+						(error.response?.data?.message || error.message),
+				);
+			}
+			return;
+		}
+
+		// 리뷰가 이미 있는 경우
+		try {
+			// 수정된 내용이 있으면 새 버전으로 저장
+			if (editedHtml !== translationContent) {
+				console.log("✅ 수정된 내용을 새 버전으로 저장");
+				const newVersion = await docApi.createDocumentVersion(documentId, {
+					versionType: "MANUAL_TRANSLATION",
+					content: editedHtml,
+				});
+
+				// 리뷰 업데이트 (새 버전으로 교체)
+				await reviewApi.updateReview(review.id, {
+					documentVersionId: newVersion.id,
+				});
+			}
+
+			if (
+				!window.confirm(
+					"이 문서를 승인하시겠습니까? 승인 후 문서 상태가 변경됩니다.",
+				)
+			) {
+				return;
+			}
+
+			await reviewApi.approveReview(review.id);
+			alert("문서가 승인되었습니다.");
+			navigate("/reviews");
+		} catch (error: any) {
+			console.error("승인 실패:", error);
+			alert(
+				"승인 처리에 실패했습니다: " +
+					(error.response?.data?.message || error.message),
+			);
+		}
+	};
+
+	// 반려 처리
+	const handleReject = async () => {
+		if (!rejectMessage.trim()) {
+			alert("반려 사유를 입력해주세요.");
+			return;
+		}
+
+		if (!review) {
+			// 리뷰가 없으면 먼저 리뷰를 생성해야 함
+			if (!documentId) {
+				alert("문서 ID가 없습니다.");
+				return;
+			}
+
+			// 버전 정보를 다시 가져와서 최신 MANUAL_TRANSLATION 버전 찾기
+			try {
+				const versions = await docApi.getDocumentVersions(documentId);
+				const manualTranslationVersion = versions
+					.filter((v) => v.versionType === "MANUAL_TRANSLATION")
+					.sort((a, b) => (b.versionNumber || 0) - (a.versionNumber || 0))[0];
+
+				if (!manualTranslationVersion) {
+					alert("검토할 번역 버전을 찾을 수 없습니다.");
+					return;
+				}
+
+				// 리뷰 생성 (반려 메시지 포함)
+				const newReview = await reviewApi.createReview({
+					documentId,
+					documentVersionId: manualTranslationVersion.id,
+					comment: rejectMessage,
+					isComplete: false,
+				});
+				setReview(newReview);
+
+				// 반려 처리
+				await reviewApi.rejectReview(newReview.id);
+
+				alert(
+					"문서가 반려되었습니다. 문서가 다시 번역 대기 상태로 변경됩니다.",
+				);
+				navigate("/reviews");
+			} catch (error: any) {
+				console.error("리뷰 생성 또는 반려 실패:", error);
+				alert(
+					"반려 처리에 실패했습니다: " +
+						(error.response?.data?.message || error.message),
+				);
+			}
+			return;
+		}
+
+		try {
+			// 먼저 리뷰에 코멘트 추가
+			await reviewApi.updateReview(review.id, { comment: rejectMessage });
+
+			// 그 다음 반려 처리
+			await reviewApi.rejectReview(review.id);
+
+			alert("문서가 반려되었습니다. 문서가 다시 번역 대기 상태로 변경됩니다.");
+			navigate("/reviews");
+		} catch (error: any) {
+			console.error("반려 실패:", error);
+			alert(
+				"반려 처리에 실패했습니다: " +
+					(error.response?.data?.message || error.message),
+			);
+		}
+	};
+
+	if (loading) {
+		return (
+			<div
+				style={{
+					padding: "48px",
+					textAlign: "center",
+					color: colors.primaryText,
+				}}
+			>
+				로딩 중...
+			</div>
+		);
+	}
+
+	if (error || !document) {
+		return (
+			<div style={{ padding: "48px" }}>
+				<div
+					style={{
+						padding: "16px",
+						backgroundColor: "#F5F5F5",
+						border: `1px solid ${colors.border}`,
+						borderRadius: "8px",
+						color: colors.primaryText,
+						marginBottom: "16px",
+					}}
+				>
+					⚠️ {error || "문서를 불러올 수 없습니다."}
+				</div>
+				<div>
+					<Button variant="secondary" onClick={() => navigate("/reviews")}>
+						목록으로 돌아가기
+					</Button>
+				</div>
+			</div>
+		);
+	}
+
+	// 상태 텍스트 변환
+	const getStatusText = (status: string) => {
+		const statusMap: Record<string, string> = {
+			DRAFT: "초안",
+			PENDING_TRANSLATION: "번역 대기",
+			IN_TRANSLATION: "번역 중",
+			PENDING_REVIEW: "검토 대기",
+			APPROVED: "번역 완료",
+			PUBLISHED: "공개됨",
+		};
+		return statusMap[status] || status;
+	};
+
+	return (
+		<div
+			style={{
+				display: "flex",
+				flexDirection: "column",
+				height: "100vh",
+				backgroundColor: colors.primaryBackground,
+			}}
+		>
+			{/* 상단 고정 바 */}
+			<div
+				style={{
+					padding: "12px 24px",
+					backgroundColor: colors.surface,
+					borderBottom: `1px solid ${colors.border}`,
+					display: "flex",
+					justifyContent: "space-between",
+					alignItems: "center",
+					gap: "16px",
+				}}
+			>
+				{/* 왼쪽: 뒤로가기 + 문서 정보 */}
+				<div
+					style={{
+						display: "flex",
+						alignItems: "center",
+						gap: "16px",
+						flex: 1,
+					}}
+				>
+					<Button
+						variant="secondary"
+						onClick={() => navigate("/reviews")}
+						style={{ fontSize: "12px", padding: "6px 12px" }}
+					>
+						← 뒤로가기
+					</Button>
+
+					{document && (
+						<div
+							style={{ display: "flex", flexDirection: "column", gap: "2px" }}
+						>
+							<div
+								style={{ fontSize: "14px", fontWeight: 600, color: "#000000" }}
+							>
+								{document.title}
+							</div>
+							<div
+								style={{ display: "flex", gap: "12px", alignItems: "center" }}
+							>
+								<span style={{ fontSize: "11px", color: colors.secondaryText }}>
+									{document.categoryId
+										? `카테고리 ${document.categoryId}`
+										: "미분류"}{" "}
+									· {getStatusText(document.status)}
+								</span>
+								{review && (
+									<span
+										style={{ fontSize: "11px", color: colors.secondaryText }}
+									>
+										검토자: {review.reviewer?.name || "-"}
+									</span>
+								)}
+							</div>
+						</div>
+					)}
+				</div>
+
+				{/* 중앙: 문서 보기 옵션 */}
+				<div
+					style={{
+						display: "flex",
+						alignItems: "center",
+						gap: "24px",
+						padding: "6px 16px",
+						backgroundColor: "#F8F9FA",
+						borderRadius: "6px",
+						border: "1px solid #D3D3D3",
+					}}
+				>
+					<span
+						style={{
+							fontSize: "12px",
+							fontWeight: 600,
+							color: colors.primaryText,
+						}}
+					>
+						문서 보기:
+					</span>
+					<label
+						style={{
+							display: "flex",
+							alignItems: "center",
+							gap: "8px",
+							fontSize: "13px",
+							cursor: "pointer",
+							fontWeight: 500,
+						}}
+					>
+						<input
+							type="checkbox"
+							checked={!collapsedPanels.has("original")}
+							onChange={() => togglePanel("original")}
+							style={{
+								cursor: "pointer",
+								width: "16px",
+								height: "16px",
+							}}
+						/>
+						<span style={{ color: "#000000" }}>원문 (Version 0)</span>
+					</label>
+					<label
+						style={{
+							display: "flex",
+							alignItems: "center",
+							gap: "8px",
+							fontSize: "13px",
+							cursor: "pointer",
+							fontWeight: 500,
+						}}
+					>
+						<input
+							type="checkbox"
+							checked={!collapsedPanels.has("aiDraft")}
+							onChange={() => togglePanel("aiDraft")}
+							style={{
+								cursor: "pointer",
+								width: "16px",
+								height: "16px",
+							}}
+						/>
+						<span style={{ color: "#000000" }}>AI 초벌 번역 (Version 1)</span>
+					</label>
+					<label
+						style={{
+							display: "flex",
+							alignItems: "center",
+							gap: "8px",
+							fontSize: "13px",
+							cursor: "pointer",
+							fontWeight: 500,
+						}}
+					>
+						<input
+							type="checkbox"
+							checked={!collapsedPanels.has("translation")}
+							onChange={() => togglePanel("translation")}
+							style={{
+								cursor: "pointer",
+								width: "16px",
+								height: "16px",
+							}}
+						/>
+						<span style={{ color: "#000000" }}>번역본 (검토 대상)</span>
+					</label>
+				</div>
+
+				{/* 오른쪽: HTML 다운로드, 승인/반려 버튼 */}
+				<div style={{ display: "flex", gap: "8px" }}>
+					<Button
+						variant="secondary"
+						onClick={() => {
+							const iframe = translationIframeRef.current;
+							if (!iframe) return;
+
+							const iframeDoc =
+								iframe.contentDocument || iframe.contentWindow?.document;
+							if (!iframeDoc) return;
+
+							const html = iframeDoc.documentElement.outerHTML;
+							const blob = new Blob([html], { type: "text/html" });
+							const url = URL.createObjectURL(blob);
+							const a = document.createElement("a");
+							a.href = url;
+							a.download = `${document?.title || "document"}_edited.html`;
+							a.click();
+							URL.revokeObjectURL(url);
+						}}
+						style={{ fontSize: "12px" }}
+					>
+						💾 HTML 다운로드
+					</Button>
+					<Button
+						variant="secondary"
+						onClick={() => setShowRejectModal(true)}
+						style={{ fontSize: "12px" }}
+					>
+						반려
+					</Button>
+					<Button
+						variant="primary"
+						onClick={handleApprove}
+						style={{ fontSize: "12px" }}
+					>
+						승인
+					</Button>
+				</div>
+			</div>
+
+			{/* 3단 레이아웃 */}
+			<div
+				style={{ display: "flex", height: "100%", gap: "4px", padding: "4px" }}
+			>
+				{[
+					{
+						id: "original",
+						title: "원문",
+						ref: originalIframeRef,
+						html: originalHtml,
+					},
+					{
+						id: "aiDraft",
+						title: "AI 초벌 번역",
+						ref: aiDraftIframeRef,
+						html: aiDraftHtml,
+					},
+					{
+						id: "translation",
+						title: "번역본 (검토 대상)",
+						ref: translationIframeRef,
+						html: translationHtml,
+					},
+				].map((panel) => {
+					const isCollapsed = collapsedPanels.has(panel.id);
+					const isFullscreen = fullscreenPanel === panel.id;
+					const visiblePanels = ["original", "aiDraft", "translation"].filter(
+						(id) => !collapsedPanels.has(id),
+					);
+					const hasFullscreen = fullscreenPanel !== null;
+					const isHidden = hasFullscreen && !isFullscreen;
+
+					if (isHidden) return null;
+
+					return (
+						<div
+							key={panel.id}
+							style={{
+								flex: isCollapsed
+									? "0 0 0"
+									: isFullscreen
+										? "1"
+										: `1 1 ${100 / visiblePanels.length}%`,
+								display: isCollapsed ? "none" : "flex",
+								flexDirection: "column",
+								transition: "flex 0.2s ease",
+								minWidth: isCollapsed ? "0" : "200px",
+							}}
+						>
+							{/* 패널 헤더 */}
+							<div
+								style={{
+									display: "flex",
+									justifyContent: "space-between",
+									alignItems: "center",
+									padding: "8px 12px",
+									backgroundColor: "#D3D3D3",
+									borderRadius: "4px 4px 0 0",
+									cursor: "default",
+									height: "36px",
+								}}
+							>
+								<span
+									style={{
+										fontSize: "12px",
+										fontWeight: 600,
+										color: "#000000",
+									}}
+								>
+									{panel.title}
+								</span>
+								<div
+									style={{ display: "flex", alignItems: "center", gap: "8px" }}
+								>
+									{panel.id === "translation" && (
+										<button
+											type="button"
+											onClick={handleSaveTranslationPanel}
+											style={{
+												padding: "4px 8px",
+												fontSize: "11px",
+												border: "1px solid #A9A9A9",
+												borderRadius: "3px",
+												backgroundColor: "#FFFFFF",
+												color: "#000000",
+												cursor: "pointer",
+												fontWeight: 500,
+											}}
+											title="번역본 수정사항 저장"
+										>
+											저장하기
+										</button>
+									)}
+									<button
+										onClick={() => toggleFullscreen(panel.id)}
+										style={{
+											padding: "4px 8px",
+											fontSize: "11px",
+											border: "1px solid #A9A9A9",
+											borderRadius: "3px",
+											backgroundColor: "#FFFFFF",
+											color: "#000000",
+											cursor: "pointer",
+											fontWeight: 500,
+										}}
+										title={isFullscreen ? "확대 해제" : "전체화면 확대"}
+									>
+										{isFullscreen ? "축소" : "확대"}
+									</button>
+								</div>
+							</div>
+
+							{/* 패널 내용 */}
+							<div
+								style={{
+									flex: 1,
+									border: "1px solid #C0C0C0",
+									borderTop: "none",
+									borderRadius: "0 0 4px 4px",
+									overflow: "hidden",
+									backgroundColor: "#FFFFFF",
+									display: "flex",
+									flexDirection: "column",
+									position: "relative",
+								}}
+							>
+								{panel.id === "translation" ? (
+									// 번역본 패널 - 에디터 툴바 포함
+									<>
+										{/* 편집 툴바 */}
+										<div
+											style={{
+												padding: "8px 12px",
+												borderBottom: "1px solid #C0C0C0",
+												display: "flex",
+												justifyContent: "flex-start",
+												alignItems: "center",
+												backgroundColor: "#F8F9FA",
+												flexWrap: "wrap",
+												gap: "8px",
+											}}
+										>
+											<div
+												style={{
+													display: "flex",
+													gap: "4px",
+													alignItems: "center",
+													flexWrap: "wrap",
+												}}
+											>
+												{/* 모드 선택 */}
+												<Button
+													variant={
+														editorMode === "text" ? "primary" : "secondary"
+													}
+													onClick={() => setEditorMode("text")}
+													style={{ fontSize: "11px", padding: "4px 8px" }}
+												>
+													텍스트 편집
+												</Button>
+												<Button
+													variant={
+														editorMode === "component" ? "primary" : "secondary"
+													}
+													onClick={() => setEditorMode("component")}
+													style={{ fontSize: "11px", padding: "4px 8px" }}
+												>
+													컴포넌트 편집
+												</Button>
+
+												{/* Rich Text 기능 (텍스트 모드일 때만) */}
+												{editorMode === "text" && (
+													<>
+														<div
+															style={{
+																width: "1px",
+																height: "20px",
+																backgroundColor: "#C0C0C0",
+																margin: "0 4px",
+															}}
+														/>
+
+														{/* 실행 취소/다시 실행 버튼 */}
+														<button
+															onClick={() => {
+																const iframeDoc =
+																	translationIframeRef.current?.contentDocument;
+																if (iframeDoc) {
+																	iframeDoc.execCommand("undo", false);
+																}
+															}}
+															style={{
+																padding: "4px 8px",
+																fontSize: "11px",
+																border: "1px solid #A9A9A9",
+																borderRadius: "3px",
+																backgroundColor: "#FFFFFF",
+																color: "#000000",
+																cursor: "pointer",
+																display: "flex",
+																alignItems: "center",
+																justifyContent: "center",
+															}}
+															title="실행 취소 (Ctrl/Cmd+Z)"
+														>
+															<Undo2 size={16} color="#000000" />
+														</button>
+														<button
+															onClick={() => {
+																const iframeDoc =
+																	translationIframeRef.current?.contentDocument;
+																if (iframeDoc) {
+																	iframeDoc.execCommand("redo", false);
+																}
+															}}
+															style={{
+																padding: "4px 8px",
+																fontSize: "11px",
+																border: "1px solid #A9A9A9",
+																borderRadius: "3px",
+																backgroundColor: "#FFFFFF",
+																color: "#000000",
+																cursor: "pointer",
+																display: "flex",
+																alignItems: "center",
+																justifyContent: "center",
+															}}
+															title="다시 실행 (Ctrl/Cmd+Y)"
+														>
+															<Redo2 size={16} color="#000000" />
+														</button>
+
+														<div
+															style={{
+																width: "1px",
+																height: "20px",
+																backgroundColor: "#C0C0C0",
+																margin: "0 4px",
+															}}
+														/>
+
+														<button
+															onClick={() => {
+																const iframeDoc =
+																	translationIframeRef.current?.contentDocument;
+																if (iframeDoc)
+																	iframeDoc.execCommand("bold", false);
+															}}
+															style={{
+																padding: "4px 8px",
+																fontSize: "11px",
+																fontWeight: "bold",
+																border: "1px solid #A9A9A9",
+																borderRadius: "3px",
+																backgroundColor: "#FFFFFF",
+																color: "#000000",
+																cursor: "pointer",
+															}}
+															title="굵게 (Ctrl+B)"
+														>
+															B
+														</button>
+														<button
+															onClick={() => {
+																const iframeDoc =
+																	translationIframeRef.current?.contentDocument;
+																if (iframeDoc)
+																	iframeDoc.execCommand("italic", false);
+															}}
+															style={{
+																padding: "4px 8px",
+																fontSize: "11px",
+																fontStyle: "italic",
+																border: "1px solid #A9A9A9",
+																borderRadius: "3px",
+																backgroundColor: "#FFFFFF",
+																color: "#000000",
+																cursor: "pointer",
+															}}
+															title="기울임 (Ctrl+I)"
+														>
+															I
+														</button>
+														<button
+															onClick={() => {
+																const iframeDoc =
+																	translationIframeRef.current?.contentDocument;
+																if (iframeDoc)
+																	iframeDoc.execCommand("underline", false);
+															}}
+															style={{
+																padding: "4px 8px",
+																fontSize: "11px",
+																textDecoration: "underline",
+																border: "1px solid #A9A9A9",
+																borderRadius: "3px",
+																backgroundColor: "#FFFFFF",
+																color: "#000000",
+																cursor: "pointer",
+															}}
+															title="밑줄 (Ctrl+U)"
+														>
+															U
+														</button>
+														<button
+															onClick={() => {
+																const iframeDoc =
+																	translationIframeRef.current?.contentDocument;
+																if (iframeDoc)
+																	iframeDoc.execCommand("strikeThrough", false);
+															}}
+															style={{
+																padding: "4px 8px",
+																fontSize: "11px",
+																textDecoration: "line-through",
+																border: "1px solid #A9A9A9",
+																borderRadius: "3px",
+																backgroundColor: "#FFFFFF",
+																color: "#000000",
+																cursor: "pointer",
+															}}
+															title="취소선"
+														>
+															S
+														</button>
+
+														<div
+															style={{
+																width: "1px",
+																height: "20px",
+																backgroundColor: "#C0C0C0",
+																margin: "0 4px",
+															}}
+														/>
+
+														<select
+															onChange={(e) => {
+																const iframeDoc =
+																	translationIframeRef.current?.contentDocument;
+																if (iframeDoc && e.target.value) {
+																	const fontSize = e.target.value;
+																	const selection = iframeDoc.getSelection();
+
+																	if (
+																		selection &&
+																		selection.rangeCount > 0 &&
+																		!selection.getRangeAt(0).collapsed
+																	) {
+																		const range = selection.getRangeAt(0);
+																		const selectedText = range.toString();
+																		const spanHtml = `<span style="font-size: ${fontSize}pt;">${selectedText}</span>`;
+																		try {
+																			iframeDoc.execCommand(
+																				"insertHTML",
+																				false,
+																				spanHtml,
+																			);
+																		} catch (err) {
+																			range.deleteContents();
+																			const tempDiv =
+																				iframeDoc.createElement("div");
+																			tempDiv.innerHTML = spanHtml;
+																			const fragment =
+																				iframeDoc.createDocumentFragment();
+																			while (tempDiv.firstChild) {
+																				fragment.appendChild(
+																					tempDiv.firstChild,
+																				);
+																			}
+																			range.insertNode(fragment);
+																			range.setStartAfter(
+																				fragment.lastChild ||
+																					range.startContainer,
+																			);
+																			range.collapse(false);
+																			selection.removeAllRanges();
+																			selection.addRange(range);
+																		}
+																	}
+																	e.target.value = "";
+																}
+															}}
+															style={{
+																fontSize: "11px",
+																padding: "4px 8px",
+																border: "1px solid #A9A9A9",
+																borderRadius: "3px",
+																backgroundColor: "#FFFFFF",
+																color: "#000000",
+																cursor: "pointer",
+															}}
+															title="글자 크기 (pt)"
+														>
+															<option value="">크기</option>
+															<option value="10">10pt</option>
+															<option value="12">12pt</option>
+															<option value="14">14pt</option>
+															<option value="16">16pt</option>
+															<option value="18">18pt</option>
+															<option value="20">20pt</option>
+															<option value="24">24pt</option>
+														</select>
+
+														<select
+															onChange={(e) => {
+																const iframeDoc =
+																	translationIframeRef.current?.contentDocument;
+																if (iframeDoc && e.target.value) {
+																	const lineHeight = e.target.value;
+																	const selection = iframeDoc.getSelection();
+
+																	if (selection && selection.rangeCount > 0) {
+																		const range = selection.getRangeAt(0);
+																		let blockElement: HTMLElement | null = null;
+
+																		if (
+																			range.commonAncestorContainer.nodeType ===
+																			1
+																		) {
+																			blockElement = (
+																				range.commonAncestorContainer as HTMLElement
+																			).closest(
+																				"p, div, h1, h2, h3, h4, h5, h6, li, blockquote, pre",
+																			);
+																		} else {
+																			blockElement =
+																				range.commonAncestorContainer.parentElement?.closest(
+																					"p, div, h1, h2, h3, h4, h5, h6, li, blockquote, pre",
+																				) || null;
+																		}
+
+																		if (blockElement) {
+																			try {
+																				const blockRange =
+																					iframeDoc.createRange();
+																				blockRange.selectNodeContents(
+																					blockElement,
+																				);
+																				selection.removeAllRanges();
+																				selection.addRange(blockRange);
+
+																				const originalHtml =
+																					blockElement.innerHTML;
+																				const tagName =
+																					blockElement.tagName.toLowerCase();
+																				const newHtml = `<${tagName} style="line-height: ${lineHeight};">${originalHtml}</${tagName}>`;
+
+																				iframeDoc.execCommand(
+																					"insertHTML",
+																					false,
+																					newHtml,
+																				);
+																			} catch (err) {
+																				blockElement.style.lineHeight =
+																					lineHeight;
+																			}
+																		}
+																	}
+																	e.target.value = "";
+																}
+															}}
+															style={{
+																fontSize: "11px",
+																padding: "4px 8px",
+																border: "1px solid #A9A9A9",
+																borderRadius: "3px",
+																backgroundColor: "#FFFFFF",
+																color: "#000000",
+																cursor: "pointer",
+																marginLeft: "4px",
+															}}
+															title="줄간격"
+														>
+															<option value="">줄간격</option>
+															<option value="1.0">1.0 (단일)</option>
+															<option value="1.15">1.15</option>
+															<option value="1.5">1.5 (기본)</option>
+															<option value="1.75">1.75</option>
+															<option value="2.0">2.0 (2배)</option>
+															<option value="2.5">2.5</option>
+															<option value="3.0">3.0</option>
+														</select>
+														<div
+															style={{
+																position: "relative",
+																display: "inline-block",
+																width: "30px",
+																height: "26px",
+																marginLeft: "4px",
+															}}
+														>
+															<input
+																type="color"
+																onChange={(e) => {
+																	const iframeDoc =
+																		translationIframeRef.current
+																			?.contentDocument;
+																	if (iframeDoc)
+																		iframeDoc.execCommand(
+																			"foreColor",
+																			false,
+																			e.target.value,
+																		);
+																}}
+																style={{
+																	position: "absolute",
+																	width: "100%",
+																	height: "100%",
+																	opacity: 0,
+																	cursor: "pointer",
+																	zIndex: 2,
+																}}
+																title="글자 색상"
+															/>
+															<button
+																style={{
+																	position: "absolute",
+																	width: "100%",
+																	height: "100%",
+																	border: "1px solid #A9A9A9",
+																	borderRadius: "3px",
+																	backgroundColor: "#FFFFFF",
+																	display: "flex",
+																	alignItems: "center",
+																	justifyContent: "center",
+																	cursor: "pointer",
+																	padding: 0,
+																	pointerEvents: "none",
+																}}
+																title="글자 색상"
+																disabled
+															>
+																<Palette size={16} color="#000000" />
+															</button>
+														</div>
+														<div
+															style={{
+																position: "relative",
+																display: "inline-block",
+																width: "30px",
+																height: "26px",
+																marginLeft: "4px",
+															}}
+														>
+															<input
+																type="color"
+																onChange={(e) => {
+																	const iframeDoc =
+																		translationIframeRef.current
+																			?.contentDocument;
+																	if (iframeDoc)
+																		iframeDoc.execCommand(
+																			"backColor",
+																			false,
+																			e.target.value,
+																		);
+																}}
+																style={{
+																	position: "absolute",
+																	width: "100%",
+																	height: "100%",
+																	opacity: 0,
+																	cursor: "pointer",
+																	zIndex: 2,
+																}}
+																title="배경 색상"
+															/>
+															<button
+																style={{
+																	position: "absolute",
+																	width: "100%",
+																	height: "100%",
+																	border: "1px solid #A9A9A9",
+																	borderRadius: "3px",
+																	backgroundColor: "#FFFFFF",
+																	display: "flex",
+																	alignItems: "center",
+																	justifyContent: "center",
+																	cursor: "pointer",
+																	padding: 0,
+																	pointerEvents: "none",
+																}}
+																title="배경 색상"
+																disabled
+															>
+																<Highlighter size={16} color="#000000" />
+															</button>
+														</div>
+
+														<div
+															style={{
+																width: "1px",
+																height: "20px",
+																backgroundColor: "#C0C0C0",
+																margin: "0 4px",
+															}}
+														/>
+														<button
+															onClick={() => {
+																const iframeDoc =
+																	translationIframeRef.current?.contentDocument;
+																if (iframeDoc)
+																	iframeDoc.execCommand("justifyLeft", false);
+															}}
+															style={{
+																padding: "4px 8px",
+																fontSize: "11px",
+																border: "1px solid #A9A9A9",
+																borderRadius: "3px",
+																backgroundColor: "#FFFFFF",
+																color: "#000000",
+																cursor: "pointer",
+																display: "flex",
+																alignItems: "center",
+																justifyContent: "center",
+															}}
+															title="왼쪽 정렬"
+														>
+															<AlignLeft size={16} />
+														</button>
+														<button
+															onClick={() => {
+																const iframeDoc =
+																	translationIframeRef.current?.contentDocument;
+																if (iframeDoc)
+																	iframeDoc.execCommand("justifyCenter", false);
+															}}
+															style={{
+																padding: "4px 8px",
+																fontSize: "11px",
+																border: "1px solid #A9A9A9",
+																borderRadius: "3px",
+																backgroundColor: "#FFFFFF",
+																color: "#000000",
+																cursor: "pointer",
+																display: "flex",
+																alignItems: "center",
+																justifyContent: "center",
+															}}
+															title="가운데 정렬"
+														>
+															<AlignCenter size={16} />
+														</button>
+														<button
+															onClick={() => {
+																const iframeDoc =
+																	translationIframeRef.current?.contentDocument;
+																if (iframeDoc)
+																	iframeDoc.execCommand("justifyRight", false);
+															}}
+															style={{
+																padding: "4px 8px",
+																fontSize: "11px",
+																border: "1px solid #A9A9A9",
+																borderRadius: "3px",
+																backgroundColor: "#FFFFFF",
+																color: "#000000",
+																cursor: "pointer",
+																display: "flex",
+																alignItems: "center",
+																justifyContent: "center",
+															}}
+															title="오른쪽 정렬"
+														>
+															<AlignRight size={16} />
+														</button>
+														<div
+															style={{
+																width: "1px",
+																height: "20px",
+																backgroundColor: "#C0C0C0",
+																margin: "0 4px",
+															}}
+														/>
+														<button
+															onClick={() => {
+																const iframeDoc =
+																	translationIframeRef.current?.contentDocument;
+																if (iframeDoc)
+																	iframeDoc.execCommand(
+																		"insertUnorderedList",
+																		false,
+																	);
+															}}
+															style={{
+																padding: "4px 8px",
+																fontSize: "11px",
+																border: "1px solid #A9A9A9",
+																borderRadius: "3px",
+																backgroundColor: "#FFFFFF",
+																color: "#000000",
+																cursor: "pointer",
+																display: "flex",
+																alignItems: "center",
+																justifyContent: "center",
+															}}
+															title="글머리 기호 목록"
+														>
+															<List size={16} />
+														</button>
+														<button
+															onClick={() => {
+																const iframeDoc =
+																	translationIframeRef.current?.contentDocument;
+																if (iframeDoc)
+																	iframeDoc.execCommand(
+																		"insertOrderedList",
+																		false,
+																	);
+															}}
+															style={{
+																padding: "4px 8px",
+																fontSize: "11px",
+																border: "1px solid #A9A9A9",
+																borderRadius: "3px",
+																backgroundColor: "#FFFFFF",
+																color: "#000000",
+																cursor: "pointer",
+																display: "flex",
+																alignItems: "center",
+																justifyContent: "center",
+															}}
+															title="번호 매기기 목록"
+														>
+															<ListOrdered size={16} />
+														</button>
+														<button
+															onClick={() => {
+																const iframeDoc =
+																	translationIframeRef.current?.contentDocument;
+																if (iframeDoc) {
+																	const url = prompt("링크 URL을 입력하세요:");
+																	if (url)
+																		iframeDoc.execCommand(
+																			"createLink",
+																			false,
+																			url,
+																		);
+																}
+															}}
+															style={{
+																padding: "4px 8px",
+																fontSize: "11px",
+																border: "1px solid #A9A9A9",
+																borderRadius: "3px",
+																backgroundColor: "#FFFFFF",
+																color: "#000000",
+																cursor: "pointer",
+																display: "flex",
+																alignItems: "center",
+																justifyContent: "center",
+															}}
+															title="링크 삽입"
+														>
+															<Link2 size={16} />
+														</button>
+														<div
+															style={{
+																width: "1px",
+																height: "20px",
+																backgroundColor: "#C0C0C0",
+																margin: "0 4px",
+															}}
+														/>
+														<div
+															style={{
+																position: "relative",
+																display: "inline-block",
+															}}
+														>
+															<input
+																type="file"
+																accept="image/*"
+																onChange={(e) => {
+																	const file = e.target.files?.[0];
+																	if (file) {
+																		const reader = new FileReader();
+																		reader.onload = (event) => {
+																			const imageUrl = event.target
+																				?.result as string;
+																			const iframeDoc =
+																				translationIframeRef.current
+																					?.contentDocument;
+																			if (iframeDoc && imageUrl) {
+																				try {
+																					iframeDoc.execCommand(
+																						"insertHTML",
+																						false,
+																						`<img src="${imageUrl}" alt="" style="max-width: 100%; height: auto;" />`,
+																					);
+																				} catch (err) {
+																					const selection =
+																						iframeDoc.getSelection();
+																					if (
+																						selection &&
+																						selection.rangeCount > 0
+																					) {
+																						const range =
+																							selection.getRangeAt(0);
+																						const img =
+																							iframeDoc.createElement("img");
+																						img.src = imageUrl;
+																						img.alt = "";
+																						img.style.maxWidth = "100%";
+																						img.style.height = "auto";
+																						range.insertNode(img);
+																					}
+																				}
+																			}
+																		};
+																		reader.readAsDataURL(file);
+																	}
+																	e.target.value = "";
+																}}
+																style={{
+																	position: "absolute",
+																	width: "100%",
+																	height: "100%",
+																	opacity: 0,
+																	cursor: "pointer",
+																	zIndex: 2,
+																}}
+																title="이미지 삽입"
+															/>
+															<button
+																style={{
+																	padding: "4px 8px",
+																	fontSize: "11px",
+																	border: "1px solid #A9A9A9",
+																	borderRadius: "3px",
+																	backgroundColor: "#FFFFFF",
+																	color: "#000000",
+																	cursor: "pointer",
+																	display: "flex",
+																	alignItems: "center",
+																	justifyContent: "center",
+																	pointerEvents: "none",
+																}}
+																title="이미지 삽입"
+																disabled
+															>
+																<Image size={16} />
+															</button>
+														</div>
+														<button
+															onClick={() => {
+																const iframeDoc =
+																	translationIframeRef.current?.contentDocument;
+																if (iframeDoc) {
+																	try {
+																		iframeDoc.execCommand(
+																			"insertHTML",
+																			false,
+																			'<pre style="background-color: #f4f4f4; padding: 10px; border-radius: 4px; overflow-x: auto;"><code></code></pre>',
+																		);
+																	} catch (err) {
+																		iframeDoc.execCommand(
+																			"formatBlock",
+																			false,
+																			"pre",
+																		);
+																	}
+																}
+															}}
+															style={{
+																padding: "4px 8px",
+																fontSize: "11px",
+																border: "1px solid #A9A9A9",
+																borderRadius: "3px",
+																backgroundColor: "#FFFFFF",
+																color: "#000000",
+																cursor: "pointer",
+																display: "flex",
+																alignItems: "center",
+																justifyContent: "center",
+															}}
+															title="코드 블록"
+														>
+															<Code size={16} />
+														</button>
+														<div
+															style={{
+																position: "relative",
+																display: "inline-block",
+															}}
+															data-more-menu
+														>
+															<button
+																onClick={() => setShowMoreMenu(!showMoreMenu)}
+																style={{
+																	padding: "4px 8px",
+																	fontSize: "11px",
+																	border: "1px solid #A9A9A9",
+																	borderRadius: "3px",
+																	backgroundColor: showMoreMenu
+																		? "#E0E0E0"
+																		: "#FFFFFF",
+																	color: "#000000",
+																	cursor: "pointer",
+																	display: "flex",
+																	alignItems: "center",
+																	justifyContent: "center",
+																}}
+																title="더보기"
+															>
+																<MoreVertical size={16} />
+															</button>
+															{showMoreMenu && (
+																<div
+																	style={{
+																		position: "absolute",
+																		top: "100%",
+																		right: 0,
+																		marginTop: "4px",
+																		backgroundColor: "#FFFFFF",
+																		border: "1px solid #A9A9A9",
+																		borderRadius: "4px",
+																		boxShadow: "0 2px 8px rgba(0,0,0,0.15)",
+																		zIndex: 1000,
+																		display: "flex",
+																		flexDirection: "row",
+																		gap: "4px",
+																		padding: "4px",
+																	}}
+																	onClick={(e) => e.stopPropagation()}
+																	data-more-menu
+																>
+																	<button
+																		onClick={() => {
+																			const iframeDoc =
+																				translationIframeRef.current
+																					?.contentDocument;
+																			if (iframeDoc) {
+																				iframeDoc.execCommand(
+																					"formatBlock",
+																					false,
+																					"blockquote",
+																				);
+																			}
+																			setShowMoreMenu(false);
+																		}}
+																		style={{
+																			padding: "4px 8px",
+																			fontSize: "11px",
+																			border: "1px solid #A9A9A9",
+																			borderRadius: "3px",
+																			backgroundColor: "#FFFFFF",
+																			color: "#000000",
+																			cursor: "pointer",
+																			display: "flex",
+																			alignItems: "center",
+																			justifyContent: "center",
+																		}}
+																		title="인용문"
+																	>
+																		<Quote size={16} />
+																	</button>
+																	<button
+																		onClick={() => {
+																			const iframeDoc =
+																				translationIframeRef.current
+																					?.contentDocument;
+																			if (iframeDoc) {
+																				iframeDoc.execCommand(
+																					"insertHorizontalRule",
+																					false,
+																				);
+																			}
+																			setShowMoreMenu(false);
+																		}}
+																		style={{
+																			padding: "4px 8px",
+																			fontSize: "11px",
+																			border: "1px solid #A9A9A9",
+																			borderRadius: "3px",
+																			backgroundColor: "#FFFFFF",
+																			color: "#000000",
+																			cursor: "pointer",
+																			display: "flex",
+																			alignItems: "center",
+																			justifyContent: "center",
+																		}}
+																		title="구분선"
+																	>
+																		<Minus size={16} />
+																	</button>
+																	<button
+																		onClick={() => {
+																			const iframeDoc =
+																				translationIframeRef.current
+																					?.contentDocument;
+																			if (iframeDoc) {
+																				const rows = prompt(
+																					"행 수를 입력하세요 (기본값: 3):",
+																					"3",
+																				);
+																				const cols = prompt(
+																					"열 수를 입력하세요 (기본값: 3):",
+																					"3",
+																				);
+																				const rowCount = Number.parseInt(
+																					rows || "3",
+																					10,
+																				);
+																				const colCount = Number.parseInt(
+																					cols || "3",
+																					10,
+																				);
+
+																				if (rowCount > 0 && colCount > 0) {
+																					let tableHtml =
+																						'<table border="1" style="border-collapse: collapse; width: 100%;">';
+																					for (let i = 0; i < rowCount; i++) {
+																						tableHtml += "<tr>";
+																						for (let j = 0; j < colCount; j++) {
+																							tableHtml +=
+																								'<td style="padding: 8px; border: 1px solid #000;">&nbsp;</td>';
+																						}
+																						tableHtml += "</tr>";
+																					}
+																					tableHtml += "</table>";
+
+																					try {
+																						iframeDoc.execCommand(
+																							"insertHTML",
+																							false,
+																							tableHtml,
+																						);
+																					} catch (err) {
+																						const selection =
+																							iframeDoc.getSelection();
+																						if (
+																							selection &&
+																							selection.rangeCount > 0
+																						) {
+																							const range =
+																								selection.getRangeAt(0);
+																							const tempDiv =
+																								iframeDoc.createElement("div");
+																							tempDiv.innerHTML = tableHtml;
+																							const fragment =
+																								iframeDoc.createDocumentFragment();
+																							while (tempDiv.firstChild) {
+																								fragment.appendChild(
+																									tempDiv.firstChild,
+																								);
+																							}
+																							range.insertNode(fragment);
+																						}
+																					}
+																				}
+																			}
+																			setShowMoreMenu(false);
+																		}}
+																		style={{
+																			padding: "4px 8px",
+																			fontSize: "11px",
+																			border: "1px solid #A9A9A9",
+																			borderRadius: "3px",
+																			backgroundColor: "#FFFFFF",
+																			color: "#000000",
+																			cursor: "pointer",
+																			display: "flex",
+																			alignItems: "center",
+																			justifyContent: "center",
+																		}}
+																		title="표"
+																	>
+																		<Table size={16} />
+																	</button>
+																	<button
+																		onClick={() => {
+																			const iframeDoc =
+																				translationIframeRef.current
+																					?.contentDocument;
+																			if (iframeDoc) {
+																				const selection =
+																					iframeDoc.getSelection();
+																				if (
+																					selection &&
+																					selection.rangeCount > 0 &&
+																					!selection.getRangeAt(0).collapsed
+																				) {
+																					const range = selection.getRangeAt(0);
+																					const selectedText = range.toString();
+																					try {
+																						iframeDoc.execCommand(
+																							"insertHTML",
+																							false,
+																							`<sup>${selectedText}</sup>`,
+																						);
+																					} catch (err) {
+																						const sup =
+																							iframeDoc.createElement("sup");
+																						sup.textContent = selectedText;
+																						range.deleteContents();
+																						range.insertNode(sup);
+																					}
+																				}
+																			}
+																			setShowMoreMenu(false);
+																		}}
+																		style={{
+																			padding: "4px 8px",
+																			fontSize: "11px",
+																			border: "1px solid #A9A9A9",
+																			borderRadius: "3px",
+																			backgroundColor: "#FFFFFF",
+																			color: "#000000",
+																			cursor: "pointer",
+																			display: "flex",
+																			alignItems: "center",
+																			justifyContent: "center",
+																		}}
+																		title="위 첨자"
+																	>
+																		<Superscript size={16} />
+																	</button>
+																	<button
+																		onClick={() => {
+																			const iframeDoc =
+																				translationIframeRef.current
+																					?.contentDocument;
+																			if (iframeDoc) {
+																				const selection =
+																					iframeDoc.getSelection();
+																				if (
+																					selection &&
+																					selection.rangeCount > 0 &&
+																					!selection.getRangeAt(0).collapsed
+																				) {
+																					const range = selection.getRangeAt(0);
+																					const selectedText = range.toString();
+																					try {
+																						iframeDoc.execCommand(
+																							"insertHTML",
+																							false,
+																							`<sub>${selectedText}</sub>`,
+																						);
+																					} catch (err) {
+																						const sub =
+																							iframeDoc.createElement("sub");
+																						sub.textContent = selectedText;
+																						range.deleteContents();
+																						range.insertNode(sub);
+																					}
+																				}
+																			}
+																			setShowMoreMenu(false);
+																		}}
+																		style={{
+																			padding: "4px 8px",
+																			fontSize: "11px",
+																			border: "1px solid #A9A9A9",
+																			borderRadius: "3px",
+																			backgroundColor: "#FFFFFF",
+																			color: "#000000",
+																			cursor: "pointer",
+																			display: "flex",
+																			alignItems: "center",
+																			justifyContent: "center",
+																		}}
+																		title="아래 첨자"
+																	>
+																		<Subscript size={16} />
+																	</button>
+																</div>
+															)}
+														</div>
+													</>
+												)}
+
+												{/* 컴포넌트 편집 모드 */}
+												{editorMode === "component" &&
+													selectedElements.length > 0 && (
+														<>
+															<div
+																style={{
+																	width: "1px",
+																	height: "20px",
+																	backgroundColor: "#C0C0C0",
+																	margin: "0 4px",
+																}}
+															/>
+
+															{/* 실행 취소/다시 실행 버튼 */}
+															<button
+																onClick={() => {
+																	const iframeDoc =
+																		translationIframeRef.current
+																			?.contentDocument;
+																	if (!iframeDoc) return;
+
+																	if (undoStackRef.current.length > 0) {
+																		redoStackRef.current.push(
+																			currentEditorHtmlRef.current,
+																		);
+																		const previousHtml =
+																			undoStackRef.current.pop()!;
+																		currentEditorHtmlRef.current = previousHtml;
+
+																		iframeDoc.open();
+																		iframeDoc.write(previousHtml);
+																		iframeDoc.close();
+
+																		setTranslationHtml(previousHtml);
+																		setSelectedElements([]);
+																	}
+																}}
+																style={{
+																	padding: "4px 8px",
+																	fontSize: "11px",
+																	border: "1px solid #A9A9A9",
+																	borderRadius: "3px",
+																	backgroundColor: "#FFFFFF",
+																	color: "#000000",
+																	cursor: "pointer",
+																	display: "flex",
+																	alignItems: "center",
+																	justifyContent: "center",
+																}}
+																title="실행 취소 (Ctrl/Cmd+Z)"
+															>
+																<Undo2 size={16} color="#000000" />
+															</button>
+															<button
+																onClick={() => {
+																	const iframeDoc =
+																		translationIframeRef.current
+																			?.contentDocument;
+																	if (!iframeDoc) return;
+
+																	if (redoStackRef.current.length > 0) {
+																		undoStackRef.current.push(
+																			currentEditorHtmlRef.current,
+																		);
+																		const nextHtml =
+																			redoStackRef.current.pop()!;
+																		currentEditorHtmlRef.current = nextHtml;
+
+																		iframeDoc.open();
+																		iframeDoc.write(nextHtml);
+																		iframeDoc.close();
+
+																		setTranslationHtml(nextHtml);
+																		setSelectedElements([]);
+																	}
+																}}
+																style={{
+																	padding: "4px 8px",
+																	fontSize: "11px",
+																	border: "1px solid #A9A9A9",
+																	borderRadius: "3px",
+																	backgroundColor: "#FFFFFF",
+																	color: "#000000",
+																	cursor: "pointer",
+																	display: "flex",
+																	alignItems: "center",
+																	justifyContent: "center",
+																}}
+																title="다시 실행 (Ctrl/Cmd+Y)"
+															>
+																<Redo2 size={16} color="#000000" />
+															</button>
+
+															<div
+																style={{
+																	width: "1px",
+																	height: "20px",
+																	backgroundColor: "#C0C0C0",
+																	margin: "0 4px",
+																}}
+															/>
+
+															<span
+																style={{
+																	fontSize: "11px",
+																	color: "#696969",
+																	marginRight: "4px",
+																}}
+															>
+																{selectedElements.length}개 선택됨
+															</span>
+															<Button
+																variant="secondary"
+																onClick={() => {
+																	if (!translationIframeRef.current) return;
+																	const iframeDoc =
+																		translationIframeRef.current
+																			.contentDocument ||
+																		translationIframeRef.current.contentWindow
+																			?.document;
+																	if (iframeDoc) {
+																		selectedElements.forEach((el) => {
+																			el.classList.remove("component-selected");
+																			el.style.outline = "";
+																			el.style.boxShadow = "";
+																			el.style.backgroundColor = "";
+																			el.style.outlineOffset = "";
+																		});
+																	}
+																	setSelectedElements([]);
+																}}
+																style={{ fontSize: "11px", padding: "4px 8px" }}
+															>
+																선택 취소
+															</Button>
+															<Button
+																variant="primary"
+																onClick={() => {
+																	if (!translationIframeRef.current) return;
+																	const iframeDoc =
+																		translationIframeRef.current
+																			.contentDocument;
+																	if (!iframeDoc) return;
+
+																	// Undo Stack에 현재 상태 저장
+																	undoStackRef.current.push(
+																		currentEditorHtmlRef.current,
+																	);
+																	redoStackRef.current = [];
+
+																	// 선택된 요소 삭제
+																	selectedElements.forEach((el) => el.remove());
+																	setSelectedElements([]);
+
+																	// 변경된 HTML 저장
+																	const updatedHtml =
+																		iframeDoc.documentElement.outerHTML;
+																	currentEditorHtmlRef.current = updatedHtml;
+																	setTranslationHtml(updatedHtml);
+																	console.log(
+																		"🗑️ 선택된 요소 삭제:",
+																		selectedElements.length,
+																		"개",
+																	);
+																}}
+																style={{ fontSize: "11px", padding: "4px 8px" }}
+															>
+																삭제
+															</Button>
+														</>
+													)}
+											</div>
+										</div>
+
+										{/* iframe 에디터 */}
+										<iframe
+											ref={panel.ref as React.RefObject<HTMLIFrameElement>}
+											style={{
+												width: "100%",
+												height: "100%",
+												border: "none",
+												display: "block",
+											}}
+											title={panel.title}
+										/>
+									</>
+								) : panel.html ? (
+									// 원문, AI 초벌 번역 패널
+									<iframe
+										ref={panel.ref as React.RefObject<HTMLIFrameElement>}
+										srcDoc={panel.html}
+										style={{
+											width: "100%",
+											height: "100%",
+											border: "none",
+											backgroundColor: "#FFFFFF",
+										}}
+										title={panel.title}
+									/>
+								) : (
+									<div
+										style={{
+											display: "flex",
+											alignItems: "center",
+											justifyContent: "center",
+											height: "100%",
+											color: colors.secondaryText,
+											fontSize: "13px",
+										}}
+									>
+										{panel.id === "original"
+											? "원문이 없습니다."
+											: panel.id === "aiDraft"
+												? "AI 초벌 번역이 없습니다."
+												: "번역본이 없습니다."}
+									</div>
+								)}
+							</div>
+						</div>
+					);
+				})}
+			</div>
+
+			{/* 반려 모달 */}
+			{showRejectModal && (
+				<div
+					style={{
+						position: "fixed",
+						top: 0,
+						left: 0,
+						right: 0,
+						bottom: 0,
+						backgroundColor: "rgba(0, 0, 0, 0.5)",
+						display: "flex",
+						alignItems: "center",
+						justifyContent: "center",
+						zIndex: 1000,
+					}}
+					onClick={() => setShowRejectModal(false)}
+				>
+					<div
+						style={{
+							backgroundColor: colors.surface,
+							padding: "24px",
+							borderRadius: "8px",
+							width: "500px",
+							maxWidth: "90vw",
+							border: `1px solid ${colors.border}`,
+						}}
+						onClick={(e) => e.stopPropagation()}
+					>
+						<h3
+							style={{
+								fontSize: "16px",
+								fontWeight: 600,
+								marginBottom: "16px",
+							}}
+						>
+							문서 반려
+						</h3>
+
+						<div style={{ marginBottom: "16px" }}>
+							<label
+								style={{
+									display: "block",
+									fontSize: "13px",
+									marginBottom: "8px",
+									color: colors.primaryText,
+								}}
+							>
+								반려 사유 *
+							</label>
+							<textarea
+								value={rejectMessage}
+								onChange={(e) => setRejectMessage(e.target.value)}
+								placeholder="예: 번역 품질이 부족합니다. 전문 용어 번역이 정확하지 않습니다."
+								style={{
+									width: "100%",
+									minHeight: "120px",
+									padding: "8px",
+									border: `1px solid ${colors.border}`,
+									borderRadius: "4px",
+									fontSize: "13px",
+									fontFamily: "inherit",
+									resize: "vertical",
+								}}
+							/>
+							<div
+								style={{
+									fontSize: "12px",
+									color: colors.secondaryText,
+									marginTop: "8px",
+								}}
+							>
+								반려 시 문서가 다시 번역 대기 상태로 변경됩니다.
+							</div>
+						</div>
+
+						<div
+							style={{
+								display: "flex",
+								gap: "8px",
+								justifyContent: "flex-end",
+							}}
+						>
+							<Button
+								variant="secondary"
+								onClick={() => {
+									setShowRejectModal(false);
+									setRejectMessage("");
+								}}
+								style={{ fontSize: "12px" }}
+							>
+								취소
+							</Button>
+							<Button
+								variant="primary"
+								onClick={handleReject}
+								style={{ fontSize: "12px" }}
+							>
+								반려 처리
+							</Button>
+						</div>
+					</div>
+				</div>
+			)}
+
+			{/* 링크 편집 모달 */}
+			{showLinkModal && (
+				<div
+					style={{
+						position: "fixed",
+						top: 0,
+						left: 0,
+						right: 0,
+						bottom: 0,
+						backgroundColor: "rgba(0, 0, 0, 0.5)",
+						display: "flex",
+						alignItems: "center",
+						justifyContent: "center",
+						zIndex: 1000,
+					}}
+					onClick={() => {
+						setShowLinkModal(false);
+						setEditingLink(null);
+						setLinkUrl("");
+					}}
+				>
+					<div
+						style={{
+							backgroundColor: colors.surface,
+							padding: "24px",
+							borderRadius: "8px",
+							width: "400px",
+							maxWidth: "90vw",
+							border: `1px solid ${colors.border}`,
+						}}
+						onClick={(e) => e.stopPropagation()}
+					>
+						<h3
+							style={{
+								fontSize: "16px",
+								fontWeight: 600,
+								marginBottom: "16px",
+							}}
+						>
+							링크 편집
+						</h3>
+
+						<div style={{ marginBottom: "16px" }}>
+							<label
+								style={{
+									display: "block",
+									fontSize: "13px",
+									marginBottom: "8px",
+									color: colors.primaryText,
+								}}
+							>
+								URL
+							</label>
+							<input
+								type="text"
+								value={linkUrl}
+								onChange={(e) => setLinkUrl(e.target.value)}
+								placeholder="https://example.com"
+								style={{
+									width: "100%",
+									padding: "8px",
+									border: `1px solid ${colors.border}`,
+									borderRadius: "4px",
+									fontSize: "13px",
+									fontFamily: "inherit",
+								}}
+								onKeyDown={(e) => {
+									if (e.key === "Enter") {
+										e.preventDefault();
+										const iframeDoc =
+											translationIframeRef.current?.contentDocument;
+										if (iframeDoc && editingLink && linkUrl.trim()) {
+											const selection = iframeDoc.getSelection();
+											if (selection) {
+												const range = iframeDoc.createRange();
+												range.selectNodeContents(editingLink);
+												selection.removeAllRanges();
+												selection.addRange(range);
+
+												iframeDoc.execCommand("unlink", false);
+												iframeDoc.execCommand(
+													"createLink",
+													false,
+													linkUrl.trim(),
+												);
+											}
+										}
+										setShowLinkModal(false);
+										setEditingLink(null);
+										setLinkUrl("");
+									}
+								}}
+								autoFocus
+							/>
+						</div>
+
+						<div
+							style={{
+								display: "flex",
+								gap: "8px",
+								justifyContent: "flex-end",
+							}}
+						>
+							<Button
+								variant="secondary"
+								onClick={() => {
+									setShowLinkModal(false);
+									setEditingLink(null);
+									setLinkUrl("");
+								}}
+								style={{ fontSize: "12px" }}
+							>
+								취소
+							</Button>
+							<Button
+								variant="secondary"
+								onClick={() => {
+									const iframeDoc =
+										translationIframeRef.current?.contentDocument;
+									if (iframeDoc && editingLink) {
+										const selection = iframeDoc.getSelection();
+										if (selection) {
+											const range = iframeDoc.createRange();
+											range.selectNodeContents(editingLink);
+											selection.removeAllRanges();
+											selection.addRange(range);
+											iframeDoc.execCommand("unlink", false);
+										}
+									}
+									setShowLinkModal(false);
+									setEditingLink(null);
+									setLinkUrl("");
+								}}
+								style={{ fontSize: "12px" }}
+							>
+								삭제
+							</Button>
+							<Button
+								variant="primary"
+								onClick={() => {
+									const iframeDoc =
+										translationIframeRef.current?.contentDocument;
+									if (iframeDoc && editingLink && linkUrl.trim()) {
+										const selection = iframeDoc.getSelection();
+										if (selection) {
+											const range = iframeDoc.createRange();
+											range.selectNodeContents(editingLink);
+											selection.removeAllRanges();
+											selection.addRange(range);
+
+											iframeDoc.execCommand("unlink", false);
+											iframeDoc.execCommand(
+												"createLink",
+												false,
+												linkUrl.trim(),
+											);
+										}
+									}
+									setShowLinkModal(false);
+									setEditingLink(null);
+									setLinkUrl("");
+								}}
+								style={{ fontSize: "12px" }}
+							>
+								저장
+							</Button>
+						</div>
+					</div>
+				</div>
+			)}
+		</div>
+	);
 }
-

--- a/src/pages/InquiryList.tsx
+++ b/src/pages/InquiryList.tsx
@@ -74,16 +74,23 @@ export default function InquiryList() {
             )}
           </h1>
           <div className="flex flex-wrap items-center gap-2">
-            <div className="flex rounded-lg border overflow-hidden" style={{ borderColor: colors.border }}>
+            <div
+              className="inline-flex items-center rounded-xl border p-1"
+              style={{ borderColor: colors.border, backgroundColor: colors.surface }}
+            >
               <button
                 type="button"
                 onClick={() => {
                   setMineOnly(false);
                   setPage(0);
                 }}
-                className="px-3 py-1.5 text-sm"
+                aria-pressed={!mineOnly}
+                className={`px-4 py-2 text-sm rounded-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 ${
+                  !mineOnly ? 'shadow-sm' : 'text-gray-600 hover:bg-white/60'
+                }`}
                 style={{
-                  backgroundColor: !mineOnly ? menuStatesActive : 'transparent',
+                  backgroundColor: !mineOnly ? 'rgba(59, 130, 246, 0.16)' : 'transparent',
+                  color: !mineOnly ? '#1d4ed8' : '#4b5563',
                   fontFamily: typography.fontFamily,
                 }}
               >
@@ -95,9 +102,13 @@ export default function InquiryList() {
                   setMineOnly(true);
                   setPage(0);
                 }}
-                className="px-3 py-1.5 text-sm"
+                aria-pressed={mineOnly}
+                className={`px-4 py-2 text-sm rounded-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 ${
+                  mineOnly ? 'shadow-sm' : 'text-gray-600 hover:bg-white/60'
+                }`}
                 style={{
-                  backgroundColor: mineOnly ? menuStatesActive : 'transparent',
+                  backgroundColor: mineOnly ? 'rgba(59, 130, 246, 0.16)' : 'transparent',
+                  color: mineOnly ? '#1d4ed8' : '#4b5563',
                   fontFamily: typography.fontFamily,
                 }}
               >
@@ -218,5 +229,3 @@ export default function InquiryList() {
     </div>
   );
 }
-
-const menuStatesActive = 'rgba(169, 169, 169, 0.35)';

--- a/src/pages/NewTranslation.tsx
+++ b/src/pages/NewTranslation.tsx
@@ -1,419 +1,517 @@
-import React, { useState, useEffect, useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { useUser } from '../contexts/UserContext';
-import { useSidebar } from '../contexts/SidebarContext';
-import { roleLevelToRole } from '../utils/hasAccess';
-import { UserRole } from '../types/user';
-import { DocumentState, TranslationDraft, SelectedArea } from '../types/translation';
-import { Button } from '../components/Button';
-import { Modal } from '../components/Modal';
-import { WysiwygEditor, EditorMode } from '../components/WysiwygEditor';
-import { documentApi, DocumentResponse } from '../services/documentApi';
-import { translationApi } from '../services/api';
-import { termApi } from '../services/termApi';
-import { AlignLeft, AlignCenter, AlignRight, AlignJustify, List, ListOrdered, Palette, Quote, Minus, Link2, Highlighter, Image, Table, Code, Superscript, Subscript, MoreVertical, Undo2, Redo2 } from 'lucide-react';
+import React, { useState, useEffect, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import { useUser } from "../contexts/UserContext";
+import { useSidebar } from "../contexts/SidebarContext";
+import { roleLevelToRole } from "../utils/hasAccess";
+import { UserRole } from "../types/user";
+import {
+	DocumentState,
+	type TranslationDraft,
+	type SelectedArea,
+} from "../types/translation";
+import { Button } from "../components/Button";
+import { Modal } from "../components/Modal";
+import { WysiwygEditor, type EditorMode } from "../components/WysiwygEditor";
+import { documentApi, type DocumentResponse } from "../services/documentApi";
+import { translationApi } from "../services/api";
+import { termApi } from "../services/termApi";
+import {
+	AlignLeft,
+	AlignCenter,
+	AlignRight,
+	AlignJustify,
+	List,
+	ListOrdered,
+	Palette,
+	Quote,
+	Minus,
+	Link2,
+	Highlighter,
+	Image,
+	Table,
+	Code,
+	Superscript,
+	Subscript,
+	MoreVertical,
+	Undo2,
+	Redo2,
+} from "lucide-react";
 
 // 수동 서식 넣기용 최소 HTML 템플릿
-const MANUAL_PASTE_HTML = '<!DOCTYPE html><html><head><meta charset="utf-8"><style>body{font-family:system-ui,Pretendard,sans-serif;padding:16px;margin:0;min-height:400px;}</style></head><body><div contenteditable="true" style="min-height:400px;outline:none;"></div></body></html>';
+const MANUAL_PASTE_HTML =
+	'<!DOCTYPE html><html><head><meta charset="utf-8"><style>body{font-family:system-ui,Pretendard,sans-serif;padding:16px;margin:0;min-height:400px;}</style></head><body><div contenteditable="true" style="min-height:400px;outline:none;"></div></body></html>';
 const WORD_CHAR_REGEX = /[A-Za-z0-9_]/;
 type GlossaryTermPair = { sourceTerm: string; targetTerm: string };
 
-const highlightGlossaryInOriginalIframe = (doc: Document, glossaryTerms: GlossaryTermPair[]) => {
-  if (!doc.body || glossaryTerms.length === 0) return;
+const highlightGlossaryInOriginalIframe = (
+	doc: Document,
+	glossaryTerms: GlossaryTermPair[],
+) => {
+	if (!doc.body || glossaryTerms.length === 0) return;
 
-  const sortedTerms = [...glossaryTerms]
-    .map((t) => ({ sourceTerm: t.sourceTerm.trim(), targetTerm: t.targetTerm.trim() }))
-    .filter((t) => t.sourceTerm.length > 1 && t.targetTerm.length > 0)
-    .sort((a, b) => b.sourceTerm.length - a.sourceTerm.length);
-  if (sortedTerms.length === 0) return;
+	const sortedTerms = [...glossaryTerms]
+		.map((t) => ({
+			sourceTerm: t.sourceTerm.trim(),
+			targetTerm: t.targetTerm.trim(),
+		}))
+		.filter((t) => t.sourceTerm.length > 1 && t.targetTerm.length > 0)
+		.sort((a, b) => b.sourceTerm.length - a.sourceTerm.length);
+	if (sortedTerms.length === 0) return;
 
-  const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_TEXT);
-  const textNodes: Text[] = [];
-  let current: Node | null = walker.nextNode();
-  while (current) {
-    const parentTag = (current.parentElement?.tagName || '').toLowerCase();
-    if (parentTag !== 'script' && parentTag !== 'style' && current.textContent?.trim()) {
-      textNodes.push(current as Text);
-    }
-    current = walker.nextNode();
-  }
+	const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_TEXT);
+	const textNodes: Text[] = [];
+	let current: Node | null = walker.nextNode();
+	while (current) {
+		const parentTag = (current.parentElement?.tagName || "").toLowerCase();
+		if (
+			parentTag !== "script" &&
+			parentTag !== "style" &&
+			current.textContent?.trim()
+		) {
+			textNodes.push(current as Text);
+		}
+		current = walker.nextNode();
+	}
 
-  textNodes.forEach((textNode) => {
-    const source = textNode.textContent || '';
-    const lower = source.toLowerCase();
-    let cursor = 0;
-    const fragment = doc.createDocumentFragment();
-    let matched = false;
+	textNodes.forEach((textNode) => {
+		const source = textNode.textContent || "";
+		const lower = source.toLowerCase();
+		let cursor = 0;
+		const fragment = doc.createDocumentFragment();
+		let matched = false;
 
-    while (cursor < source.length) {
-      let bestStart = -1;
-      let bestEnd = -1;
-      let bestTerm: GlossaryTermPair | null = null;
+		while (cursor < source.length) {
+			let bestStart = -1;
+			let bestEnd = -1;
+			let bestTerm: GlossaryTermPair | null = null;
 
-      for (const term of sortedTerms) {
-        const termLower = term.sourceTerm.toLowerCase();
-        const found = lower.indexOf(termLower, cursor);
-        if (found === -1) continue;
-        const end = found + termLower.length;
+			for (const term of sortedTerms) {
+				const termLower = term.sourceTerm.toLowerCase();
+				const found = lower.indexOf(termLower, cursor);
+				if (found === -1) continue;
+				const end = found + termLower.length;
 
-        const before = found > 0 ? source[found - 1] : '';
-        const after = end < source.length ? source[end] : '';
-        const leftBoundary = !before || !WORD_CHAR_REGEX.test(before);
-        const rightBoundary = !after || !WORD_CHAR_REGEX.test(after);
-        if (!leftBoundary || !rightBoundary) continue;
+				const before = found > 0 ? source[found - 1] : "";
+				const after = end < source.length ? source[end] : "";
+				const leftBoundary = !before || !WORD_CHAR_REGEX.test(before);
+				const rightBoundary = !after || !WORD_CHAR_REGEX.test(after);
+				if (!leftBoundary || !rightBoundary) continue;
 
-        if (bestStart === -1 || found < bestStart || (found === bestStart && bestTerm && term.sourceTerm.length > bestTerm.sourceTerm.length)) {
-          bestStart = found;
-          bestEnd = end;
-          bestTerm = term;
-        }
-      }
+				if (
+					bestStart === -1 ||
+					found < bestStart ||
+					(found === bestStart &&
+						bestTerm &&
+						term.sourceTerm.length > bestTerm.sourceTerm.length)
+				) {
+					bestStart = found;
+					bestEnd = end;
+					bestTerm = term;
+				}
+			}
 
-      if (bestStart === -1) {
-        fragment.appendChild(doc.createTextNode(source.slice(cursor)));
-        break;
-      }
+			if (bestStart === -1) {
+				fragment.appendChild(doc.createTextNode(source.slice(cursor)));
+				break;
+			}
 
-      if (bestStart > cursor) {
-        fragment.appendChild(doc.createTextNode(source.slice(cursor, bestStart)));
-      }
+			if (bestStart > cursor) {
+				fragment.appendChild(
+					doc.createTextNode(source.slice(cursor, bestStart)),
+				);
+			}
 
-      const span = doc.createElement('span');
-      span.className = 'original-glossary-term';
-      span.setAttribute('data-source-term', bestTerm?.sourceTerm || '');
-      span.setAttribute('data-target-term', bestTerm?.targetTerm || '');
-      span.textContent = `${source.slice(bestStart, bestEnd)}(${bestTerm?.targetTerm || ''})`;
-      fragment.appendChild(span);
+			const span = doc.createElement("span");
+			span.className = "original-glossary-term";
+			span.setAttribute("data-source-term", bestTerm?.sourceTerm || "");
+			span.setAttribute("data-target-term", bestTerm?.targetTerm || "");
+			span.textContent = `${source.slice(bestStart, bestEnd)}(${bestTerm?.targetTerm || ""})`;
+			fragment.appendChild(span);
 
-      matched = true;
-      cursor = bestEnd;
-    }
+			matched = true;
+			cursor = bestEnd;
+		}
 
-    if (matched) textNode.replaceWith(fragment);
-  });
+		if (matched) textNode.replaceWith(fragment);
+	});
 };
 
 // 과거 버전에서 AI_DRAFT에 삽입된 glossary-term 마크업 제거
 const removeLegacyGlossaryMarkup = (html: string) => {
-  if (!html) return html;
-  try {
-    const parser = new DOMParser();
-    const doc = parser.parseFromString(html, 'text/html');
-    const glossaryNodes = doc.querySelectorAll('span.glossary-term');
+	if (!html) return html;
+	try {
+		const parser = new DOMParser();
+		const doc = parser.parseFromString(html, "text/html");
+		const glossaryNodes = doc.querySelectorAll("span.glossary-term");
 
-    glossaryNodes.forEach((node) => {
-      const original = node.getAttribute('data-original') || '';
-      const text = node.textContent || '';
-      const suffix = original ? `(${original})` : '';
-      const restored = suffix && text.endsWith(suffix) ? text.slice(0, -suffix.length) : text;
-      node.replaceWith(doc.createTextNode(restored));
-    });
+		glossaryNodes.forEach((node) => {
+			const original = node.getAttribute("data-original") || "";
+			const text = node.textContent || "";
+			const suffix = original ? `(${original})` : "";
+			const restored =
+				suffix && text.endsWith(suffix) ? text.slice(0, -suffix.length) : text;
+			node.replaceWith(doc.createTextNode(restored));
+		});
 
-    return doc.documentElement.outerHTML;
-  } catch {
-    return html;
-  }
+		return doc.documentElement.outerHTML;
+	} catch {
+		return html;
+	}
 };
 
 // STEP 1: 크롤링 주소 입력
 const Step1CrawlingInput: React.FC<{
-  url: string;
-  setUrl: (url: string) => void;
-  onExecute: () => void;
-  onManualPaste?: () => void;
-  isLoading: boolean;
-  loadingProgress?: number;
-  draftDocuments?: DocumentResponse[];
-  onLoadDraft?: (doc: DocumentResponse) => void;
-}> = ({ url, setUrl, onExecute, onManualPaste, isLoading, loadingProgress = 0, draftDocuments = [], onLoadDraft }) => {
-  const [showDraftList, setShowDraftList] = useState(false);
+	url: string;
+	setUrl: (url: string) => void;
+	onExecute: () => void;
+	onManualPaste?: () => void;
+	isLoading: boolean;
+	loadingProgress?: number;
+	draftDocuments?: DocumentResponse[];
+	onLoadDraft?: (doc: DocumentResponse) => void;
+}> = ({
+	url,
+	setUrl,
+	onExecute,
+	onManualPaste,
+	isLoading,
+	loadingProgress = 0,
+	draftDocuments = [],
+	onLoadDraft,
+}) => {
+	const [showDraftList, setShowDraftList] = useState(false);
 
-  return (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        height: '100%',
-        gap: '24px',
-      }}
-    >
-      {/* 임시저장 문서 섹션 - 항상 표시 */}
-      <div
-        style={{
-          width: '100%',
-          maxWidth: '600px',
-          padding: '16px',
-          backgroundColor: '#FFF9E6',
-          border: '1px solid #FFE5B4',
-          borderRadius: '8px',
-        }}
-      >
-        <div style={{ 
-          display: 'flex', 
-          justifyContent: 'space-between', 
-          alignItems: 'center', 
-          marginBottom: '12px',
-          minHeight: '28px',
-        }}>
-          <span style={{ 
-            fontSize: '13px', 
-            fontWeight: 600, 
-            color: '#8B4513',
-            lineHeight: '20px',
-            display: 'flex',
-            alignItems: 'center',
-          }}>
-            임시저장된 문서 ({draftDocuments.length}개)
-          </span>
-          {draftDocuments.length > 0 && (
-            <button
-              onClick={() => setShowDraftList(!showDraftList)}
-              style={{
-                padding: '4px 8px',
-                fontSize: '12px',
-                border: '1px solid #D3A86A',
-                borderRadius: '4px',
-                backgroundColor: '#FFFFFF',
-                color: '#8B4513',
-                cursor: 'pointer',
-                height: '24px',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                lineHeight: '1',
-              }}
-            >
-              {showDraftList ? '숨기기' : '보기'}
-            </button>
-          )}
-        </div>
-        {draftDocuments.length === 0 ? (
-          <div style={{ 
-            padding: '12px', 
-            textAlign: 'center', 
-            color: '#8B4513', 
-            fontSize: '12px',
-            fontStyle: 'italic',
-          }}>
-            임시저장된 문서가 없습니다.
-          </div>
-        ) : showDraftList && (
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-            {draftDocuments.map((doc) => (
-              <div
-                key={doc.id}
-                style={{
-                  padding: '12px',
-                  backgroundColor: '#FFFFFF',
-                  border: '1px solid #D3A86A',
-                  borderRadius: '4px',
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  alignItems: 'center',
-                }}
-              >
-                <div style={{ flex: 1 }}>
-                  <div style={{ fontSize: '13px', fontWeight: 500, color: '#000000', marginBottom: '4px' }}>
-                    {doc.title}
-                  </div>
-                  <div style={{ fontSize: '11px', color: '#666' }}>
-                    {doc.originalUrl}
-                  </div>
-                </div>
-                <Button
-                  variant="secondary"
-                  onClick={() => onLoadDraft?.(doc)}
-                  style={{ fontSize: '12px', padding: '6px 12px' }}
-                >
-                  불러오기
-                </Button>
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
+	return (
+		<div
+			style={{
+				display: "flex",
+				flexDirection: "column",
+				alignItems: "center",
+				justifyContent: "center",
+				height: "100%",
+				gap: "24px",
+			}}
+		>
+			{/* 임시저장 문서 섹션 - 항상 표시 */}
+			<div
+				style={{
+					width: "100%",
+					maxWidth: "600px",
+					padding: "16px",
+					backgroundColor: "#FFF9E6",
+					border: "1px solid #FFE5B4",
+					borderRadius: "8px",
+				}}
+			>
+				<div
+					style={{
+						display: "flex",
+						justifyContent: "space-between",
+						alignItems: "center",
+						marginBottom: "12px",
+						minHeight: "28px",
+					}}
+				>
+					<span
+						style={{
+							fontSize: "13px",
+							fontWeight: 600,
+							color: "#8B4513",
+							lineHeight: "20px",
+							display: "flex",
+							alignItems: "center",
+						}}
+					>
+						임시저장된 문서 ({draftDocuments.length}개)
+					</span>
+					{draftDocuments.length > 0 && (
+						<button
+							onClick={() => setShowDraftList(!showDraftList)}
+							style={{
+								padding: "4px 8px",
+								fontSize: "12px",
+								border: "1px solid #D3A86A",
+								borderRadius: "4px",
+								backgroundColor: "#FFFFFF",
+								color: "#8B4513",
+								cursor: "pointer",
+								height: "24px",
+								display: "flex",
+								alignItems: "center",
+								justifyContent: "center",
+								lineHeight: "1",
+							}}
+						>
+							{showDraftList ? "숨기기" : "보기"}
+						</button>
+					)}
+				</div>
+				{draftDocuments.length === 0 ? (
+					<div
+						style={{
+							padding: "12px",
+							textAlign: "center",
+							color: "#8B4513",
+							fontSize: "12px",
+							fontStyle: "italic",
+						}}
+					>
+						임시저장된 문서가 없습니다.
+					</div>
+				) : (
+					showDraftList && (
+						<div
+							style={{ display: "flex", flexDirection: "column", gap: "8px" }}
+						>
+							{draftDocuments.map((doc) => (
+								<div
+									key={doc.id}
+									style={{
+										padding: "12px",
+										backgroundColor: "#FFFFFF",
+										border: "1px solid #D3A86A",
+										borderRadius: "4px",
+										display: "flex",
+										justifyContent: "space-between",
+										alignItems: "center",
+									}}
+								>
+									<div style={{ flex: 1 }}>
+										<div
+											style={{
+												fontSize: "13px",
+												fontWeight: 500,
+												color: "#000000",
+												marginBottom: "4px",
+											}}
+										>
+											{doc.title}
+										</div>
+										<div style={{ fontSize: "11px", color: "#666" }}>
+											{doc.originalUrl}
+										</div>
+									</div>
+									<Button
+										variant="secondary"
+										onClick={() => onLoadDraft?.(doc)}
+										style={{ fontSize: "12px", padding: "6px 12px" }}
+									>
+										불러오기
+									</Button>
+								</div>
+							))}
+						</div>
+					)
+				)}
+			</div>
 
-      {/* 기존 URL 입력 */}
-      <div
-        style={{
-          width: '100%',
-          maxWidth: '600px',
-        }}
-      >
-        <input
-          type="url"
-          value={url}
-          onChange={(e) => setUrl(e.target.value)}
-          placeholder="https://example.com"
-          disabled={isLoading}
-          style={{
-            width: '100%',
-            padding: '12px 16px',
-            fontSize: '14px',
-            fontFamily: 'system-ui, Pretendard, sans-serif',
-            border: '1px solid #C0C0C0',
-            borderRadius: '8px',
-            backgroundColor: '#FFFFFF',
-            color: '#000000',
-          }}
-        />
-      </div>
-      <div style={{ display: 'flex', alignItems: 'center', gap: '12px', flexWrap: 'wrap' }}>
-        <Button
-          variant="primary"
-          onClick={onExecute}
-          disabled={isLoading || !url.trim()}
-        >
-          {isLoading ? '크롤링 중...' : '크롤링 실행'}
-        </Button>
-        <Button
-          variant="secondary"
-          onClick={onManualPaste}
-          disabled={isLoading}
-          style={{ fontSize: '13px' }}
-        >
-          수동 서식 넣기
-        </Button>
-        {isLoading && loadingProgress > 0 && (
-          <span style={{ fontSize: '13px', color: '#696969', fontWeight: 600 }}>
-            {Math.round(loadingProgress)}%
-          </span>
-        )}
-      </div>
-      {onManualPaste && (
-        <span style={{ fontSize: '12px', color: '#696969' }}>
-          크롤링이 잘 되지 않을 때 웹사이트에서 복사한 내용을 붙여넣기 할 수 있습니다
-        </span>
-      )}
-      {url.trim().toLowerCase().endsWith('.pdf') && (
-        <div
-          style={{
-            width: '100%',
-            maxWidth: '600px',
-            padding: '12px 16px',
-            backgroundColor: '#EFF6FF',
-            border: '1px solid #BFDBFE',
-            borderRadius: '8px',
-            display: 'flex',
-            alignItems: 'flex-start',
-            gap: '10px',
-          }}
-        >
-          <span style={{ fontSize: '18px', flexShrink: 0 }}>📄</span>
-          <div>
-            <div style={{ fontSize: '13px', fontWeight: 600, color: '#1D4ED8', marginBottom: '4px' }}>
-              PDF 문서가 감지됐습니다
-            </div>
-            <div style={{ fontSize: '12px', color: '#1E40AF', lineHeight: '1.5' }}>
-              PDF URL은 텍스트를 자동으로 추출하여 번역 등록합니다. 일반 웹페이지와 동일하게 크롤링 실행을 눌러주세요.
-            </div>
-          </div>
-        </div>
-      )}
-    </div>
-  );
+			{/* 기존 URL 입력 */}
+			<div
+				style={{
+					width: "100%",
+					maxWidth: "600px",
+				}}
+			>
+				<input
+					type="url"
+					value={url}
+					onChange={(e) => setUrl(e.target.value)}
+					placeholder="https://example.com"
+					disabled={isLoading}
+					style={{
+						width: "100%",
+						padding: "12px 16px",
+						fontSize: "14px",
+						fontFamily: "system-ui, Pretendard, sans-serif",
+						border: "1px solid #C0C0C0",
+						borderRadius: "8px",
+						backgroundColor: "#FFFFFF",
+						color: "#000000",
+					}}
+				/>
+			</div>
+			<div
+				style={{
+					display: "flex",
+					alignItems: "center",
+					gap: "12px",
+					flexWrap: "wrap",
+				}}
+			>
+				<Button
+					variant="primary"
+					onClick={onExecute}
+					disabled={isLoading || !url.trim()}
+				>
+					{isLoading ? "크롤링 중..." : "크롤링 실행"}
+				</Button>
+				<Button
+					variant="secondary"
+					onClick={onManualPaste}
+					disabled={isLoading}
+					style={{ fontSize: "13px" }}
+				>
+					수동 서식 넣기
+				</Button>
+				{isLoading && loadingProgress > 0 && (
+					<span style={{ fontSize: "13px", color: "#696969", fontWeight: 600 }}>
+						{Math.round(loadingProgress)}%
+					</span>
+				)}
+			</div>
+			{onManualPaste && (
+				<span style={{ fontSize: "12px", color: "#696969" }}>
+					크롤링이 잘 되지 않을 때 웹사이트에서 복사한 내용을 붙여넣기 할 수
+					있습니다
+				</span>
+			)}
+			{url.trim().toLowerCase().endsWith(".pdf") && (
+				<div
+					style={{
+						width: "100%",
+						maxWidth: "600px",
+						padding: "12px 16px",
+						backgroundColor: "#EFF6FF",
+						border: "1px solid #BFDBFE",
+						borderRadius: "8px",
+						display: "flex",
+						alignItems: "flex-start",
+						gap: "10px",
+					}}
+				>
+					<span style={{ fontSize: "18px", flexShrink: 0 }}>📄</span>
+					<div>
+						<div
+							style={{
+								fontSize: "13px",
+								fontWeight: 600,
+								color: "#1D4ED8",
+								marginBottom: "4px",
+							}}
+						>
+							PDF 문서가 감지됐습니다
+						</div>
+						<div
+							style={{ fontSize: "12px", color: "#1E40AF", lineHeight: "1.5" }}
+						>
+							PDF URL은 텍스트를 자동으로 추출하여 번역 등록합니다. 일반
+							웹페이지와 동일하게 크롤링 실행을 눌러주세요.
+						</div>
+					</div>
+				</div>
+			)}
+		</div>
+	);
 };
 
 // STEP 2: 크롤링 결과 + 영역 선택 (Translation.jsx 방식, 스타일만 회색)
 const Step2AreaSelection: React.FC<{
-  html: string;
-  selectedAreas: SelectedArea[];
-  onAreaSelect: (area: SelectedArea) => void;
-  onAreaRemove: (id: string) => void;
-  onHtmlUpdate?: (html: string) => void; // iframe의 현재 HTML 업데이트
+	html: string;
+	selectedAreas: SelectedArea[];
+	onAreaSelect: (area: SelectedArea) => void;
+	onAreaRemove: (id: string) => void;
+	onHtmlUpdate?: (html: string) => void; // iframe의 현재 HTML 업데이트
 }> = ({ html, selectedAreas, onAreaSelect, onAreaRemove, onHtmlUpdate }) => {
-  const iframeRef = React.useRef<HTMLIFrameElement>(null);
-  const [hoveredAreaId, setHoveredAreaId] = React.useState<string | null>(null);
-  const [pageLoaded, setPageLoaded] = React.useState(false);
-  
-  const listenersAttached = React.useRef(false);
-  const initialRestoreDone = React.useRef(false);
-  const isUserInteraction = React.useRef(false);
-  
-  // 초기 로드 시 한 번만 선택 상태 복원
-  React.useEffect(() => {
-    if (!iframeRef.current || !pageLoaded || initialRestoreDone.current) return;
-    
-    const iframe = iframeRef.current;
-    const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-    if (!iframeDoc) return;
-    
-    if (selectedAreas.length > 0) {
-      selectedAreas.forEach(area => {
-        const el = iframeDoc.querySelector(`[data-transflow-id="${area.id}"]`) as HTMLElement;
-        if (el) {
-          el.classList.add('transflow-selected');
-        }
-      });
-    }
-    
-    if (onHtmlUpdate) {
-      const currentHtml = iframeDoc.documentElement.outerHTML;
-      onHtmlUpdate(currentHtml);
-    }
-    
-    initialRestoreDone.current = true;
-  }, [pageLoaded]);
-  
-  // 사용자 인터랙션 후 selectedAreas 변경 시에만 동기화
-  React.useEffect(() => {
-    if (!iframeRef.current || !pageLoaded || !initialRestoreDone.current || !isUserInteraction.current) return;
-    
-    const iframe = iframeRef.current;
-    const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-    if (!iframeDoc) return;
-    
-    if (onHtmlUpdate) {
-      const currentHtml = iframeDoc.documentElement.outerHTML;
-      onHtmlUpdate(currentHtml);
-    }
-    
-    isUserInteraction.current = false;
-  }, [selectedAreas]);
+	const iframeRef = React.useRef<HTMLIFrameElement>(null);
+	const [hoveredAreaId, setHoveredAreaId] = React.useState<string | null>(null);
+	const [pageLoaded, setPageLoaded] = React.useState(false);
 
-  // ⭐ hoveredAreaId가 변경될 때 iframe에서 해당 영역 하이라이트
-  React.useEffect(() => {
-    if (!iframeRef.current || !pageLoaded) return;
-    
-    const iframe = iframeRef.current;
-    const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-    if (!iframeDoc) return;
-    
-    // 기존 호버 하이라이트 제거
-    iframeDoc.querySelectorAll('.transflow-hovering').forEach(el => {
-      el.classList.remove('transflow-hovering');
-    });
-    
-    // hoveredAreaId에 해당하는 요소 하이라이트
-    if (hoveredAreaId) {
-      const el = iframeDoc.querySelector(`[data-transflow-id="${hoveredAreaId}"]`) as HTMLElement;
-      if (el && !el.classList.contains('transflow-selected')) {
-        el.classList.add('transflow-hovering');
-        // 스크롤하여 보이도록 (필요한 경우)
-        el.scrollIntoView({ behavior: 'smooth', block: 'center' });
-      }
-    }
-  }, [hoveredAreaId, pageLoaded]);
+	const listenersAttached = React.useRef(false);
+	const initialRestoreDone = React.useRef(false);
+	const isUserInteraction = React.useRef(false);
 
-  // 영역 선택 모드 활성화 함수 (Translation.jsx와 동일한 구조)
-  // useCallback을 제거하고 일반 함수로 변경 (의존성 문제 해결)
-  const enableElementSelection = (iframeDoc: Document) => {
-    // 이미 리스너가 붙어있으면 중복 방지
-    if (listenersAttached.current) {
-      return;
-    }
-    // 기존 스타일 제거
-    const existingStyle = iframeDoc.getElementById('transflow-selection-style');
-    if (existingStyle) {
-      existingStyle.remove();
-    }
-    
-    // Translation.jsx와 동일한 스타일 추가
-    const style = iframeDoc.createElement('style');
-    style.id = 'transflow-selection-style';
-    style.textContent = `
+	// 초기 로드 시 한 번만 선택 상태 복원
+	React.useEffect(() => {
+		if (!iframeRef.current || !pageLoaded || initialRestoreDone.current) return;
+
+		const iframe = iframeRef.current;
+		const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
+		if (!iframeDoc) return;
+
+		if (selectedAreas.length > 0) {
+			selectedAreas.forEach((area) => {
+				const el = iframeDoc.querySelector(
+					`[data-transflow-id="${area.id}"]`,
+				) as HTMLElement;
+				if (el) {
+					el.classList.add("transflow-selected");
+				}
+			});
+		}
+
+		if (onHtmlUpdate) {
+			const currentHtml = iframeDoc.documentElement.outerHTML;
+			onHtmlUpdate(currentHtml);
+		}
+
+		initialRestoreDone.current = true;
+	}, [pageLoaded]);
+
+	// 사용자 인터랙션 후 selectedAreas 변경 시에만 동기화
+	React.useEffect(() => {
+		if (
+			!iframeRef.current ||
+			!pageLoaded ||
+			!initialRestoreDone.current ||
+			!isUserInteraction.current
+		)
+			return;
+
+		const iframe = iframeRef.current;
+		const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
+		if (!iframeDoc) return;
+
+		if (onHtmlUpdate) {
+			const currentHtml = iframeDoc.documentElement.outerHTML;
+			onHtmlUpdate(currentHtml);
+		}
+
+		isUserInteraction.current = false;
+	}, [selectedAreas]);
+
+	// ⭐ hoveredAreaId가 변경될 때 iframe에서 해당 영역 하이라이트
+	React.useEffect(() => {
+		if (!iframeRef.current || !pageLoaded) return;
+
+		const iframe = iframeRef.current;
+		const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
+		if (!iframeDoc) return;
+
+		// 기존 호버 하이라이트 제거
+		iframeDoc.querySelectorAll(".transflow-hovering").forEach((el) => {
+			el.classList.remove("transflow-hovering");
+		});
+
+		// hoveredAreaId에 해당하는 요소 하이라이트
+		if (hoveredAreaId) {
+			const el = iframeDoc.querySelector(
+				`[data-transflow-id="${hoveredAreaId}"]`,
+			) as HTMLElement;
+			if (el && !el.classList.contains("transflow-selected")) {
+				el.classList.add("transflow-hovering");
+				// 스크롤하여 보이도록 (필요한 경우)
+				el.scrollIntoView({ behavior: "smooth", block: "center" });
+			}
+		}
+	}, [hoveredAreaId, pageLoaded]);
+
+	// 영역 선택 모드 활성화 함수 (Translation.jsx와 동일한 구조)
+	// useCallback을 제거하고 일반 함수로 변경 (의존성 문제 해결)
+	const enableElementSelection = (iframeDoc: Document) => {
+		// 이미 리스너가 붙어있으면 중복 방지
+		if (listenersAttached.current) {
+			return;
+		}
+		// 기존 스타일 제거
+		const existingStyle = iframeDoc.getElementById("transflow-selection-style");
+		if (existingStyle) {
+			existingStyle.remove();
+		}
+
+		// Translation.jsx와 동일한 스타일 추가
+		const style = iframeDoc.createElement("style");
+		style.id = "transflow-selection-style";
+		style.textContent = `
       * {
         user-select: none !important;
         -webkit-user-select: none !important;
@@ -463,511 +561,634 @@ const Step2AreaSelection: React.FC<{
         cursor: crosshair !important;
       }
     `;
-    iframeDoc.head.appendChild(style);
-    
-    let highlightedElement: HTMLElement | null = null;
-    
-    const updateSelectedElements = () => {
-      const newSelected: any[] = [];
-      iframeDoc.querySelectorAll('.transflow-selected').forEach((el) => {
-        const elementId = el.getAttribute('data-transflow-id');
-        if (elementId) {
-          newSelected.push({
-            html: (el as HTMLElement).outerHTML,
-            id: elementId
-          });
-        }
-      });
-      
-      newSelected.forEach(item => {
-        const existingArea = selectedAreas.find(area => area.id === item.id);
-        if (!existingArea) {
-          const el = iframeDoc.querySelector(`[data-transflow-id="${item.id}"]`) as HTMLElement;
-          let selector = '';
-          if (el && el.id) {
-            selector = `#${el.id}`;
-          } else if (el && el.className) {
-            const classes = Array.from(el.classList).filter(c => !c.startsWith('transflow-')).join('.');
-            if (classes) {
-              selector = `${el.tagName.toLowerCase()}.${classes}`;
-            }
-          } else if (el) {
-            selector = el.tagName.toLowerCase();
-          }
-          
-          isUserInteraction.current = true;
-          onAreaSelect({
-            id: item.id,
-            selector,
-            html: item.html,
-            order: selectedAreas.length + 1,
-          });
-        }
-      });
-    };
-    
-    // 마우스 오버 시 하이라이트
-    const handleMouseOver = (e: MouseEvent) => {
-      const target = e.target as HTMLElement;
-      if (!target || target === iframeDoc.body || target === iframeDoc.documentElement) return;
-      if (target.tagName === 'SCRIPT' || target.tagName === 'STYLE' || target.tagName === 'NOSCRIPT') return;
-      
-      if (highlightedElement && highlightedElement !== target) {
-        highlightedElement.classList.remove('transflow-hovering');
-      }
-      if (!target.classList.contains('transflow-selected')) {
-        target.classList.add('transflow-hovering');
-        highlightedElement = target;
-      }
-    };
-    
-    // 마우스 아웃 시 하이라이트 제거
-    const handleMouseOut = (e: MouseEvent) => {
-      const target = e.target as HTMLElement;
-      if (target && !target.classList.contains('transflow-selected')) {
-        target.classList.remove('transflow-hovering');
-      }
-    };
-    
-    const handleClick = (e: MouseEvent) => {
-      const target = e.target as HTMLElement;
-      if (!target || target === iframeDoc.body || target === iframeDoc.documentElement) return;
-      if (target.tagName === 'SCRIPT' || target.tagName === 'STYLE' || target.tagName === 'NOSCRIPT') return;
-      
-      e.preventDefault();
-      e.stopPropagation();
-      
-      const linkElement = target.closest('a') || (target.tagName === 'A' ? target : null);
-      const elementToSelect = linkElement || target;
-      
-      let elementId = elementToSelect.getAttribute('data-transflow-id');
-      if (!elementId) {
-        elementId = `transflow-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
-        elementToSelect.setAttribute('data-transflow-id', elementId);
-      }
-      
-      isUserInteraction.current = true;
-      
-      if (elementToSelect.classList.contains('transflow-selected')) {
-        elementToSelect.classList.remove('transflow-selected');
-        onAreaRemove(elementId);
-      } else {
-        elementToSelect.classList.add('transflow-selected');
-        updateSelectedElements();
-      }
-      
-      elementToSelect.classList.remove('transflow-hovering');
-      highlightedElement = null;
-    };
-    
-    // ⚡ 최적화: 이벤트 위임 사용 (body에만 리스너 추가)
-    // 모든 요소에 개별 리스너를 추가하는 대신 body에서 이벤트 위임 사용
-    if (iframeDoc.body) {
-      // mouseover 이벤트 위임
-      iframeDoc.body.addEventListener('mouseover', (e) => {
-        const target = e.target as HTMLElement;
-        if (!target || target === iframeDoc.body || target === iframeDoc.documentElement) return;
-        if (target.tagName === 'SCRIPT' || target.tagName === 'STYLE' || target.tagName === 'NOSCRIPT') return;
-        handleMouseOver(e);
-      }, true);
-      
-      // mouseout 이벤트 위임
-      iframeDoc.body.addEventListener('mouseout', (e) => {
-        const target = e.target as HTMLElement;
-        if (target && !target.classList.contains('transflow-selected')) {
-          handleMouseOut(e);
-        }
-      }, true);
-      
-      // click 이벤트 위임
-      iframeDoc.body.addEventListener('click', (e) => {
-        const target = e.target as HTMLElement;
-        if (!target || target === iframeDoc.body || target === iframeDoc.documentElement) return;
-        if (target.tagName === 'SCRIPT' || target.tagName === 'STYLE' || target.tagName === 'NOSCRIPT') return;
-        handleClick(e);
-      }, true);
-      
-    }
-    
-    listenersAttached.current = true;
-  };
+		iframeDoc.head.appendChild(style);
 
-  useEffect(() => {
-    listenersAttached.current = false;
-    initialRestoreDone.current = false;
-    isUserInteraction.current = false;
-    setPageLoaded(false);
-    
-    if (iframeRef.current && html) {
-      const iframe = iframeRef.current;
-      const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-      
-      if (iframeDoc) {
-        let htmlContent = html;
-        
-        // 임시저장에서 불러온 HTML에서 선택 상태 클래스 제거
-        htmlContent = htmlContent.replace(/\s*class="[^"]*transflow-selected[^"]*"/g, (match) => {
-          const cleaned = match.replace(/\btransflow-selected\b\s*/g, '').replace(/\s+/g, ' ').trim();
-          return cleaned === 'class=""' ? '' : cleaned;
-        });
-        htmlContent = htmlContent.replace(/\s*class='[^']*transflow-selected[^']*'/g, (match) => {
-          const cleaned = match.replace(/\btransflow-selected\b\s*/g, '').replace(/\s+/g, ' ').trim();
-          return cleaned === "class=''" ? '' : cleaned;
-        });
-        
-        // 크롤링된 페이지의 스크립트 제거 (변수 중복 선언 오류 방지)
-        htmlContent = htmlContent.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '');
-        
-        const hasDoctype = htmlContent.trim().toLowerCase().startsWith('<!doctype');
-        const hasHtml = htmlContent.includes('<html');
-        const hasBody = htmlContent.includes('<body');
-        
-        if (!hasDoctype || !hasHtml || !hasBody) {
-          if (!htmlContent.includes('<body')) {
-            htmlContent = `<body>${htmlContent}</body>`;
-          }
-          if (!htmlContent.includes('<html')) {
-            htmlContent = `<html>${htmlContent}</html>`;
-          }
-          if (!htmlContent.includes('<head>')) {
-            htmlContent = htmlContent.replace('<html>', '<html><head></head>');
-          }
-          if (!hasDoctype) {
-            htmlContent = `<!DOCTYPE html>${htmlContent}`;
-          }
-        }
-        
-        // CSS 추가 (Translation.jsx와 동일)
-        const cssMatch = html.match(/<style id="transflow-css">[\s\S]*?<\/style>/i);
-        if (cssMatch && !htmlContent.includes('transflow-css')) {
-          const cssTag = cssMatch[0];
-          if (htmlContent.includes('</head>')) {
-            htmlContent = htmlContent.replace('</head>', `${cssTag}\n</head>`);
-          } else if (htmlContent.includes('<html')) {
-            htmlContent = htmlContent.replace('<html>', `<html><head>${cssTag}</head>`);
-          }
-        }
-        
-        try {
-          iframeDoc.open();
-          iframeDoc.write(htmlContent);
-          iframeDoc.close();
-        } catch (error) {
-          // iframe 내부 스크립트 에러는 무시 (크롤링된 페이지의 스크립트 에러)
-          console.warn('iframe write error (ignored):', error);
-        }
-        
-        // iframe 내부 스크립트 에러 무시 (크롤링된 페이지의 스크립트 에러는 무시)
-        if (iframe.contentWindow) {
-          iframe.contentWindow.addEventListener('error', (e) => {
-            // iframe 내부 에러는 무시 (크롤링된 페이지의 스크립트 에러)
-            e.stopPropagation();
-            return true;
-          }, true);
-        }
-        
-        // 영역 선택 모드 활성화 (Translation.jsx와 동일한 방식)
-        // pageLoaded를 체크하지 않고 직접 호출 (클로저 문제 해결)
-        const checkAndEnableSelection = () => {
-          try {
-            if (iframeDoc.body && iframeDoc.body.children.length > 0) {
-              enableElementSelection(iframeDoc);
-              setPageLoaded(true);
-            } else {
-              setTimeout(checkAndEnableSelection, 100);
-            }
-          } catch (error) {
-            // iframe 내부 스크립트 에러는 무시
-          }
-        };
-        
-        setTimeout(checkAndEnableSelection, 300);
-      }
-    }
-  }, [html]); // enableElementSelection 의존성 제거!
+		let highlightedElement: HTMLElement | null = null;
 
-  return (
-    <div
-      style={{
-        display: 'flex',
-        height: '100%',
-        gap: '16px',
-      }}
-    >
-      {/* 좌측 70%: 크롤링된 웹 페이지 */}
-      <div
-        style={{
-          flex: '0 0 70%',
-          border: '1px solid #C0C0C0',
-          borderRadius: '8px',
-          overflow: 'auto',
-          backgroundColor: '#FFFFFF',
-        }}
-      >
-        <iframe
-          ref={iframeRef}
-          style={{
-            width: '100%',
-            height: '100%',
-            border: 'none',
-          }}
-          title="Crawled page"
-        />
-      </div>
+		const updateSelectedElements = () => {
+			const newSelected: any[] = [];
+			iframeDoc.querySelectorAll(".transflow-selected").forEach((el) => {
+				const elementId = el.getAttribute("data-transflow-id");
+				if (elementId) {
+					newSelected.push({
+						html: (el as HTMLElement).outerHTML,
+						id: elementId,
+					});
+				}
+			});
 
-      {/* 우측 30%: 선택된 영역 리스트 */}
-      <div
-        style={{
-          flex: '0 0 30%',
-          border: '1px solid #C0C0C0',
-          borderRadius: '8px',
-          padding: '16px',
-          backgroundColor: '#DCDCDC',
-          overflow: 'auto',
-        }}
-      >
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '16px' }}>
-        <h3
-          style={{
-            fontSize: '14px',
-            fontWeight: 600,
-            color: '#000000',
-            fontFamily: 'system-ui, Pretendard, sans-serif',
-              margin: 0,
-          }}
-        >
-          선택된 영역 ({selectedAreas.length})
-        </h3>
-          {selectedAreas.length > 0 && (
-            <Button
-              variant="secondary"
-              onClick={() => {
-                selectedAreas.forEach(area => onAreaRemove(area.id));
-              }}
-              style={{ fontSize: '12px', padding: '4px 8px' }}
-            >
-              전체 선택 취소
-            </Button>
-          )}
-        </div>
-        {selectedAreas.length === 0 ? (
-          <div
-            style={{
-              fontSize: '13px',
-              color: '#696969',
-              fontFamily: 'system-ui, Pretendard, sans-serif',
-            }}
-          >
-            영역을 선택하세요
-          </div>
-        ) : (
-          <div className="space-y-2">
-            {selectedAreas.map((area, idx) => (
-              <div
-                key={area.id}
-                onMouseEnter={() => setHoveredAreaId(area.id)}
-                onMouseLeave={() => setHoveredAreaId(null)}
-                style={{
-                  padding: '12px',
-                  border: '1px solid #C0C0C0',
-                  borderRadius: '8px',
-                  backgroundColor: hoveredAreaId === area.id ? '#D3D3D3' : '#FFFFFF',
-                  cursor: 'pointer',
-                  transition: 'background-color 0.2s',
-                }}
-              >
-                <div
-                  style={{
-                    fontSize: '13px',
-                    fontWeight: 500,
-                    color: '#000000',
-                    fontFamily: 'system-ui, Pretendard, sans-serif',
-                    marginBottom: '8px',
-                  }}
-                >
-                  영역 {idx + 1}
-                </div>
-                <Button
-                  variant="secondary"
-                  onClick={() => onAreaRemove(area.id)}
-                  style={{ fontSize: '12px', padding: '4px 8px' }}
-                >
-                  제거
-                </Button>
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
-    </div>
-  );
+			newSelected.forEach((item) => {
+				const existingArea = selectedAreas.find((area) => area.id === item.id);
+				if (!existingArea) {
+					const el = iframeDoc.querySelector(
+						`[data-transflow-id="${item.id}"]`,
+					) as HTMLElement;
+					let selector = "";
+					if (el && el.id) {
+						selector = `#${el.id}`;
+					} else if (el && el.className) {
+						const classes = Array.from(el.classList)
+							.filter((c) => !c.startsWith("transflow-"))
+							.join(".");
+						if (classes) {
+							selector = `${el.tagName.toLowerCase()}.${classes}`;
+						}
+					} else if (el) {
+						selector = el.tagName.toLowerCase();
+					}
+
+					isUserInteraction.current = true;
+					onAreaSelect({
+						id: item.id,
+						selector,
+						html: item.html,
+						order: selectedAreas.length + 1,
+					});
+				}
+			});
+		};
+
+		// 마우스 오버 시 하이라이트
+		const handleMouseOver = (e: MouseEvent) => {
+			const target = e.target as HTMLElement;
+			if (
+				!target ||
+				target === iframeDoc.body ||
+				target === iframeDoc.documentElement
+			)
+				return;
+			if (
+				target.tagName === "SCRIPT" ||
+				target.tagName === "STYLE" ||
+				target.tagName === "NOSCRIPT"
+			)
+				return;
+
+			if (highlightedElement && highlightedElement !== target) {
+				highlightedElement.classList.remove("transflow-hovering");
+			}
+			if (!target.classList.contains("transflow-selected")) {
+				target.classList.add("transflow-hovering");
+				highlightedElement = target;
+			}
+		};
+
+		// 마우스 아웃 시 하이라이트 제거
+		const handleMouseOut = (e: MouseEvent) => {
+			const target = e.target as HTMLElement;
+			if (target && !target.classList.contains("transflow-selected")) {
+				target.classList.remove("transflow-hovering");
+			}
+		};
+
+		const handleClick = (e: MouseEvent) => {
+			const target = e.target as HTMLElement;
+			if (
+				!target ||
+				target === iframeDoc.body ||
+				target === iframeDoc.documentElement
+			)
+				return;
+			if (
+				target.tagName === "SCRIPT" ||
+				target.tagName === "STYLE" ||
+				target.tagName === "NOSCRIPT"
+			)
+				return;
+
+			e.preventDefault();
+			e.stopPropagation();
+
+			const linkElement =
+				target.closest("a") || (target.tagName === "A" ? target : null);
+			const elementToSelect = linkElement || target;
+
+			let elementId = elementToSelect.getAttribute("data-transflow-id");
+			if (!elementId) {
+				elementId = `transflow-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+				elementToSelect.setAttribute("data-transflow-id", elementId);
+			}
+
+			isUserInteraction.current = true;
+
+			if (elementToSelect.classList.contains("transflow-selected")) {
+				elementToSelect.classList.remove("transflow-selected");
+				onAreaRemove(elementId);
+			} else {
+				elementToSelect.classList.add("transflow-selected");
+				updateSelectedElements();
+			}
+
+			elementToSelect.classList.remove("transflow-hovering");
+			highlightedElement = null;
+		};
+
+		// ⚡ 최적화: 이벤트 위임 사용 (body에만 리스너 추가)
+		// 모든 요소에 개별 리스너를 추가하는 대신 body에서 이벤트 위임 사용
+		if (iframeDoc.body) {
+			// mouseover 이벤트 위임
+			iframeDoc.body.addEventListener(
+				"mouseover",
+				(e) => {
+					const target = e.target as HTMLElement;
+					if (
+						!target ||
+						target === iframeDoc.body ||
+						target === iframeDoc.documentElement
+					)
+						return;
+					if (
+						target.tagName === "SCRIPT" ||
+						target.tagName === "STYLE" ||
+						target.tagName === "NOSCRIPT"
+					)
+						return;
+					handleMouseOver(e);
+				},
+				true,
+			);
+
+			// mouseout 이벤트 위임
+			iframeDoc.body.addEventListener(
+				"mouseout",
+				(e) => {
+					const target = e.target as HTMLElement;
+					if (target && !target.classList.contains("transflow-selected")) {
+						handleMouseOut(e);
+					}
+				},
+				true,
+			);
+
+			// click 이벤트 위임
+			iframeDoc.body.addEventListener(
+				"click",
+				(e) => {
+					const target = e.target as HTMLElement;
+					if (
+						!target ||
+						target === iframeDoc.body ||
+						target === iframeDoc.documentElement
+					)
+						return;
+					if (
+						target.tagName === "SCRIPT" ||
+						target.tagName === "STYLE" ||
+						target.tagName === "NOSCRIPT"
+					)
+						return;
+					handleClick(e);
+				},
+				true,
+			);
+		}
+
+		listenersAttached.current = true;
+	};
+
+	useEffect(() => {
+		listenersAttached.current = false;
+		initialRestoreDone.current = false;
+		isUserInteraction.current = false;
+		setPageLoaded(false);
+
+		if (iframeRef.current && html) {
+			const iframe = iframeRef.current;
+			const iframeDoc =
+				iframe.contentDocument || iframe.contentWindow?.document;
+
+			if (iframeDoc) {
+				let htmlContent = html;
+
+				// 임시저장에서 불러온 HTML에서 선택 상태 클래스 제거
+				htmlContent = htmlContent.replace(
+					/\s*class="[^"]*transflow-selected[^"]*"/g,
+					(match) => {
+						const cleaned = match
+							.replace(/\btransflow-selected\b\s*/g, "")
+							.replace(/\s+/g, " ")
+							.trim();
+						return cleaned === 'class=""' ? "" : cleaned;
+					},
+				);
+				htmlContent = htmlContent.replace(
+					/\s*class='[^']*transflow-selected[^']*'/g,
+					(match) => {
+						const cleaned = match
+							.replace(/\btransflow-selected\b\s*/g, "")
+							.replace(/\s+/g, " ")
+							.trim();
+						return cleaned === "class=''" ? "" : cleaned;
+					},
+				);
+
+				// 크롤링된 페이지의 스크립트 제거 (변수 중복 선언 오류 방지)
+				htmlContent = htmlContent.replace(
+					/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi,
+					"",
+				);
+
+				const hasDoctype = htmlContent
+					.trim()
+					.toLowerCase()
+					.startsWith("<!doctype");
+				const hasHtml = htmlContent.includes("<html");
+				const hasBody = htmlContent.includes("<body");
+
+				if (!hasDoctype || !hasHtml || !hasBody) {
+					if (!htmlContent.includes("<body")) {
+						htmlContent = `<body>${htmlContent}</body>`;
+					}
+					if (!htmlContent.includes("<html")) {
+						htmlContent = `<html>${htmlContent}</html>`;
+					}
+					if (!htmlContent.includes("<head>")) {
+						htmlContent = htmlContent.replace("<html>", "<html><head></head>");
+					}
+					if (!hasDoctype) {
+						htmlContent = `<!DOCTYPE html>${htmlContent}`;
+					}
+				}
+
+				// CSS 추가 (Translation.jsx와 동일)
+				const cssMatch = html.match(
+					/<style id="transflow-css">[\s\S]*?<\/style>/i,
+				);
+				if (cssMatch && !htmlContent.includes("transflow-css")) {
+					const cssTag = cssMatch[0];
+					if (htmlContent.includes("</head>")) {
+						htmlContent = htmlContent.replace("</head>", `${cssTag}\n</head>`);
+					} else if (htmlContent.includes("<html")) {
+						htmlContent = htmlContent.replace(
+							"<html>",
+							`<html><head>${cssTag}</head>`,
+						);
+					}
+				}
+
+				try {
+					iframeDoc.open();
+					iframeDoc.write(htmlContent);
+					iframeDoc.close();
+				} catch (error) {
+					// iframe 내부 스크립트 에러는 무시 (크롤링된 페이지의 스크립트 에러)
+					console.warn("iframe write error (ignored):", error);
+				}
+
+				// iframe 내부 스크립트 에러 무시 (크롤링된 페이지의 스크립트 에러는 무시)
+				if (iframe.contentWindow) {
+					iframe.contentWindow.addEventListener(
+						"error",
+						(e) => {
+							// iframe 내부 에러는 무시 (크롤링된 페이지의 스크립트 에러)
+							e.stopPropagation();
+							return true;
+						},
+						true,
+					);
+				}
+
+				// 영역 선택 모드 활성화 (Translation.jsx와 동일한 방식)
+				// pageLoaded를 체크하지 않고 직접 호출 (클로저 문제 해결)
+				const checkAndEnableSelection = () => {
+					try {
+						if (iframeDoc.body && iframeDoc.body.children.length > 0) {
+							enableElementSelection(iframeDoc);
+							setPageLoaded(true);
+						} else {
+							setTimeout(checkAndEnableSelection, 100);
+						}
+					} catch (error) {
+						// iframe 내부 스크립트 에러는 무시
+					}
+				};
+
+				setTimeout(checkAndEnableSelection, 300);
+			}
+		}
+	}, [html]); // enableElementSelection 의존성 제거!
+
+	return (
+		<div
+			style={{
+				display: "flex",
+				height: "100%",
+				gap: "16px",
+			}}
+		>
+			{/* 좌측 70%: 크롤링된 웹 페이지 */}
+			<div
+				style={{
+					flex: "0 0 70%",
+					border: "1px solid #C0C0C0",
+					borderRadius: "8px",
+					overflow: "auto",
+					backgroundColor: "#FFFFFF",
+				}}
+			>
+				<iframe
+					ref={iframeRef}
+					style={{
+						width: "100%",
+						height: "100%",
+						border: "none",
+					}}
+					title="Crawled page"
+				/>
+			</div>
+
+			{/* 우측 30%: 선택된 영역 리스트 */}
+			<div
+				style={{
+					flex: "0 0 30%",
+					border: "1px solid #C0C0C0",
+					borderRadius: "8px",
+					padding: "16px",
+					backgroundColor: "#DCDCDC",
+					overflow: "auto",
+				}}
+			>
+				<div
+					style={{
+						display: "flex",
+						justifyContent: "space-between",
+						alignItems: "center",
+						marginBottom: "16px",
+					}}
+				>
+					<h3
+						style={{
+							fontSize: "14px",
+							fontWeight: 600,
+							color: "#000000",
+							fontFamily: "system-ui, Pretendard, sans-serif",
+							margin: 0,
+						}}
+					>
+						선택된 영역 ({selectedAreas.length})
+					</h3>
+					{selectedAreas.length > 0 && (
+						<Button
+							variant="secondary"
+							onClick={() => {
+								selectedAreas.forEach((area) => onAreaRemove(area.id));
+							}}
+							style={{ fontSize: "12px", padding: "4px 8px" }}
+						>
+							전체 선택 취소
+						</Button>
+					)}
+				</div>
+				{selectedAreas.length === 0 ? (
+					<div
+						style={{
+							fontSize: "13px",
+							color: "#696969",
+							fontFamily: "system-ui, Pretendard, sans-serif",
+						}}
+					>
+						영역을 선택하세요
+					</div>
+				) : (
+					<div className="space-y-2">
+						{selectedAreas.map((area, idx) => (
+							<div
+								key={area.id}
+								onMouseEnter={() => setHoveredAreaId(area.id)}
+								onMouseLeave={() => setHoveredAreaId(null)}
+								style={{
+									padding: "12px",
+									border: "1px solid #C0C0C0",
+									borderRadius: "8px",
+									backgroundColor:
+										hoveredAreaId === area.id ? "#D3D3D3" : "#FFFFFF",
+									cursor: "pointer",
+									transition: "background-color 0.2s",
+								}}
+							>
+								<div
+									style={{
+										fontSize: "13px",
+										fontWeight: 500,
+										color: "#000000",
+										fontFamily: "system-ui, Pretendard, sans-serif",
+										marginBottom: "8px",
+									}}
+								>
+									영역 {idx + 1}
+								</div>
+								<Button
+									variant="secondary"
+									onClick={() => onAreaRemove(area.id)}
+									style={{ fontSize: "12px", padding: "4px 8px" }}
+								>
+									제거
+								</Button>
+							</div>
+						))}
+					</div>
+				)}
+			</div>
+		</div>
+	);
 };
 
 // STEP 3: 번역 전 편집 (Translation.jsx 방식으로 변경)
 const Step3PreEdit: React.FC<{
-  html: string;
-  onHtmlChange: (html: string) => void;
-  selectedAreas: SelectedArea[];
-  isManualPasteMode?: boolean;
-  onClearForManualPaste?: () => void;
-}> = ({ html, onHtmlChange, selectedAreas, isManualPasteMode = false, onClearForManualPaste }) => {
-  const iframeRef = React.useRef<HTMLIFrameElement>(null);
-  const [mode, setMode] = useState<'text' | 'component' | 'spacing'>('text');
-  const [selectedElements, setSelectedElements] = useState<HTMLElement[]>([]); // 다중 선택
-  const [isInitialized, setIsInitialized] = useState(false); // 초기화 플래그
+	html: string;
+	onHtmlChange: (html: string) => void;
+	selectedAreas: SelectedArea[];
+	isManualPasteMode?: boolean;
+	onClearForManualPaste?: () => void;
+}> = ({
+	html,
+	onHtmlChange,
+	selectedAreas,
+	isManualPasteMode = false,
+	onClearForManualPaste,
+}) => {
+	const iframeRef = React.useRef<HTMLIFrameElement>(null);
+	const [mode, setMode] = useState<"text" | "component" | "spacing">("text");
+	const [selectedElements, setSelectedElements] = useState<HTMLElement[]>([]); // 다중 선택
+	const [isInitialized, setIsInitialized] = useState(false); // 초기화 플래그
 
-  // "..." 메뉴 (초기화 / HTML 다운로드)
-  const [step3UtilityMenuOpen, setStep3UtilityMenuOpen] = useState(false);
-  const step3UtilityMenuRef = React.useRef<HTMLDivElement>(null);
+	// "..." 메뉴 (초기화 / HTML 다운로드)
+	const [step3UtilityMenuOpen, setStep3UtilityMenuOpen] = useState(false);
+	const step3UtilityMenuRef = React.useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (!step3UtilityMenuOpen) return;
+	useEffect(() => {
+		if (!step3UtilityMenuOpen) return;
 
-    const onDocMouseDown = (e: MouseEvent) => {
-      const target = e.target as Node | null;
-      if (!target) return;
-      if (step3UtilityMenuRef.current && !step3UtilityMenuRef.current.contains(target)) {
-        setStep3UtilityMenuOpen(false);
-      }
-    };
+		const onDocMouseDown = (e: MouseEvent) => {
+			const target = e.target as Node | null;
+			if (!target) return;
+			if (
+				step3UtilityMenuRef.current &&
+				!step3UtilityMenuRef.current.contains(target)
+			) {
+				setStep3UtilityMenuOpen(false);
+			}
+		};
 
-    document.addEventListener('mousedown', onDocMouseDown);
-    return () => document.removeEventListener('mousedown', onDocMouseDown);
-  }, [step3UtilityMenuOpen]);
+		document.addEventListener("mousedown", onDocMouseDown);
+		return () => document.removeEventListener("mousedown", onDocMouseDown);
+	}, [step3UtilityMenuOpen]);
 
-  // 더보기 메뉴 (Step 3 텍스트 에디터 - 인용문/구분선/표/첨자)
-  const [step3ShowMoreMenu, setStep3ShowMoreMenu] = useState(false);
-  const step3MoreMenuRef = React.useRef<HTMLDivElement>(null);
+	// 더보기 메뉴 (Step 3 텍스트 에디터 - 인용문/구분선/표/첨자)
+	const [step3ShowMoreMenu, setStep3ShowMoreMenu] = useState(false);
+	const step3MoreMenuRef = React.useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (!step3ShowMoreMenu) return;
+	useEffect(() => {
+		if (!step3ShowMoreMenu) return;
 
-    const onDocMouseDown = (e: MouseEvent) => {
-      const target = e.target as Node | null;
-      if (!target) return;
-      if (step3MoreMenuRef.current && !step3MoreMenuRef.current.contains(target)) {
-        setStep3ShowMoreMenu(false);
-      }
-    };
+		const onDocMouseDown = (e: MouseEvent) => {
+			const target = e.target as Node | null;
+			if (!target) return;
+			if (
+				step3MoreMenuRef.current &&
+				!step3MoreMenuRef.current.contains(target)
+			) {
+				setStep3ShowMoreMenu(false);
+			}
+		};
 
-    document.addEventListener('mousedown', onDocMouseDown);
-    return () => document.removeEventListener('mousedown', onDocMouseDown);
-  }, [step3ShowMoreMenu]);
-  
-  // 컴포넌트 편집용 Undo/Redo Stack
-  const undoStackRef = React.useRef<string[]>([]);
-  const redoStackRef = React.useRef<string[]>([]);
-  const currentHtmlRef = React.useRef<string>('');
+		document.addEventListener("mousedown", onDocMouseDown);
+		return () => document.removeEventListener("mousedown", onDocMouseDown);
+	}, [step3ShowMoreMenu]);
 
-  // iframe 내부 편집 후 HTML 상태 동기화
-  const syncIframeHtml = (iframeDoc: Document) => {
-    const updatedHtml = iframeDoc.documentElement?.outerHTML || '';
-    currentHtmlRef.current = updatedHtml;
-    onHtmlChange(updatedHtml);
-  };
+	// 컴포넌트 편집용 Undo/Redo Stack
+	const undoStackRef = React.useRef<string[]>([]);
+	const redoStackRef = React.useRef<string[]>([]);
+	const currentHtmlRef = React.useRef<string>("");
 
-  // removeFormat 후 border-style:solid 잔상 제거
-  // 원인: 웹 크롤링 HTML 내 <em>/<span> 등의 "border: 0px solid" inline style을
-  // removeFormat이 border-width:0 은 삭제하고 border-style:solid 만 남겨서 검은/파란 박스가 생김
-  const fixDanglingBorderStyle = (iframeDoc: Document) => {
-    iframeDoc.querySelectorAll('*').forEach((el) => {
-      const htmlEl = el as HTMLElement;
-      if (htmlEl.style && htmlEl.style.borderStyle === 'solid' && !htmlEl.style.borderWidth) {
-        htmlEl.style.borderWidth = '0';
-      }
-    });
-  };
+	// iframe 내부 편집 후 HTML 상태 동기화
+	const syncIframeHtml = (iframeDoc: Document) => {
+		const updatedHtml = iframeDoc.documentElement?.outerHTML || "";
+		currentHtmlRef.current = updatedHtml;
+		onHtmlChange(updatedHtml);
+	};
 
-  // 공백 제거용 별도 undo stack
-  const spacingUndoStackRef = React.useRef<string[]>([]);
-  const spacingRedoStackRef = React.useRef<string[]>([]);
-  const spacingCurrentHtmlRef = React.useRef<string>('');
-  // 컴포넌트 클릭 핸들러 저장 (제거를 위해)
-  const componentClickHandlersRef = React.useRef<Map<HTMLElement, (e: Event) => void>>(new Map());
-  // 공백 제거 모드 클릭 핸들러 저장 (제거를 위해)
-  const spacingClickHandlersRef = React.useRef<Map<HTMLElement, (e: Event) => void>>(new Map());
-  // 링크 클릭 방지 핸들러 저장 (제거를 위해)
-  const linkClickHandlersRef = React.useRef<Map<HTMLElement, (e: Event) => void>>(new Map());
-  // window 키보드 이벤트 리스너 저장 (cleanup에서 제거하기 위해)
-  const windowKeydownHandlerRef = React.useRef<((e: KeyboardEvent) => void) | null>(null);
-  const iframeKeydownHandlerRef = React.useRef<((e: KeyboardEvent) => void) | null>(null);
-  
-  // 이전 모드 추적 (spacing 블록에서 선택 초기화 시 사용)
-  const prevModeRef = React.useRef<'text' | 'component' | 'spacing'>('text');
-  // 공백 제거 상태 추적
-  const spacingRemovedRef = React.useRef<{
-    top: boolean;
-    bottom: boolean;
-    left: boolean;
-    right: boolean;
-    auto: boolean;
-  }>({
-    top: false,
-    bottom: false,
-    left: false,
-    right: false,
-    auto: false,
-  });
-  
-  // 모드 변경 시 편집 기능 전환 (iframe 재렌더링 없이)
-  useEffect(() => {
-    if (!isInitialized || !iframeRef.current) return;
-    
-    const iframe = iframeRef.current;
-    const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-    if (!iframeDoc) return;
-    
-    console.log('🔄 모드 변경:', mode);
-    
-    // 기존 이벤트 리스너 제거 (클린업)
-    const removeAllListeners = () => {
-      const allElements = iframeDoc.querySelectorAll('*');
-      allElements.forEach(el => {
-        const newEl = el.cloneNode(true);
-        el.parentNode?.replaceChild(newEl, el);
-      });
-    };
-    
-    if (mode === 'text') {
-      // 텍스트 편집 모드
-      const editableElements = iframeDoc.querySelectorAll('p, h1, h2, h3, h4, h5, h6, span, div, li, ul, ol, blockquote, pre, code, table, tr, td, th, label, a, button, article, section, header, footer, main, aside');
-      editableElements.forEach((el) => {
-        if (el.tagName && !['SCRIPT', 'STYLE', 'NOSCRIPT'].includes(el.tagName)) {
-          (el as HTMLElement).contentEditable = 'true';
-          (el as HTMLElement).style.cursor = 'text';
-          (el as HTMLElement).style.outline = 'none';
-        }
-      });
-      
-      // ⭐ 링크 클릭 방지 (다른 사이트로 이동 방지)
-      // 기존 링크 클릭 핸들러 제거
-      linkClickHandlersRef.current.forEach((handler, link) => {
-        link.removeEventListener('click', handler, true);
-      });
-      linkClickHandlersRef.current.clear();
-      
-      // 모든 링크에 클릭 방지 핸들러 추가
-      const allLinks = iframeDoc.querySelectorAll('a');
-      const preventLinkNavigation = (e: Event) => {
-        e.preventDefault();
-        e.stopPropagation();
-        e.stopImmediatePropagation();
-        return false;
-      };
-      
-      allLinks.forEach(link => {
-        const htmlLink = link as HTMLElement;
-        htmlLink.addEventListener('click', preventLinkNavigation, true);
-        linkClickHandlersRef.current.set(htmlLink, preventLinkNavigation);
-        // 링크 스타일 변경 (편집 모드임을 표시)
-        htmlLink.style.cursor = 'text';
-        htmlLink.style.textDecoration = 'none';
-      });
-      
-      // 링크 스타일 CSS 추가
-      const linkStyle = iframeDoc.createElement('style');
-      linkStyle.id = 'text-edit-link-style';
-      linkStyle.textContent = `
+	// removeFormat 후 border-style:solid 잔상 제거
+	// 원인: 웹 크롤링 HTML 내 <em>/<span> 등의 "border: 0px solid" inline style을
+	// removeFormat이 border-width:0 은 삭제하고 border-style:solid 만 남겨서 검은/파란 박스가 생김
+	const fixDanglingBorderStyle = (iframeDoc: Document) => {
+		iframeDoc.querySelectorAll("*").forEach((el) => {
+			const htmlEl = el as HTMLElement;
+			if (
+				htmlEl.style &&
+				htmlEl.style.borderStyle === "solid" &&
+				!htmlEl.style.borderWidth
+			) {
+				htmlEl.style.borderWidth = "0";
+			}
+		});
+	};
+
+	// 공백 제거용 별도 undo stack
+	const spacingUndoStackRef = React.useRef<string[]>([]);
+	const spacingRedoStackRef = React.useRef<string[]>([]);
+	const spacingCurrentHtmlRef = React.useRef<string>("");
+	// 컴포넌트 클릭 핸들러 저장 (제거를 위해)
+	const componentClickHandlersRef = React.useRef<
+		Map<HTMLElement, (e: Event) => void>
+	>(new Map());
+	// 공백 제거 모드 클릭 핸들러 저장 (제거를 위해)
+	const spacingClickHandlersRef = React.useRef<
+		Map<HTMLElement, (e: Event) => void>
+	>(new Map());
+	// 링크 클릭 방지 핸들러 저장 (제거를 위해)
+	const linkClickHandlersRef = React.useRef<
+		Map<HTMLElement, (e: Event) => void>
+	>(new Map());
+	// window 키보드 이벤트 리스너 저장 (cleanup에서 제거하기 위해)
+	const windowKeydownHandlerRef = React.useRef<
+		((e: KeyboardEvent) => void) | null
+	>(null);
+	const iframeKeydownHandlerRef = React.useRef<
+		((e: KeyboardEvent) => void) | null
+	>(null);
+
+	// 이전 모드 추적 (spacing 블록에서 선택 초기화 시 사용)
+	const prevModeRef = React.useRef<"text" | "component" | "spacing">("text");
+	// 공백 제거 상태 추적
+	const spacingRemovedRef = React.useRef<{
+		top: boolean;
+		bottom: boolean;
+		left: boolean;
+		right: boolean;
+		auto: boolean;
+	}>({
+		top: false,
+		bottom: false,
+		left: false,
+		right: false,
+		auto: false,
+	});
+
+	// 모드 변경 시 편집 기능 전환 (iframe 재렌더링 없이)
+	useEffect(() => {
+		if (!isInitialized || !iframeRef.current) return;
+
+		const iframe = iframeRef.current;
+		const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
+		if (!iframeDoc) return;
+
+		console.log("🔄 모드 변경:", mode);
+
+		// 기존 이벤트 리스너 제거 (클린업)
+		const removeAllListeners = () => {
+			const allElements = iframeDoc.querySelectorAll("*");
+			allElements.forEach((el) => {
+				const newEl = el.cloneNode(true);
+				el.parentNode?.replaceChild(newEl, el);
+			});
+		};
+
+		if (mode === "text") {
+			// 텍스트 편집 모드
+			const editableElements = iframeDoc.querySelectorAll(
+				"p, h1, h2, h3, h4, h5, h6, span, div, li, ul, ol, blockquote, pre, code, table, tr, td, th, label, a, button, article, section, header, footer, main, aside",
+			);
+			editableElements.forEach((el) => {
+				if (
+					el.tagName &&
+					!["SCRIPT", "STYLE", "NOSCRIPT"].includes(el.tagName)
+				) {
+					(el as HTMLElement).contentEditable = "true";
+					(el as HTMLElement).style.cursor = "text";
+					(el as HTMLElement).style.outline = "none";
+				}
+			});
+
+			// ⭐ 링크 클릭 방지 (다른 사이트로 이동 방지)
+			// 기존 링크 클릭 핸들러 제거
+			linkClickHandlersRef.current.forEach((handler, link) => {
+				link.removeEventListener("click", handler, true);
+			});
+			linkClickHandlersRef.current.clear();
+
+			// 모든 링크에 클릭 방지 핸들러 추가
+			const allLinks = iframeDoc.querySelectorAll("a");
+			const preventLinkNavigation = (e: Event) => {
+				e.preventDefault();
+				e.stopPropagation();
+				e.stopImmediatePropagation();
+				return false;
+			};
+
+			allLinks.forEach((link) => {
+				const htmlLink = link as HTMLElement;
+				htmlLink.addEventListener("click", preventLinkNavigation, true);
+				linkClickHandlersRef.current.set(htmlLink, preventLinkNavigation);
+				// 링크 스타일 변경 (편집 모드임을 표시)
+				htmlLink.style.cursor = "text";
+				htmlLink.style.textDecoration = "none";
+			});
+
+			// 링크 스타일 CSS 추가
+			const linkStyle = iframeDoc.createElement("style");
+			linkStyle.id = "text-edit-link-style";
+			linkStyle.textContent = `
         a {
           cursor: text !important;
           pointer-events: auto !important;
@@ -976,184 +1197,211 @@ const Step3PreEdit: React.FC<{
           text-decoration: underline !important;
         }
       `;
-      const existingLinkStyle = iframeDoc.getElementById('text-edit-link-style');
-      if (existingLinkStyle) {
-        existingLinkStyle.remove();
-      }
-      iframeDoc.head.appendChild(linkStyle);
-      
-      // ⭐ 포커스 시 파란색/outline 제거 (브라우저 기본 포커스 링 제거)
-      const focusStyle = iframeDoc.getElementById('text-edit-no-focus-outline');
-      if (focusStyle) focusStyle.remove();
-      const noFocusOutline = iframeDoc.createElement('style');
-      noFocusOutline.id = 'text-edit-no-focus-outline';
-      noFocusOutline.textContent = `
+			const existingLinkStyle = iframeDoc.getElementById(
+				"text-edit-link-style",
+			);
+			if (existingLinkStyle) {
+				existingLinkStyle.remove();
+			}
+			iframeDoc.head.appendChild(linkStyle);
+
+			// ⭐ 포커스 시 파란색/outline 제거 (브라우저 기본 포커스 링 제거)
+			const focusStyle = iframeDoc.getElementById("text-edit-no-focus-outline");
+			if (focusStyle) focusStyle.remove();
+			const noFocusOutline = iframeDoc.createElement("style");
+			noFocusOutline.id = "text-edit-no-focus-outline";
+			noFocusOutline.textContent = `
         *, *:focus, [contenteditable="true"], [contenteditable="true"]:focus,
         div:focus, p:focus, span:focus {
           outline: none !important;
           box-shadow: none !important;
         }
       `;
-      iframeDoc.head.appendChild(noFocusOutline);
-      
-      // transflow-selection-style 제거 (파란/보라색 호버 스타일 제거)
-      const transflowSelectionStyle = iframeDoc.getElementById('transflow-selection-style');
-      if (transflowSelectionStyle) transflowSelectionStyle.remove();
-      
-      // 컴포넌트 편집 스타일 제거 및 이벤트 리스너 제거
-      const allElements = iframeDoc.querySelectorAll('[data-component-editable]');
-      allElements.forEach(el => {
-        const htmlEl = el as HTMLElement;
-        htmlEl.style.outline = 'none';
-        htmlEl.style.cursor = 'text';
-        htmlEl.style.boxShadow = 'none'; // boxShadow도 제거!
-        htmlEl.style.backgroundColor = ''; // ⭐ 초록색 배경 제거
-        htmlEl.classList.remove('component-selected');
-        htmlEl.removeAttribute('data-component-editable');
-        
-        // 이벤트 리스너 제거
-        const handler = componentClickHandlersRef.current.get(htmlEl);
-        if (handler) {
-          htmlEl.removeEventListener('click', handler, true);
-          componentClickHandlersRef.current.delete(htmlEl);
-        }
-      });
-      
-      // data-transflow-id가 있는 요소들의 outline도 제거 (컴포넌트 선택 스타일 제거)
-      const transflowElements = iframeDoc.querySelectorAll('[data-transflow-id]');
-      transflowElements.forEach(el => {
-        const htmlEl = el as HTMLElement;
-        htmlEl.style.outline = 'none';
-        htmlEl.style.boxShadow = 'none';
-        
-        // 이벤트 리스너 제거 (혹시 남아있을 수 있음)
-        const handler = componentClickHandlersRef.current.get(htmlEl);
-        if (handler) {
-          htmlEl.removeEventListener('click', handler, true);
-          componentClickHandlersRef.current.delete(htmlEl);
-        }
-      });
-      
-      // 모든 컴포넌트 클릭 핸들러 제거
-      componentClickHandlersRef.current.forEach((handler, el) => {
-        el.removeEventListener('click', handler, true);
-      });
-      componentClickHandlersRef.current.clear();
-      
-      // 공백 제거 모드 스타일 및 속성 제거
-      const spacingEditableInText = iframeDoc.querySelectorAll('[data-spacing-editable]');
-      spacingEditableInText.forEach(el => {
-        const htmlEl = el as HTMLElement;
-        htmlEl.classList.remove('spacing-selected');
-        htmlEl.removeAttribute('data-spacing-editable');
-        htmlEl.style.outline = 'none';
-        htmlEl.style.boxShadow = 'none';
-        htmlEl.style.backgroundColor = '';
-      });
-      const spacingStyleInText = iframeDoc.getElementById('transflow-spacing-global-style');
-      if (spacingStyleInText) spacingStyleInText.remove();
-      
-      // 공백 제거 모드 클릭 핸들러 제거
-      spacingClickHandlersRef.current.forEach((handler, el) => {
-        el.removeEventListener('click', handler, true);
-      });
-      spacingClickHandlersRef.current.clear();
-      
-      // 공백 제거 모드 선택 스타일 제거
-      const spacingSelectedElements = iframeDoc.querySelectorAll('.spacing-selected');
-      spacingSelectedElements.forEach(el => {
-        const htmlEl = el as HTMLElement;
-        htmlEl.classList.remove('spacing-selected');
-        htmlEl.style.outline = 'none';
-        htmlEl.style.boxShadow = 'none';
-      });
-      
-      // 선택된 요소 초기화
-      setSelectedElements([]);
-      
-      // ⭐ 텍스트 모드 키보드 단축키 (Ctrl+Z, Ctrl+Shift+Z)
-      const handleTextKeydown = (e: KeyboardEvent) => {
-        // Cmd+Z (Mac) 또는 Ctrl+Z (Windows) - Undo
-        if ((e.ctrlKey || e.metaKey) && e.key === 'z' && !e.shiftKey) {
-          e.preventDefault();
-          e.stopImmediatePropagation();
-          iframeDoc.execCommand('undo', false);
-          const updatedHtml = iframeDoc.documentElement.outerHTML;
-          onHtmlChange(updatedHtml);
-          console.log('↩️ Undo (Step 3 텍스트 편집)');
-        }
-        // Cmd+Shift+Z (Mac) 또는 Ctrl+Y (Windows) - Redo
-        else if ((e.ctrlKey || e.metaKey) && (e.key === 'y' || (e.key === 'z' && e.shiftKey))) {
-          e.preventDefault();
-          e.stopImmediatePropagation();
-          iframeDoc.execCommand('redo', false);
-          const updatedHtml = iframeDoc.documentElement.outerHTML;
-          onHtmlChange(updatedHtml);
-          console.log('↪️ Redo (Step 3 텍스트 편집)');
-        }
-        
-        // ⭐ 백스페이스 키 처리 (브라우저 기본 동작 허용)
-        if (e.key === 'Backspace' && !e.ctrlKey && !e.metaKey && !e.altKey) {
-          console.log('⌫ 백스페이스 (STEP 3 텍스트 편집)');
-        }
-      };
-      
-      // 기존 리스너 제거
-      if (iframeKeydownHandlerRef.current && iframeDoc) {
-        iframeDoc.removeEventListener('keydown', iframeKeydownHandlerRef.current, true);
-      }
-      // 새 리스너 등록 및 저장
-      iframeKeydownHandlerRef.current = handleTextKeydown;
-      iframeDoc.addEventListener('keydown', handleTextKeydown, true);
-      prevModeRef.current = 'text';
-      console.log('✅ Step 3 텍스트 모드 키보드 단축키 등록 완료');
-      
-    } else if (mode === 'component') {
-      // 컴포넌트 편집 모드
-      // contentEditable 비활성화
-      const editableElements = iframeDoc.querySelectorAll('[contenteditable="true"]');
-      editableElements.forEach((el) => {
-        (el as HTMLElement).contentEditable = 'false';
-        (el as HTMLElement).style.cursor = 'default';
-      });
-      
-      // ⭐ 링크 클릭 핸들러 제거
-      linkClickHandlersRef.current.forEach((handler, link) => {
-        link.removeEventListener('click', handler, true);
-      });
-      linkClickHandlersRef.current.clear();
-      
-      // 링크 스타일 태그 제거
-      const linkStyle = iframeDoc.getElementById('text-edit-link-style');
-      if (linkStyle) {
-        linkStyle.remove();
-      }
-      
-      // 공백 제거 모드 선택 스타일 및 속성 제거
-      const spacingEditableElements = iframeDoc.querySelectorAll('[data-spacing-editable]');
-      spacingEditableElements.forEach(el => {
-        const htmlEl = el as HTMLElement;
-        htmlEl.classList.remove('spacing-selected');
-        htmlEl.removeAttribute('data-spacing-editable');
-        htmlEl.style.outline = 'none';
-        htmlEl.style.boxShadow = 'none';
-        htmlEl.style.backgroundColor = '';
-      });
-      const spacingGlobalStyle = iframeDoc.getElementById('transflow-spacing-global-style');
-      if (spacingGlobalStyle) spacingGlobalStyle.remove();
-      
-      // 공백 제거 모드 클릭 핸들러 제거
-      spacingClickHandlersRef.current.forEach((handler, el) => {
-        el.removeEventListener('click', handler, true);
-      });
-      spacingClickHandlersRef.current.clear();
-      
-      // 클릭 가능한 컴포넌트 스타일 추가 (붙여넣은 HTML의 outline 덮어쓰기 위해 !important 스타일 시트 추가)
-      const componentGlobalStyle = iframeDoc.getElementById('transflow-component-global-style') as HTMLStyleElement | null;
-      if (componentGlobalStyle) componentGlobalStyle.remove();
-      const newComponentGlobalStyle = iframeDoc.createElement('style');
-      newComponentGlobalStyle.id = 'transflow-component-global-style';
-      newComponentGlobalStyle.textContent = `
+			iframeDoc.head.appendChild(noFocusOutline);
+
+			// transflow-selection-style 제거 (파란/보라색 호버 스타일 제거)
+			const transflowSelectionStyle = iframeDoc.getElementById(
+				"transflow-selection-style",
+			);
+			if (transflowSelectionStyle) transflowSelectionStyle.remove();
+
+			// 컴포넌트 편집 스타일 제거 및 이벤트 리스너 제거
+			const allElements = iframeDoc.querySelectorAll(
+				"[data-component-editable]",
+			);
+			allElements.forEach((el) => {
+				const htmlEl = el as HTMLElement;
+				htmlEl.style.outline = "none";
+				htmlEl.style.cursor = "text";
+				htmlEl.style.boxShadow = "none"; // boxShadow도 제거!
+				htmlEl.style.backgroundColor = ""; // ⭐ 초록색 배경 제거
+				htmlEl.classList.remove("component-selected");
+				htmlEl.removeAttribute("data-component-editable");
+
+				// 이벤트 리스너 제거
+				const handler = componentClickHandlersRef.current.get(htmlEl);
+				if (handler) {
+					htmlEl.removeEventListener("click", handler, true);
+					componentClickHandlersRef.current.delete(htmlEl);
+				}
+			});
+
+			// data-transflow-id가 있는 요소들의 outline도 제거 (컴포넌트 선택 스타일 제거)
+			const transflowElements = iframeDoc.querySelectorAll(
+				"[data-transflow-id]",
+			);
+			transflowElements.forEach((el) => {
+				const htmlEl = el as HTMLElement;
+				htmlEl.style.outline = "none";
+				htmlEl.style.boxShadow = "none";
+
+				// 이벤트 리스너 제거 (혹시 남아있을 수 있음)
+				const handler = componentClickHandlersRef.current.get(htmlEl);
+				if (handler) {
+					htmlEl.removeEventListener("click", handler, true);
+					componentClickHandlersRef.current.delete(htmlEl);
+				}
+			});
+
+			// 모든 컴포넌트 클릭 핸들러 제거
+			componentClickHandlersRef.current.forEach((handler, el) => {
+				el.removeEventListener("click", handler, true);
+			});
+			componentClickHandlersRef.current.clear();
+
+			// 공백 제거 모드 스타일 및 속성 제거
+			const spacingEditableInText = iframeDoc.querySelectorAll(
+				"[data-spacing-editable]",
+			);
+			spacingEditableInText.forEach((el) => {
+				const htmlEl = el as HTMLElement;
+				htmlEl.classList.remove("spacing-selected");
+				htmlEl.removeAttribute("data-spacing-editable");
+				htmlEl.style.outline = "none";
+				htmlEl.style.boxShadow = "none";
+				htmlEl.style.backgroundColor = "";
+			});
+			const spacingStyleInText = iframeDoc.getElementById(
+				"transflow-spacing-global-style",
+			);
+			if (spacingStyleInText) spacingStyleInText.remove();
+
+			// 공백 제거 모드 클릭 핸들러 제거
+			spacingClickHandlersRef.current.forEach((handler, el) => {
+				el.removeEventListener("click", handler, true);
+			});
+			spacingClickHandlersRef.current.clear();
+
+			// 공백 제거 모드 선택 스타일 제거
+			const spacingSelectedElements =
+				iframeDoc.querySelectorAll(".spacing-selected");
+			spacingSelectedElements.forEach((el) => {
+				const htmlEl = el as HTMLElement;
+				htmlEl.classList.remove("spacing-selected");
+				htmlEl.style.outline = "none";
+				htmlEl.style.boxShadow = "none";
+			});
+
+			// 선택된 요소 초기화
+			setSelectedElements([]);
+
+			// ⭐ 텍스트 모드 키보드 단축키 (Ctrl+Z, Ctrl+Shift+Z)
+			const handleTextKeydown = (e: KeyboardEvent) => {
+				// Cmd+Z (Mac) 또는 Ctrl+Z (Windows) - Undo
+				if ((e.ctrlKey || e.metaKey) && e.key === "z" && !e.shiftKey) {
+					e.preventDefault();
+					e.stopImmediatePropagation();
+					iframeDoc.execCommand("undo", false);
+					const updatedHtml = iframeDoc.documentElement.outerHTML;
+					onHtmlChange(updatedHtml);
+					console.log("↩️ Undo (Step 3 텍스트 편집)");
+				}
+				// Cmd+Shift+Z (Mac) 또는 Ctrl+Y (Windows) - Redo
+				else if (
+					(e.ctrlKey || e.metaKey) &&
+					(e.key === "y" || (e.key === "z" && e.shiftKey))
+				) {
+					e.preventDefault();
+					e.stopImmediatePropagation();
+					iframeDoc.execCommand("redo", false);
+					const updatedHtml = iframeDoc.documentElement.outerHTML;
+					onHtmlChange(updatedHtml);
+					console.log("↪️ Redo (Step 3 텍스트 편집)");
+				}
+
+				// ⭐ 백스페이스 키 처리 (브라우저 기본 동작 허용)
+				if (e.key === "Backspace" && !e.ctrlKey && !e.metaKey && !e.altKey) {
+					console.log("⌫ 백스페이스 (STEP 3 텍스트 편집)");
+				}
+			};
+
+			// 기존 리스너 제거
+			if (iframeKeydownHandlerRef.current && iframeDoc) {
+				iframeDoc.removeEventListener(
+					"keydown",
+					iframeKeydownHandlerRef.current,
+					true,
+				);
+			}
+			// 새 리스너 등록 및 저장
+			iframeKeydownHandlerRef.current = handleTextKeydown;
+			iframeDoc.addEventListener("keydown", handleTextKeydown, true);
+			prevModeRef.current = "text";
+			console.log("✅ Step 3 텍스트 모드 키보드 단축키 등록 완료");
+		} else if (mode === "component") {
+			// 컴포넌트 편집 모드
+			// contentEditable 비활성화
+			const editableElements = iframeDoc.querySelectorAll(
+				'[contenteditable="true"]',
+			);
+			editableElements.forEach((el) => {
+				(el as HTMLElement).contentEditable = "false";
+				(el as HTMLElement).style.cursor = "default";
+			});
+
+			// ⭐ 링크 클릭 핸들러 제거
+			linkClickHandlersRef.current.forEach((handler, link) => {
+				link.removeEventListener("click", handler, true);
+			});
+			linkClickHandlersRef.current.clear();
+
+			// 링크 스타일 태그 제거
+			const linkStyle = iframeDoc.getElementById("text-edit-link-style");
+			if (linkStyle) {
+				linkStyle.remove();
+			}
+
+			// 공백 제거 모드 선택 스타일 및 속성 제거
+			const spacingEditableElements = iframeDoc.querySelectorAll(
+				"[data-spacing-editable]",
+			);
+			spacingEditableElements.forEach((el) => {
+				const htmlEl = el as HTMLElement;
+				htmlEl.classList.remove("spacing-selected");
+				htmlEl.removeAttribute("data-spacing-editable");
+				htmlEl.style.outline = "none";
+				htmlEl.style.boxShadow = "none";
+				htmlEl.style.backgroundColor = "";
+			});
+			const spacingGlobalStyle = iframeDoc.getElementById(
+				"transflow-spacing-global-style",
+			);
+			if (spacingGlobalStyle) spacingGlobalStyle.remove();
+
+			// 공백 제거 모드 클릭 핸들러 제거
+			spacingClickHandlersRef.current.forEach((handler, el) => {
+				el.removeEventListener("click", handler, true);
+			});
+			spacingClickHandlersRef.current.clear();
+
+			// 클릭 가능한 컴포넌트 스타일 추가 (붙여넣은 HTML의 outline 덮어쓰기 위해 !important 스타일 시트 추가)
+			const componentGlobalStyle = iframeDoc.getElementById(
+				"transflow-component-global-style",
+			) as HTMLStyleElement | null;
+			if (componentGlobalStyle) componentGlobalStyle.remove();
+			const newComponentGlobalStyle = iframeDoc.createElement("style");
+			newComponentGlobalStyle.id = "transflow-component-global-style";
+			newComponentGlobalStyle.textContent = `
         [data-component-editable="true"] {
           outline: 2px dashed #C0C0C0 !important;
           outline-offset: 2px !important;
@@ -1164,430 +1412,617 @@ const Step3PreEdit: React.FC<{
           background-color: rgba(40, 167, 69, 0.25) !important;
         }
       `;
-      iframeDoc.head.appendChild(newComponentGlobalStyle);
-      
-      const componentElements = iframeDoc.querySelectorAll('div, section, article, header, footer, main, aside, nav, p, h1, h2, h3, h4, h5, h6');
-      
-      // 컴포넌트 클릭 핸들러 (다중 선택 + 토글)
-      const handleComponentClick = (e: Event) => {
-        e.stopPropagation();
-        e.preventDefault();
-        
-        const target = e.target as HTMLElement;
-        if (!target || ['SCRIPT', 'STYLE', 'NOSCRIPT', 'HTML', 'HEAD', 'BODY'].includes(target.tagName)) return;
-        
-        console.log('🎯 컴포넌트 클릭:', target.tagName);
-        
-        // 이미 선택된 요소인지 확인 (토글)
-        const isSelected = target.classList.contains('component-selected');
-        
-        if (isSelected) {
-          // 선택 해제
-          target.classList.remove('component-selected');
-          target.style.setProperty('outline', '2px dashed #C0C0C0', 'important');
-          target.style.setProperty('outline-offset', '2px', 'important');
-          target.style.setProperty('box-shadow', 'none', 'important');
-          target.style.setProperty('background-color', '', 'important');
-          console.log('❌ 선택 해제:', target.tagName);
-          
-          setSelectedElements(prev => prev.filter(el => el !== target));
-        } else {
-          // 선택 추가 (STEP 2와 동일한 녹색 스타일, !important로 붙여넣은 스타일 덮어쓰기)
-          target.classList.add('component-selected');
-          target.style.setProperty('outline', '4px solid #28a745', 'important');
-          target.style.setProperty('outline-offset', '3px', 'important');
-          target.style.setProperty('background-color', 'rgba(40, 167, 69, 0.25)', 'important');
-          target.style.setProperty('box-shadow', '0 0 0 4px rgba(40, 167, 69, 0.4), 0 4px 12px rgba(40, 167, 69, 0.5)', 'important');
-          console.log('✅ 선택 추가:', target.tagName);
-          
-          setSelectedElements(prev => [...prev, target]);
-        }
-      };
-      
-      componentElements.forEach((el) => {
-        if (el.tagName && !['SCRIPT', 'STYLE', 'NOSCRIPT', 'HTML', 'HEAD', 'BODY'].includes(el.tagName)) {
-          const htmlEl = el as HTMLElement;
-          htmlEl.setAttribute('data-component-editable', 'true');
-          htmlEl.style.cursor = 'pointer';
-          htmlEl.style.setProperty('outline', '2px dashed #C0C0C0', 'important');
-          htmlEl.style.setProperty('outline-offset', '2px', 'important');
-          
-          // 기존 핸들러가 있으면 제거
-          const existingHandler = componentClickHandlersRef.current.get(htmlEl);
-          if (existingHandler) {
-            htmlEl.removeEventListener('click', existingHandler, true);
-          }
-          
-          // 클릭 이벤트 리스너 추가 및 저장
-          htmlEl.addEventListener('click', handleComponentClick, true);
-          componentClickHandlersRef.current.set(htmlEl, handleComponentClick);
-        }
-      });
-      
-      // ⭐ 링크 클릭 방지 (다른 사이트로 이동 방지)
-      const allLinks = iframeDoc.querySelectorAll('a');
-      const preventLinkNavigation = (e: Event) => {
-        e.preventDefault();
-        e.stopPropagation();
-        e.stopImmediatePropagation();
-        return false;
-      };
-      
-      allLinks.forEach(link => {
-        const htmlLink = link as HTMLElement;
-        // 기존 핸들러가 있으면 제거
-        const existingLinkHandler = linkClickHandlersRef.current.get(htmlLink);
-        if (existingLinkHandler) {
-          htmlLink.removeEventListener('click', existingLinkHandler, true);
-        }
-        htmlLink.addEventListener('click', preventLinkNavigation, true);
-        linkClickHandlersRef.current.set(htmlLink, preventLinkNavigation);
-        htmlLink.style.cursor = 'pointer';
-      });
-      
-      console.log('✅ 컴포넌트 클릭 리스너 추가 완료:', componentElements.length, '개');
-      console.log('✅ 링크 클릭 방지 핸들러 추가 완료:', allLinks.length, '개');
-      
-      // ⭐ 컴포넌트 모드 키보드 단축키 (Ctrl+Z, Ctrl+Shift+Z)
-      const handleComponentKeydown = (e: KeyboardEvent) => {
-        console.log('🔑 Step 3 iframe 키 감지:', e.key, 'ctrl:', e.ctrlKey, 'meta:', e.metaKey, 'shift:', e.shiftKey);
-        // Cmd+Z (Mac) 또는 Ctrl+Z (Windows) - Undo
-        if ((e.ctrlKey || e.metaKey) && e.key === 'z' && !e.shiftKey) {
-          e.preventDefault();
-          e.stopImmediatePropagation();
-          
-          if (undoStackRef.current.length > 0) {
-            console.log('↩️ Undo (Step 3 컴포넌트 편집) - stack:', undoStackRef.current.length);
-            
-            // 현재 상태를 redo stack에 저장
-            redoStackRef.current.push(currentHtmlRef.current);
-            
-            // undo stack에서 이전 상태 복원
-            const previousHtml = undoStackRef.current.pop()!;
-            currentHtmlRef.current = previousHtml;
-            
-            // iframe에 HTML 복원
-            iframeDoc.open();
-            iframeDoc.write(previousHtml);
-            iframeDoc.close();
-            
-            onHtmlChange(previousHtml);
-            
-            // 컴포넌트 편집 모드 다시 초기화
-            setTimeout(() => {
-              const newIframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-              if (!newIframeDoc) return;
-              
-              // contentEditable 비활성화
-              const editableElements = newIframeDoc.querySelectorAll('[contenteditable="true"]');
-              editableElements.forEach((el) => {
-                (el as HTMLElement).contentEditable = 'false';
-                (el as HTMLElement).style.cursor = 'default';
-              });
-              
-              // 컴포넌트 클릭 핸들러 추가
-              const componentElements = newIframeDoc.querySelectorAll('div, section, article, header, footer, main, aside, nav, p, h1, h2, h3, h4, h5, h6');
-              
-              const handleComponentClick = (e: Event) => {
-                e.stopPropagation();
-                e.preventDefault();
-                
-                const target = e.target as HTMLElement;
-                if (!target || ['SCRIPT', 'STYLE', 'NOSCRIPT', 'HTML', 'HEAD', 'BODY'].includes(target.tagName)) return;
-                
-                const isSelected = target.classList.contains('component-selected');
-                
-                if (isSelected) {
-                  target.classList.remove('component-selected');
-                  target.style.outline = '1px dashed #C0C0C0';
-                  target.style.boxShadow = 'none';
-                  target.style.backgroundColor = '';
-                  setSelectedElements(prev => prev.filter(el => el !== target));
-                } else {
-                  target.classList.add('component-selected');
-                  target.style.outline = '4px solid #28a745';
-                  target.style.outlineOffset = '3px';
-                  target.style.backgroundColor = 'rgba(40, 167, 69, 0.25)';
-                  target.style.boxShadow = '0 0 0 4px rgba(40, 167, 69, 0.4), 0 4px 12px rgba(40, 167, 69, 0.5)';
-                  target.style.transition = 'all 0.2s ease';
-                  setSelectedElements(prev => [...prev, target]);
-                }
-              };
-              
-              componentElements.forEach((el) => {
-                if (el.tagName && !['SCRIPT', 'STYLE', 'NOSCRIPT', 'HTML', 'HEAD', 'BODY'].includes(el.tagName)) {
-                  const htmlEl = el as HTMLElement;
-                  htmlEl.setAttribute('data-component-editable', 'true');
-                  htmlEl.style.cursor = 'pointer';
-                  htmlEl.style.outline = '1px dashed #C0C0C0';
-                  
-                  const existingHandler = componentClickHandlersRef.current.get(htmlEl);
-                  if (existingHandler) {
-                    htmlEl.removeEventListener('click', existingHandler, true);
-                  }
-                  htmlEl.addEventListener('click', handleComponentClick, true);
-                  componentClickHandlersRef.current.set(htmlEl, handleComponentClick);
-                }
-              });
-              
-              // 링크 클릭 방지 핸들러 추가
-              const allLinks = newIframeDoc.querySelectorAll('a');
-              const preventLinkNavigation = (e: Event) => {
-                e.preventDefault();
-                e.stopPropagation();
-                e.stopImmediatePropagation();
-                return false;
-              };
-              
-              allLinks.forEach(link => {
-                const htmlLink = link as HTMLElement;
-                const existingLinkHandler = linkClickHandlersRef.current.get(htmlLink);
-                if (existingLinkHandler) {
-                  htmlLink.removeEventListener('click', existingLinkHandler, true);
-                }
-                htmlLink.addEventListener('click', preventLinkNavigation, true);
-                linkClickHandlersRef.current.set(htmlLink, preventLinkNavigation);
-                htmlLink.style.cursor = 'pointer';
-              });
-              
-              if (newIframeDoc.body) {
-                newIframeDoc.body.setAttribute('tabindex', '-1');
-                newIframeDoc.body.focus();
-              }
-            }, 100);
-            
-            setSelectedElements([]);
-          } else {
-            console.log('⚠️ Step 3 컴포넌트 Undo stack이 비어있습니다');
-          }
-        }
-        // Cmd+Shift+Z (Mac) 또는 Ctrl+Y (Windows) - Redo
-        else if ((e.ctrlKey || e.metaKey) && (e.key === 'y' || (e.key === 'z' && e.shiftKey))) {
-          e.preventDefault();
-          e.stopImmediatePropagation();
-          
-          if (redoStackRef.current.length > 0) {
-            console.log('↪️ Redo (Step 3 컴포넌트 편집) - stack:', redoStackRef.current.length);
-            
-            // 현재 상태를 undo stack에 저장
-            undoStackRef.current.push(currentHtmlRef.current);
-            
-            // redo stack에서 다음 상태 복원
-            const nextHtml = redoStackRef.current.pop()!;
-            currentHtmlRef.current = nextHtml;
-            
-            // iframe에 HTML 복원
-            iframeDoc.open();
-            iframeDoc.write(nextHtml);
-            iframeDoc.close();
-            
-            onHtmlChange(nextHtml);
-            
-            // 컴포넌트 편집 모드 다시 초기화
-            setTimeout(() => {
-              const newIframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-              if (!newIframeDoc) return;
-              
-              // contentEditable 비활성화
-              const editableElements = newIframeDoc.querySelectorAll('[contenteditable="true"]');
-              editableElements.forEach((el) => {
-                (el as HTMLElement).contentEditable = 'false';
-                (el as HTMLElement).style.cursor = 'default';
-              });
-              
-              // 컴포넌트 클릭 핸들러 추가
-              const componentElements = newIframeDoc.querySelectorAll('div, section, article, header, footer, main, aside, nav, p, h1, h2, h3, h4, h5, h6');
-              
-              const handleComponentClick = (e: Event) => {
-                e.stopPropagation();
-                e.preventDefault();
-                
-                const target = e.target as HTMLElement;
-                if (!target || ['SCRIPT', 'STYLE', 'NOSCRIPT', 'HTML', 'HEAD', 'BODY'].includes(target.tagName)) return;
-                
-                const isSelected = target.classList.contains('component-selected');
-                
-                if (isSelected) {
-                  target.classList.remove('component-selected');
-                  target.style.outline = '1px dashed #C0C0C0';
-                  target.style.boxShadow = 'none';
-                  target.style.backgroundColor = '';
-                  setSelectedElements(prev => prev.filter(el => el !== target));
-                } else {
-                  target.classList.add('component-selected');
-                  target.style.outline = '4px solid #28a745';
-                  target.style.outlineOffset = '3px';
-                  target.style.backgroundColor = 'rgba(40, 167, 69, 0.25)';
-                  target.style.boxShadow = '0 0 0 4px rgba(40, 167, 69, 0.4), 0 4px 12px rgba(40, 167, 69, 0.5)';
-                  target.style.transition = 'all 0.2s ease';
-                  setSelectedElements(prev => [...prev, target]);
-                }
-              };
-              
-              componentElements.forEach((el) => {
-                if (el.tagName && !['SCRIPT', 'STYLE', 'NOSCRIPT', 'HTML', 'HEAD', 'BODY'].includes(el.tagName)) {
-                  const htmlEl = el as HTMLElement;
-                  htmlEl.setAttribute('data-component-editable', 'true');
-                  htmlEl.style.cursor = 'pointer';
-                  htmlEl.style.outline = '1px dashed #C0C0C0';
-                  
-                  const existingHandler = componentClickHandlersRef.current.get(htmlEl);
-                  if (existingHandler) {
-                    htmlEl.removeEventListener('click', existingHandler, true);
-                  }
-                  htmlEl.addEventListener('click', handleComponentClick, true);
-                  componentClickHandlersRef.current.set(htmlEl, handleComponentClick);
-                }
-              });
-              
-              // 링크 클릭 방지 핸들러 추가
-              const allLinks = newIframeDoc.querySelectorAll('a');
-              const preventLinkNavigation = (e: Event) => {
-                e.preventDefault();
-                e.stopPropagation();
-                e.stopImmediatePropagation();
-                return false;
-              };
-              
-              allLinks.forEach(link => {
-                const htmlLink = link as HTMLElement;
-                const existingLinkHandler = linkClickHandlersRef.current.get(htmlLink);
-                if (existingLinkHandler) {
-                  htmlLink.removeEventListener('click', existingLinkHandler, true);
-                }
-                htmlLink.addEventListener('click', preventLinkNavigation, true);
-                linkClickHandlersRef.current.set(htmlLink, preventLinkNavigation);
-                htmlLink.style.cursor = 'pointer';
-              });
-              
-              if (newIframeDoc.body) {
-                newIframeDoc.body.setAttribute('tabindex', '-1');
-                newIframeDoc.body.focus();
-              }
-            }, 100);
-            
-            setSelectedElements([]);
-          } else {
-            console.log('⚠️ Step 3 컴포넌트 Redo stack이 비어있습니다');
-          }
-        }
-      };
-      
-      // 기존 리스너 제거
-      if (iframeKeydownHandlerRef.current && iframeDoc) {
-        iframeDoc.removeEventListener('keydown', iframeKeydownHandlerRef.current, true);
-      }
-      // 새 리스너 등록 및 저장
-      iframeKeydownHandlerRef.current = handleComponentKeydown;
-      iframeDoc.addEventListener('keydown', handleComponentKeydown, true);
-      console.log('✅ Step 3 컴포넌트 모드 키보드 단축키 등록 완료');
-      
-      // 부모 window에서도 이벤트 잡기 (iframe 포커스가 없을 때 대비)
-      const handleWindowKeydown = (e: KeyboardEvent) => {
-        console.log('🔑 Step 3 window 키 감지:', e.key, 'ctrl:', e.ctrlKey, 'meta:', e.metaKey, 'shift:', e.shiftKey);
-        
-        // Ctrl+Z (되돌리기)
-        if ((e.ctrlKey || e.metaKey) && e.key === 'z' && !e.shiftKey) {
-          e.preventDefault();
-          e.stopImmediatePropagation();
-          
-          if (undoStackRef.current.length > 0 && iframeDoc) {
-            console.log('↩️ Undo (Step 3 컴포넌트 편집 - window)');
-            console.log('📊 Step 3 Undo stack:', undoStackRef.current.length, '| Redo stack:', redoStackRef.current.length);
-            
-            redoStackRef.current.push(currentHtmlRef.current);
-            const previousHtml = undoStackRef.current.pop()!;
-            console.log('📊 Step 3 Undo 후 - Undo stack:', undoStackRef.current.length, '| Redo stack:', redoStackRef.current.length);
-            currentHtmlRef.current = previousHtml;
-            
-            iframeDoc.open();
-            iframeDoc.write(previousHtml);
-            iframeDoc.close();
-            
-            onHtmlChange(previousHtml);
-            setSelectedElements([]);
-            
-            // ⭐ html 의존성 배열에 추가되어 useEffect가 자동으로 재실행됨
-          }
-        }
-        // Ctrl+Shift+Z 또는 Ctrl+Y (다시 실행)
-        else if ((e.ctrlKey || e.metaKey) && (e.key === 'y' || (e.key === 'z' && e.shiftKey))) {
-          e.preventDefault();
-          e.stopImmediatePropagation();
-          console.log('🔑 Step 3 Redo 키 감지! key:', e.key, 'Redo stack:', redoStackRef.current.length);
-          
-          if (redoStackRef.current.length > 0 && iframeDoc) {
-            console.log('↪️ Redo (Step 3 컴포넌트 편집 - window)');
-            console.log('📊 Step 3 Redo 전 - Undo stack:', undoStackRef.current.length, '| Redo stack:', redoStackRef.current.length);
-            
-            undoStackRef.current.push(currentHtmlRef.current);
-            const nextHtml = redoStackRef.current.pop()!;
-            console.log('📊 Step 3 Redo 후 - Undo stack:', undoStackRef.current.length, '| Redo stack:', redoStackRef.current.length);
-            currentHtmlRef.current = nextHtml;
-            
-            iframeDoc.open();
-            iframeDoc.write(nextHtml);
-            iframeDoc.close();
-            
-            onHtmlChange(nextHtml);
-            setSelectedElements([]);
-            
-            // ⭐ html 의존성 배열에 추가되어 useEffect가 자동으로 재실행됨
-          } else {
-            console.log('⚠️ Step 3 Redo stack이 비어있음 (window)');
-          }
-        }
-      };
-      
-      // 기존 window 리스너 제거
-      if (windowKeydownHandlerRef.current) {
-        window.removeEventListener('keydown', windowKeydownHandlerRef.current, true);
-      }
-      // 새 window 리스너 등록 및 저장
-      windowKeydownHandlerRef.current = handleWindowKeydown;
-      window.addEventListener('keydown', handleWindowKeydown, true);
-      prevModeRef.current = 'component';
-      console.log('✅ Step 3 window 키보드 이벤트 리스너 등록 완료');
-      
-    } else if (mode === 'spacing') {
-      // 수동 공백 제거 모드 (컴포넌트 편집 모드와 동일하게 전역 스타일로 점선 적용)
-      const editableElements = iframeDoc.querySelectorAll('[contenteditable="true"]');
-      editableElements.forEach((el) => {
-        (el as HTMLElement).contentEditable = 'false';
-        (el as HTMLElement).style.cursor = 'pointer';
-      });
-      linkClickHandlersRef.current.forEach((handler, link) => {
-        link.removeEventListener('click', handler, true);
-      });
-      linkClickHandlersRef.current.clear();
-      const linkStyle = iframeDoc.getElementById('text-edit-link-style');
-      if (linkStyle) linkStyle.remove();
-      const componentElements = iframeDoc.querySelectorAll('[data-component-editable]');
-      componentElements.forEach(el => {
-        const htmlEl = el as HTMLElement;
-        htmlEl.style.outline = 'none';
-        htmlEl.style.boxShadow = 'none';
-        htmlEl.classList.remove('component-selected');
-        htmlEl.removeAttribute('data-component-editable');
-        const handler = componentClickHandlersRef.current.get(htmlEl);
-        if (handler) {
-          htmlEl.removeEventListener('click', handler, true);
-          componentClickHandlersRef.current.delete(htmlEl);
-        }
-      });
-      componentClickHandlersRef.current.clear();
-      const transflowElements = iframeDoc.querySelectorAll('[data-transflow-id]');
-      transflowElements.forEach(el => {
-        const htmlEl = el as HTMLElement;
-        htmlEl.style.outline = 'none';
-        htmlEl.style.boxShadow = 'none';
-      });
-      // 컴포넌트 모드처럼 전역 스타일로 점선 적용
-      const spacingGlobalStyle = iframeDoc.getElementById('transflow-spacing-global-style') as HTMLStyleElement | null;
-      if (spacingGlobalStyle) spacingGlobalStyle.remove();
-      const newSpacingGlobalStyle = iframeDoc.createElement('style');
-      newSpacingGlobalStyle.id = 'transflow-spacing-global-style';
-      newSpacingGlobalStyle.textContent = `
+			iframeDoc.head.appendChild(newComponentGlobalStyle);
+
+			const componentElements = iframeDoc.querySelectorAll(
+				"div, section, article, header, footer, main, aside, nav, p, h1, h2, h3, h4, h5, h6",
+			);
+
+			// 컴포넌트 클릭 핸들러 (다중 선택 + 토글)
+			const handleComponentClick = (e: Event) => {
+				e.stopPropagation();
+				e.preventDefault();
+
+				const target = e.target as HTMLElement;
+				if (
+					!target ||
+					["SCRIPT", "STYLE", "NOSCRIPT", "HTML", "HEAD", "BODY"].includes(
+						target.tagName,
+					)
+				)
+					return;
+
+				console.log("🎯 컴포넌트 클릭:", target.tagName);
+
+				// 이미 선택된 요소인지 확인 (토글)
+				const isSelected = target.classList.contains("component-selected");
+
+				if (isSelected) {
+					// 선택 해제
+					target.classList.remove("component-selected");
+					target.style.setProperty(
+						"outline",
+						"2px dashed #C0C0C0",
+						"important",
+					);
+					target.style.setProperty("outline-offset", "2px", "important");
+					target.style.setProperty("box-shadow", "none", "important");
+					target.style.setProperty("background-color", "", "important");
+					console.log("❌ 선택 해제:", target.tagName);
+
+					setSelectedElements((prev) => prev.filter((el) => el !== target));
+				} else {
+					// 선택 추가 (STEP 2와 동일한 녹색 스타일, !important로 붙여넣은 스타일 덮어쓰기)
+					target.classList.add("component-selected");
+					target.style.setProperty("outline", "4px solid #28a745", "important");
+					target.style.setProperty("outline-offset", "3px", "important");
+					target.style.setProperty(
+						"background-color",
+						"rgba(40, 167, 69, 0.25)",
+						"important",
+					);
+					target.style.setProperty(
+						"box-shadow",
+						"0 0 0 4px rgba(40, 167, 69, 0.4), 0 4px 12px rgba(40, 167, 69, 0.5)",
+						"important",
+					);
+					console.log("✅ 선택 추가:", target.tagName);
+
+					setSelectedElements((prev) => [...prev, target]);
+				}
+			};
+
+			componentElements.forEach((el) => {
+				if (
+					el.tagName &&
+					!["SCRIPT", "STYLE", "NOSCRIPT", "HTML", "HEAD", "BODY"].includes(
+						el.tagName,
+					)
+				) {
+					const htmlEl = el as HTMLElement;
+					htmlEl.setAttribute("data-component-editable", "true");
+					htmlEl.style.cursor = "pointer";
+					htmlEl.style.setProperty(
+						"outline",
+						"2px dashed #C0C0C0",
+						"important",
+					);
+					htmlEl.style.setProperty("outline-offset", "2px", "important");
+
+					// 기존 핸들러가 있으면 제거
+					const existingHandler = componentClickHandlersRef.current.get(htmlEl);
+					if (existingHandler) {
+						htmlEl.removeEventListener("click", existingHandler, true);
+					}
+
+					// 클릭 이벤트 리스너 추가 및 저장
+					htmlEl.addEventListener("click", handleComponentClick, true);
+					componentClickHandlersRef.current.set(htmlEl, handleComponentClick);
+				}
+			});
+
+			// ⭐ 링크 클릭 방지 (다른 사이트로 이동 방지)
+			const allLinks = iframeDoc.querySelectorAll("a");
+			const preventLinkNavigation = (e: Event) => {
+				e.preventDefault();
+				e.stopPropagation();
+				e.stopImmediatePropagation();
+				return false;
+			};
+
+			allLinks.forEach((link) => {
+				const htmlLink = link as HTMLElement;
+				// 기존 핸들러가 있으면 제거
+				const existingLinkHandler = linkClickHandlersRef.current.get(htmlLink);
+				if (existingLinkHandler) {
+					htmlLink.removeEventListener("click", existingLinkHandler, true);
+				}
+				htmlLink.addEventListener("click", preventLinkNavigation, true);
+				linkClickHandlersRef.current.set(htmlLink, preventLinkNavigation);
+				htmlLink.style.cursor = "pointer";
+			});
+
+			console.log(
+				"✅ 컴포넌트 클릭 리스너 추가 완료:",
+				componentElements.length,
+				"개",
+			);
+			console.log("✅ 링크 클릭 방지 핸들러 추가 완료:", allLinks.length, "개");
+
+			// ⭐ 컴포넌트 모드 키보드 단축키 (Ctrl+Z, Ctrl+Shift+Z)
+			const handleComponentKeydown = (e: KeyboardEvent) => {
+				console.log(
+					"🔑 Step 3 iframe 키 감지:",
+					e.key,
+					"ctrl:",
+					e.ctrlKey,
+					"meta:",
+					e.metaKey,
+					"shift:",
+					e.shiftKey,
+				);
+				// Cmd+Z (Mac) 또는 Ctrl+Z (Windows) - Undo
+				if ((e.ctrlKey || e.metaKey) && e.key === "z" && !e.shiftKey) {
+					e.preventDefault();
+					e.stopImmediatePropagation();
+
+					if (undoStackRef.current.length > 0) {
+						console.log(
+							"↩️ Undo (Step 3 컴포넌트 편집) - stack:",
+							undoStackRef.current.length,
+						);
+
+						// 현재 상태를 redo stack에 저장
+						redoStackRef.current.push(currentHtmlRef.current);
+
+						// undo stack에서 이전 상태 복원
+						const previousHtml = undoStackRef.current.pop()!;
+						currentHtmlRef.current = previousHtml;
+
+						// iframe에 HTML 복원
+						iframeDoc.open();
+						iframeDoc.write(previousHtml);
+						iframeDoc.close();
+
+						onHtmlChange(previousHtml);
+
+						// 컴포넌트 편집 모드 다시 초기화
+						setTimeout(() => {
+							const newIframeDoc =
+								iframe.contentDocument || iframe.contentWindow?.document;
+							if (!newIframeDoc) return;
+
+							// contentEditable 비활성화
+							const editableElements = newIframeDoc.querySelectorAll(
+								'[contenteditable="true"]',
+							);
+							editableElements.forEach((el) => {
+								(el as HTMLElement).contentEditable = "false";
+								(el as HTMLElement).style.cursor = "default";
+							});
+
+							// 컴포넌트 클릭 핸들러 추가
+							const componentElements = newIframeDoc.querySelectorAll(
+								"div, section, article, header, footer, main, aside, nav, p, h1, h2, h3, h4, h5, h6",
+							);
+
+							const handleComponentClick = (e: Event) => {
+								e.stopPropagation();
+								e.preventDefault();
+
+								const target = e.target as HTMLElement;
+								if (
+									!target ||
+									[
+										"SCRIPT",
+										"STYLE",
+										"NOSCRIPT",
+										"HTML",
+										"HEAD",
+										"BODY",
+									].includes(target.tagName)
+								)
+									return;
+
+								const isSelected =
+									target.classList.contains("component-selected");
+
+								if (isSelected) {
+									target.classList.remove("component-selected");
+									target.style.outline = "1px dashed #C0C0C0";
+									target.style.boxShadow = "none";
+									target.style.backgroundColor = "";
+									setSelectedElements((prev) =>
+										prev.filter((el) => el !== target),
+									);
+								} else {
+									target.classList.add("component-selected");
+									target.style.outline = "4px solid #28a745";
+									target.style.outlineOffset = "3px";
+									target.style.backgroundColor = "rgba(40, 167, 69, 0.25)";
+									target.style.boxShadow =
+										"0 0 0 4px rgba(40, 167, 69, 0.4), 0 4px 12px rgba(40, 167, 69, 0.5)";
+									target.style.transition = "all 0.2s ease";
+									setSelectedElements((prev) => [...prev, target]);
+								}
+							};
+
+							componentElements.forEach((el) => {
+								if (
+									el.tagName &&
+									![
+										"SCRIPT",
+										"STYLE",
+										"NOSCRIPT",
+										"HTML",
+										"HEAD",
+										"BODY",
+									].includes(el.tagName)
+								) {
+									const htmlEl = el as HTMLElement;
+									htmlEl.setAttribute("data-component-editable", "true");
+									htmlEl.style.cursor = "pointer";
+									htmlEl.style.outline = "1px dashed #C0C0C0";
+
+									const existingHandler =
+										componentClickHandlersRef.current.get(htmlEl);
+									if (existingHandler) {
+										htmlEl.removeEventListener("click", existingHandler, true);
+									}
+									htmlEl.addEventListener("click", handleComponentClick, true);
+									componentClickHandlersRef.current.set(
+										htmlEl,
+										handleComponentClick,
+									);
+								}
+							});
+
+							// 링크 클릭 방지 핸들러 추가
+							const allLinks = newIframeDoc.querySelectorAll("a");
+							const preventLinkNavigation = (e: Event) => {
+								e.preventDefault();
+								e.stopPropagation();
+								e.stopImmediatePropagation();
+								return false;
+							};
+
+							allLinks.forEach((link) => {
+								const htmlLink = link as HTMLElement;
+								const existingLinkHandler =
+									linkClickHandlersRef.current.get(htmlLink);
+								if (existingLinkHandler) {
+									htmlLink.removeEventListener(
+										"click",
+										existingLinkHandler,
+										true,
+									);
+								}
+								htmlLink.addEventListener("click", preventLinkNavigation, true);
+								linkClickHandlersRef.current.set(
+									htmlLink,
+									preventLinkNavigation,
+								);
+								htmlLink.style.cursor = "pointer";
+							});
+
+							if (newIframeDoc.body) {
+								newIframeDoc.body.setAttribute("tabindex", "-1");
+								newIframeDoc.body.focus();
+							}
+						}, 100);
+
+						setSelectedElements([]);
+					} else {
+						console.log("⚠️ Step 3 컴포넌트 Undo stack이 비어있습니다");
+					}
+				}
+				// Cmd+Shift+Z (Mac) 또는 Ctrl+Y (Windows) - Redo
+				else if (
+					(e.ctrlKey || e.metaKey) &&
+					(e.key === "y" || (e.key === "z" && e.shiftKey))
+				) {
+					e.preventDefault();
+					e.stopImmediatePropagation();
+
+					if (redoStackRef.current.length > 0) {
+						console.log(
+							"↪️ Redo (Step 3 컴포넌트 편집) - stack:",
+							redoStackRef.current.length,
+						);
+
+						// 현재 상태를 undo stack에 저장
+						undoStackRef.current.push(currentHtmlRef.current);
+
+						// redo stack에서 다음 상태 복원
+						const nextHtml = redoStackRef.current.pop()!;
+						currentHtmlRef.current = nextHtml;
+
+						// iframe에 HTML 복원
+						iframeDoc.open();
+						iframeDoc.write(nextHtml);
+						iframeDoc.close();
+
+						onHtmlChange(nextHtml);
+
+						// 컴포넌트 편집 모드 다시 초기화
+						setTimeout(() => {
+							const newIframeDoc =
+								iframe.contentDocument || iframe.contentWindow?.document;
+							if (!newIframeDoc) return;
+
+							// contentEditable 비활성화
+							const editableElements = newIframeDoc.querySelectorAll(
+								'[contenteditable="true"]',
+							);
+							editableElements.forEach((el) => {
+								(el as HTMLElement).contentEditable = "false";
+								(el as HTMLElement).style.cursor = "default";
+							});
+
+							// 컴포넌트 클릭 핸들러 추가
+							const componentElements = newIframeDoc.querySelectorAll(
+								"div, section, article, header, footer, main, aside, nav, p, h1, h2, h3, h4, h5, h6",
+							);
+
+							const handleComponentClick = (e: Event) => {
+								e.stopPropagation();
+								e.preventDefault();
+
+								const target = e.target as HTMLElement;
+								if (
+									!target ||
+									[
+										"SCRIPT",
+										"STYLE",
+										"NOSCRIPT",
+										"HTML",
+										"HEAD",
+										"BODY",
+									].includes(target.tagName)
+								)
+									return;
+
+								const isSelected =
+									target.classList.contains("component-selected");
+
+								if (isSelected) {
+									target.classList.remove("component-selected");
+									target.style.outline = "1px dashed #C0C0C0";
+									target.style.boxShadow = "none";
+									target.style.backgroundColor = "";
+									setSelectedElements((prev) =>
+										prev.filter((el) => el !== target),
+									);
+								} else {
+									target.classList.add("component-selected");
+									target.style.outline = "4px solid #28a745";
+									target.style.outlineOffset = "3px";
+									target.style.backgroundColor = "rgba(40, 167, 69, 0.25)";
+									target.style.boxShadow =
+										"0 0 0 4px rgba(40, 167, 69, 0.4), 0 4px 12px rgba(40, 167, 69, 0.5)";
+									target.style.transition = "all 0.2s ease";
+									setSelectedElements((prev) => [...prev, target]);
+								}
+							};
+
+							componentElements.forEach((el) => {
+								if (
+									el.tagName &&
+									![
+										"SCRIPT",
+										"STYLE",
+										"NOSCRIPT",
+										"HTML",
+										"HEAD",
+										"BODY",
+									].includes(el.tagName)
+								) {
+									const htmlEl = el as HTMLElement;
+									htmlEl.setAttribute("data-component-editable", "true");
+									htmlEl.style.cursor = "pointer";
+									htmlEl.style.outline = "1px dashed #C0C0C0";
+
+									const existingHandler =
+										componentClickHandlersRef.current.get(htmlEl);
+									if (existingHandler) {
+										htmlEl.removeEventListener("click", existingHandler, true);
+									}
+									htmlEl.addEventListener("click", handleComponentClick, true);
+									componentClickHandlersRef.current.set(
+										htmlEl,
+										handleComponentClick,
+									);
+								}
+							});
+
+							// 링크 클릭 방지 핸들러 추가
+							const allLinks = newIframeDoc.querySelectorAll("a");
+							const preventLinkNavigation = (e: Event) => {
+								e.preventDefault();
+								e.stopPropagation();
+								e.stopImmediatePropagation();
+								return false;
+							};
+
+							allLinks.forEach((link) => {
+								const htmlLink = link as HTMLElement;
+								const existingLinkHandler =
+									linkClickHandlersRef.current.get(htmlLink);
+								if (existingLinkHandler) {
+									htmlLink.removeEventListener(
+										"click",
+										existingLinkHandler,
+										true,
+									);
+								}
+								htmlLink.addEventListener("click", preventLinkNavigation, true);
+								linkClickHandlersRef.current.set(
+									htmlLink,
+									preventLinkNavigation,
+								);
+								htmlLink.style.cursor = "pointer";
+							});
+
+							if (newIframeDoc.body) {
+								newIframeDoc.body.setAttribute("tabindex", "-1");
+								newIframeDoc.body.focus();
+							}
+						}, 100);
+
+						setSelectedElements([]);
+					} else {
+						console.log("⚠️ Step 3 컴포넌트 Redo stack이 비어있습니다");
+					}
+				}
+			};
+
+			// 기존 리스너 제거
+			if (iframeKeydownHandlerRef.current && iframeDoc) {
+				iframeDoc.removeEventListener(
+					"keydown",
+					iframeKeydownHandlerRef.current,
+					true,
+				);
+			}
+			// 새 리스너 등록 및 저장
+			iframeKeydownHandlerRef.current = handleComponentKeydown;
+			iframeDoc.addEventListener("keydown", handleComponentKeydown, true);
+			console.log("✅ Step 3 컴포넌트 모드 키보드 단축키 등록 완료");
+
+			// 부모 window에서도 이벤트 잡기 (iframe 포커스가 없을 때 대비)
+			const handleWindowKeydown = (e: KeyboardEvent) => {
+				console.log(
+					"🔑 Step 3 window 키 감지:",
+					e.key,
+					"ctrl:",
+					e.ctrlKey,
+					"meta:",
+					e.metaKey,
+					"shift:",
+					e.shiftKey,
+				);
+
+				// Ctrl+Z (되돌리기)
+				if ((e.ctrlKey || e.metaKey) && e.key === "z" && !e.shiftKey) {
+					e.preventDefault();
+					e.stopImmediatePropagation();
+
+					if (undoStackRef.current.length > 0 && iframeDoc) {
+						console.log("↩️ Undo (Step 3 컴포넌트 편집 - window)");
+						console.log(
+							"📊 Step 3 Undo stack:",
+							undoStackRef.current.length,
+							"| Redo stack:",
+							redoStackRef.current.length,
+						);
+
+						redoStackRef.current.push(currentHtmlRef.current);
+						const previousHtml = undoStackRef.current.pop()!;
+						console.log(
+							"📊 Step 3 Undo 후 - Undo stack:",
+							undoStackRef.current.length,
+							"| Redo stack:",
+							redoStackRef.current.length,
+						);
+						currentHtmlRef.current = previousHtml;
+
+						iframeDoc.open();
+						iframeDoc.write(previousHtml);
+						iframeDoc.close();
+
+						onHtmlChange(previousHtml);
+						setSelectedElements([]);
+
+						// ⭐ html 의존성 배열에 추가되어 useEffect가 자동으로 재실행됨
+					}
+				}
+				// Ctrl+Shift+Z 또는 Ctrl+Y (다시 실행)
+				else if (
+					(e.ctrlKey || e.metaKey) &&
+					(e.key === "y" || (e.key === "z" && e.shiftKey))
+				) {
+					e.preventDefault();
+					e.stopImmediatePropagation();
+					console.log(
+						"🔑 Step 3 Redo 키 감지! key:",
+						e.key,
+						"Redo stack:",
+						redoStackRef.current.length,
+					);
+
+					if (redoStackRef.current.length > 0 && iframeDoc) {
+						console.log("↪️ Redo (Step 3 컴포넌트 편집 - window)");
+						console.log(
+							"📊 Step 3 Redo 전 - Undo stack:",
+							undoStackRef.current.length,
+							"| Redo stack:",
+							redoStackRef.current.length,
+						);
+
+						undoStackRef.current.push(currentHtmlRef.current);
+						const nextHtml = redoStackRef.current.pop()!;
+						console.log(
+							"📊 Step 3 Redo 후 - Undo stack:",
+							undoStackRef.current.length,
+							"| Redo stack:",
+							redoStackRef.current.length,
+						);
+						currentHtmlRef.current = nextHtml;
+
+						iframeDoc.open();
+						iframeDoc.write(nextHtml);
+						iframeDoc.close();
+
+						onHtmlChange(nextHtml);
+						setSelectedElements([]);
+
+						// ⭐ html 의존성 배열에 추가되어 useEffect가 자동으로 재실행됨
+					} else {
+						console.log("⚠️ Step 3 Redo stack이 비어있음 (window)");
+					}
+				}
+			};
+
+			// 기존 window 리스너 제거
+			if (windowKeydownHandlerRef.current) {
+				window.removeEventListener(
+					"keydown",
+					windowKeydownHandlerRef.current,
+					true,
+				);
+			}
+			// 새 window 리스너 등록 및 저장
+			windowKeydownHandlerRef.current = handleWindowKeydown;
+			window.addEventListener("keydown", handleWindowKeydown, true);
+			prevModeRef.current = "component";
+			console.log("✅ Step 3 window 키보드 이벤트 리스너 등록 완료");
+		} else if (mode === "spacing") {
+			// 수동 공백 제거 모드 (컴포넌트 편집 모드와 동일하게 전역 스타일로 점선 적용)
+			const editableElements = iframeDoc.querySelectorAll(
+				'[contenteditable="true"]',
+			);
+			editableElements.forEach((el) => {
+				(el as HTMLElement).contentEditable = "false";
+				(el as HTMLElement).style.cursor = "pointer";
+			});
+			linkClickHandlersRef.current.forEach((handler, link) => {
+				link.removeEventListener("click", handler, true);
+			});
+			linkClickHandlersRef.current.clear();
+			const linkStyle = iframeDoc.getElementById("text-edit-link-style");
+			if (linkStyle) linkStyle.remove();
+			const componentElements = iframeDoc.querySelectorAll(
+				"[data-component-editable]",
+			);
+			componentElements.forEach((el) => {
+				const htmlEl = el as HTMLElement;
+				htmlEl.style.outline = "none";
+				htmlEl.style.boxShadow = "none";
+				htmlEl.classList.remove("component-selected");
+				htmlEl.removeAttribute("data-component-editable");
+				const handler = componentClickHandlersRef.current.get(htmlEl);
+				if (handler) {
+					htmlEl.removeEventListener("click", handler, true);
+					componentClickHandlersRef.current.delete(htmlEl);
+				}
+			});
+			componentClickHandlersRef.current.clear();
+			const transflowElements = iframeDoc.querySelectorAll(
+				"[data-transflow-id]",
+			);
+			transflowElements.forEach((el) => {
+				const htmlEl = el as HTMLElement;
+				htmlEl.style.outline = "none";
+				htmlEl.style.boxShadow = "none";
+			});
+			// 컴포넌트 모드처럼 전역 스타일로 점선 적용
+			const spacingGlobalStyle = iframeDoc.getElementById(
+				"transflow-spacing-global-style",
+			) as HTMLStyleElement | null;
+			if (spacingGlobalStyle) spacingGlobalStyle.remove();
+			const newSpacingGlobalStyle = iframeDoc.createElement("style");
+			newSpacingGlobalStyle.id = "transflow-spacing-global-style";
+			newSpacingGlobalStyle.textContent = `
         [data-spacing-editable="true"] {
           outline: 2px dashed #FFA500 !important;
           outline-offset: 2px !important;
@@ -1598,294 +2033,366 @@ const Step3PreEdit: React.FC<{
           background-color: rgba(255, 165, 0, 0.25) !important;
         }
       `;
-      iframeDoc.head.appendChild(newSpacingGlobalStyle);
-      const handleSpacingClick = (e: Event) => {
-        e.stopPropagation();
-        e.preventDefault();
-        const target = e.target as HTMLElement;
-        if (!target || !target.hasAttribute('data-spacing-editable')) return;
-        const isSelected = target.classList.contains('spacing-selected');
-        if (isSelected) {
-          target.classList.remove('spacing-selected');
-          setSelectedElements(prev => prev.filter(el => el !== target));
-        } else {
-          target.classList.add('spacing-selected');
-          setSelectedElements(prev => [...prev, target]);
-        }
-      };
-      const spacingElements = iframeDoc.querySelectorAll('div, section, article, header, footer, main, aside, nav, p, h1, h2, h3, h4, h5, h6');
-      spacingElements.forEach((el) => {
-        if (el.tagName && !['SCRIPT', 'STYLE', 'NOSCRIPT'].includes(el.tagName)) {
-          const htmlEl = el as HTMLElement;
-          htmlEl.setAttribute('data-spacing-editable', 'true');
-          htmlEl.style.cursor = 'pointer';
-          const existingHandler = spacingClickHandlersRef.current.get(htmlEl);
-          if (existingHandler) htmlEl.removeEventListener('click', existingHandler, true);
-          htmlEl.addEventListener('click', handleSpacingClick, true);
-          spacingClickHandlersRef.current.set(htmlEl, handleSpacingClick);
-        }
-      });
-      const allLinks = iframeDoc.querySelectorAll('a');
-      const preventLinkNav = (ev: Event) => { ev.preventDefault(); ev.stopPropagation(); return false; };
-      allLinks.forEach(link => {
-        const htmlLink = link as HTMLElement;
-        const existing = linkClickHandlersRef.current.get(htmlLink);
-        if (existing) htmlLink.removeEventListener('click', existing, true);
-        htmlLink.addEventListener('click', preventLinkNav, true);
-        linkClickHandlersRef.current.set(htmlLink, preventLinkNav);
-      });
-      // 모드 전환 시에만 선택 초기화 (작업 후 재진입 시 선택 유지)
-      if (prevModeRef.current !== 'spacing') {
-        setSelectedElements([]);
-      }
-      prevModeRef.current = 'spacing';
-      console.log('✅ 수동 공백 제거 모드 활성화');
-    }
-    
-    // ⭐ Cleanup: window 이벤트 리스너 제거
-    return () => {
-      console.log('🧹 Step 3 cleanup: 이벤트 리스너 제거');
-      // window 리스너 제거
-      if (windowKeydownHandlerRef.current) {
-        window.removeEventListener('keydown', windowKeydownHandlerRef.current, true);
-        console.log('✅ Step 3 window 키보드 리스너 제거');
-      }
-      // iframe 리스너는 모드 전환 시 자동으로 제거됨 (DOM이 재설정되므로)
-    };
-  }, [mode, isInitialized, html]); // ⭐ html 추가하여 undo/redo 후 자동 재활성화
+			iframeDoc.head.appendChild(newSpacingGlobalStyle);
+			const handleSpacingClick = (e: Event) => {
+				e.stopPropagation();
+				e.preventDefault();
+				const target = e.target as HTMLElement;
+				if (!target || !target.hasAttribute("data-spacing-editable")) return;
+				const isSelected = target.classList.contains("spacing-selected");
+				if (isSelected) {
+					target.classList.remove("spacing-selected");
+					setSelectedElements((prev) => prev.filter((el) => el !== target));
+				} else {
+					target.classList.add("spacing-selected");
+					setSelectedElements((prev) => [...prev, target]);
+				}
+			};
+			const spacingElements = iframeDoc.querySelectorAll(
+				"div, section, article, header, footer, main, aside, nav, p, h1, h2, h3, h4, h5, h6",
+			);
+			spacingElements.forEach((el) => {
+				if (
+					el.tagName &&
+					!["SCRIPT", "STYLE", "NOSCRIPT"].includes(el.tagName)
+				) {
+					const htmlEl = el as HTMLElement;
+					htmlEl.setAttribute("data-spacing-editable", "true");
+					htmlEl.style.cursor = "pointer";
+					const existingHandler = spacingClickHandlersRef.current.get(htmlEl);
+					if (existingHandler)
+						htmlEl.removeEventListener("click", existingHandler, true);
+					htmlEl.addEventListener("click", handleSpacingClick, true);
+					spacingClickHandlersRef.current.set(htmlEl, handleSpacingClick);
+				}
+			});
+			const allLinks = iframeDoc.querySelectorAll("a");
+			const preventLinkNav = (ev: Event) => {
+				ev.preventDefault();
+				ev.stopPropagation();
+				return false;
+			};
+			allLinks.forEach((link) => {
+				const htmlLink = link as HTMLElement;
+				const existing = linkClickHandlersRef.current.get(htmlLink);
+				if (existing) htmlLink.removeEventListener("click", existing, true);
+				htmlLink.addEventListener("click", preventLinkNav, true);
+				linkClickHandlersRef.current.set(htmlLink, preventLinkNav);
+			});
+			// 모드 전환 시에만 선택 초기화 (작업 후 재진입 시 선택 유지)
+			if (prevModeRef.current !== "spacing") {
+				setSelectedElements([]);
+			}
+			prevModeRef.current = "spacing";
+			console.log("✅ 수동 공백 제거 모드 활성화");
+		}
 
-  // 초기 렌더링만 수행 (한 번만 실행)
-  useEffect(() => {
-    if (isInitialized) return; // 이미 초기화되었으면 스킵
-    
-    console.log('📝 Step3PreEdit 초기 렌더링:', {
-      hasIframe: !!iframeRef.current,
-      hasHtml: !!html,
-      selectedAreasCount: selectedAreas.length,
-      isManualPasteMode,
-    });
-    
-    const canInit = iframeRef.current && (html || isManualPasteMode) && (selectedAreas.length > 0 || isManualPasteMode);
-    if (canInit) {
-      const iframe = iframeRef.current!;
-      const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-      
-      if (iframeDoc) {
-        // 수동 붙여넣기 모드: 최소 HTML 사용
-        let htmlContent = isManualPasteMode ? MANUAL_PASTE_HTML : html;
-        
-        // HTML 구조 확인 및 보완
-        const hasDoctype = htmlContent.trim().toLowerCase().startsWith('<!doctype');
-        const hasHtml = htmlContent.includes('<html');
-        const hasBody = htmlContent.includes('<body');
-        
-        if (!hasDoctype || !hasHtml || !hasBody) {
-          if (!htmlContent.includes('<body')) {
-            htmlContent = `<body>${htmlContent}</body>`;
-          }
-          if (!htmlContent.includes('<html')) {
-            htmlContent = `<html>${htmlContent}</html>`;
-          }
-          if (!htmlContent.includes('<head>')) {
-            htmlContent = htmlContent.replace('<html>', '<html><head></head>');
-          }
-          if (!hasDoctype) {
-            htmlContent = `<!DOCTYPE html>${htmlContent}`;
-          }
-        }
-        
-        try {
-          iframeDoc.open();
-          iframeDoc.write(htmlContent);
-          iframeDoc.close();
-        } catch (error) {
-          // iframe 내부 스크립트 에러는 무시 (크롤링된 페이지의 스크립트 에러)
-          console.warn('iframe write error (ignored):', error);
-        }
-        
-        // Translation.jsx의 handleStartPreEdit 로직: 선택된 영역만 남기고 나머지 제거 (수동 모드에서는 스킵)
-        setTimeout(() => {
-          if (iframeDoc.body) {
-            if (!isManualPasteMode) {
-              const selectedElementIds = new Set(selectedAreas.map(area => area.id));
-            console.log('🔍 선택된 요소 ID 목록:', Array.from(selectedElementIds));
-            
-            // 모든 data-transflow-id 속성을 가진 요소 찾기
-            const allElementsWithId = iframeDoc.querySelectorAll('[data-transflow-id]');
-            console.log('📦 iframe 내 data-transflow-id 요소:', 
-              Array.from(allElementsWithId).map(el => ({
-                id: el.getAttribute('data-transflow-id'),
-                tag: el.tagName,
-                selected: selectedElementIds.has(el.getAttribute('data-transflow-id') || '')
-              }))
-            );
-            
-            // 선택되지 않은 요소 제거 (Translation.jsx와 동일)
-            const removeUnselectedElements = (element: HTMLElement): boolean => {
-              if (element.hasAttribute('data-transflow-id')) {
-                const elementId = element.getAttribute('data-transflow-id');
-                if (elementId && selectedElementIds.has(elementId)) {
-                  console.log('✅ 선택된 요소 발견:', elementId, element.tagName);
-                  return true;
-                }
-              }
-              
-              const children = Array.from(element.children) as HTMLElement[];
-              const childrenToKeep: HTMLElement[] = [];
-              
-              children.forEach(child => {
-                if (removeUnselectedElements(child)) {
-                  childrenToKeep.push(child);
-                }
-              });
-              
-              if (childrenToKeep.length > 0) {
-                const allChildren = Array.from(element.children);
-                allChildren.forEach(child => {
-                  if (!childrenToKeep.includes(child as HTMLElement)) {
-                    element.removeChild(child);
-                  }
-                });
-                return true;
-              }
-              
-              return false;
-            };
-            
-            const bodyChildren = Array.from(iframeDoc.body.children) as HTMLElement[];
-            const bodyChildrenToKeep: HTMLElement[] = [];
-            
-            bodyChildren.forEach(child => {
-              if (removeUnselectedElements(child)) {
-                bodyChildrenToKeep.push(child);
-              }
-            });
-            
-            const allBodyChildren = Array.from(iframeDoc.body.children);
-            allBodyChildren.forEach(child => {
-              if (!bodyChildrenToKeep.includes(child as HTMLElement)) {
-                iframeDoc.body.removeChild(child);
-              }
-            });
-            
-            console.log('✨ 최종 body 자식 요소:', iframeDoc.body.children.length, '개');
-            console.log('📄 최종 HTML:', iframeDoc.body.innerHTML.substring(0, 500));
-            
-              // 선택 표시 제거
-              iframeDoc.querySelectorAll('.transflow-selected, .transflow-hovering, .transflow-area-selected').forEach(el => {
-                (el as HTMLElement).classList.remove('transflow-selected', 'transflow-hovering', 'transflow-area-selected');
-              });
-            }
-            
-            // 선택된 영역만 남은 HTML (또는 수동 모드에서는 전체)을 onHtmlChange로 저장
-            const selectedOnlyHtml = iframeDoc.documentElement.outerHTML;
-            console.log('💾 STEP 3 선택된 영역만 저장:', selectedOnlyHtml.substring(0, 200));
-            
-            // 초기 HTML을 currentHtmlRef와 undo stack에 저장
-            currentHtmlRef.current = selectedOnlyHtml;
-            undoStackRef.current = []; // 초기화
-            redoStackRef.current = []; // 초기화
-            // ⭐ 공백 제거 undo stack도 초기화
-            spacingCurrentHtmlRef.current = selectedOnlyHtml;
-            spacingUndoStackRef.current = [];
-            spacingRedoStackRef.current = [];
-            
-            onHtmlChange(selectedOnlyHtml);
-            
-            // 초기화 완료 표시
-            setIsInitialized(true);
-            
-            // 텍스트 편집 모드로 시작 (기본값)
-            if (mode === 'text') {
-              // 텍스트 편집 활성화 (Translation.jsx의 enableTextEditing과 동일)
-              const editableElements = iframeDoc.querySelectorAll('p, h1, h2, h3, h4, h5, h6, span, div, li, ul, ol, blockquote, pre, code, table, tr, td, th, label, a, button, article, section, header, footer, main, aside');
-              
-              editableElements.forEach((el) => {
-                if (el.tagName && !['SCRIPT', 'STYLE', 'NOSCRIPT'].includes(el.tagName)) {
-                  (el as HTMLElement).contentEditable = 'true';
-                  (el as HTMLElement).style.cursor = 'text';
-                }
-              });
-              
-              // 스크립트, 스타일 태그는 편집 불가능하게
-              const scripts = iframeDoc.querySelectorAll('script, style, noscript');
-              scripts.forEach((el) => {
-                (el as HTMLElement).contentEditable = 'false';
-              });
-              
-              // Cmd+Z (Mac) 및 Ctrl+Z (Windows) Undo/Redo 기능
-              const handleKeyDown = (e: KeyboardEvent) => {
-                // Cmd+Z (Mac) 또는 Ctrl+Z (Windows) - Undo
-                if ((e.ctrlKey || e.metaKey) && e.key === 'z' && !e.shiftKey) {
-                  e.preventDefault();
-                  e.stopImmediatePropagation();
-                  iframeDoc.execCommand('undo', false);
-                  const updatedHtml = iframeDoc.documentElement.outerHTML;
-                  onHtmlChange(updatedHtml);
-                }
-                // Cmd+Shift+Z (Mac) 또는 Ctrl+Y (Windows) - Redo
-                else if ((e.ctrlKey || e.metaKey) && (e.key === 'y' || (e.key === 'z' && e.shiftKey))) {
-                  e.preventDefault();
-                  e.stopImmediatePropagation();
-                  iframeDoc.execCommand('redo', false);
-                  const updatedHtml = iframeDoc.documentElement.outerHTML;
-                  onHtmlChange(updatedHtml);
-                }
-                
-                // ⭐ 백스페이스 키 처리 (브라우저 기본 동작 허용)
-                if (e.key === 'Backspace' && !e.ctrlKey && !e.metaKey && !e.altKey) {
-                  // 브라우저가 알아서 처리하게 놔둠 (포커스 유지)
-                  console.log('⌫ 백스페이스 (STEP 3 텍스트 편집)');
-                }
-              };
-              
-              iframeDoc.addEventListener('keydown', handleKeyDown, true);
-              
-              // ⚡ 최적화: input 이벤트 디바운스 (메모리 사용 감소)
-              let inputTimeoutId: NodeJS.Timeout | null = null;
-              const handleInput = () => {
-                // 기존 타이머 취소
-                if (inputTimeoutId) {
-                  clearTimeout(inputTimeoutId);
-                }
-                
-                // 500ms 후에 HTML 추출 (디바운스)
-                inputTimeoutId = setTimeout(() => {
-                  const updatedHtml = iframeDoc.documentElement.outerHTML;
-                  onHtmlChange(updatedHtml);
-                  inputTimeoutId = null;
-                }, 500);
-              };
-              iframeDoc.body.addEventListener('input', handleInput);
-              
-              // ⭐ 붙여넣기 시 웹에서 복사한 HTML 서식 유지
-              const handlePaste = (e: ClipboardEvent) => {
-                e.preventDefault();
-                const html = e.clipboardData?.getData('text/html');
-                const text = e.clipboardData?.getData('text/plain');
-                if (html) {
-                  iframeDoc.execCommand('insertHTML', false, html);
-                } else if (text) {
-                  iframeDoc.execCommand('insertText', false, text);
-                }
-                const updatedHtml = iframeDoc.documentElement.outerHTML;
-                onHtmlChange(updatedHtml);
-              };
-              iframeDoc.addEventListener('paste', handlePaste);
-            } else {
-              // 컴포넌트 편집 모드
-              const allElements = iframeDoc.querySelectorAll('*');
-              
-              // 모든 요소를 편집 불가능하게
-              allElements.forEach((el) => {
-                (el as HTMLElement).contentEditable = 'false';
-                (el as HTMLElement).style.cursor = 'pointer';
-              });
-              
-              // 컴포넌트 선택 스타일 추가
-              const componentStyle = iframeDoc.createElement('style');
-              componentStyle.id = 'transflow-component-style';
-              componentStyle.textContent = `
+		// ⭐ Cleanup: window 이벤트 리스너 제거
+		return () => {
+			console.log("🧹 Step 3 cleanup: 이벤트 리스너 제거");
+			// window 리스너 제거
+			if (windowKeydownHandlerRef.current) {
+				window.removeEventListener(
+					"keydown",
+					windowKeydownHandlerRef.current,
+					true,
+				);
+				console.log("✅ Step 3 window 키보드 리스너 제거");
+			}
+			// iframe 리스너는 모드 전환 시 자동으로 제거됨 (DOM이 재설정되므로)
+		};
+	}, [mode, isInitialized, html]); // ⭐ html 추가하여 undo/redo 후 자동 재활성화
+
+	// 초기 렌더링만 수행 (한 번만 실행)
+	useEffect(() => {
+		if (isInitialized) return; // 이미 초기화되었으면 스킵
+
+		console.log("📝 Step3PreEdit 초기 렌더링:", {
+			hasIframe: !!iframeRef.current,
+			hasHtml: !!html,
+			selectedAreasCount: selectedAreas.length,
+			isManualPasteMode,
+		});
+
+		const canInit =
+			iframeRef.current &&
+			(html || isManualPasteMode) &&
+			(selectedAreas.length > 0 || isManualPasteMode);
+		if (canInit) {
+			const iframe = iframeRef.current!;
+			const iframeDoc =
+				iframe.contentDocument || iframe.contentWindow?.document;
+
+			if (iframeDoc) {
+				// 수동 붙여넣기 모드: 최소 HTML 사용
+				let htmlContent = isManualPasteMode ? MANUAL_PASTE_HTML : html;
+
+				// HTML 구조 확인 및 보완
+				const hasDoctype = htmlContent
+					.trim()
+					.toLowerCase()
+					.startsWith("<!doctype");
+				const hasHtml = htmlContent.includes("<html");
+				const hasBody = htmlContent.includes("<body");
+
+				if (!hasDoctype || !hasHtml || !hasBody) {
+					if (!htmlContent.includes("<body")) {
+						htmlContent = `<body>${htmlContent}</body>`;
+					}
+					if (!htmlContent.includes("<html")) {
+						htmlContent = `<html>${htmlContent}</html>`;
+					}
+					if (!htmlContent.includes("<head>")) {
+						htmlContent = htmlContent.replace("<html>", "<html><head></head>");
+					}
+					if (!hasDoctype) {
+						htmlContent = `<!DOCTYPE html>${htmlContent}`;
+					}
+				}
+
+				try {
+					iframeDoc.open();
+					iframeDoc.write(htmlContent);
+					iframeDoc.close();
+				} catch (error) {
+					// iframe 내부 스크립트 에러는 무시 (크롤링된 페이지의 스크립트 에러)
+					console.warn("iframe write error (ignored):", error);
+				}
+
+				// Translation.jsx의 handleStartPreEdit 로직: 선택된 영역만 남기고 나머지 제거 (수동 모드에서는 스킵)
+				setTimeout(() => {
+					if (iframeDoc.body) {
+						if (!isManualPasteMode) {
+							const selectedElementIds = new Set(
+								selectedAreas.map((area) => area.id),
+							);
+							console.log(
+								"🔍 선택된 요소 ID 목록:",
+								Array.from(selectedElementIds),
+							);
+
+							// 모든 data-transflow-id 속성을 가진 요소 찾기
+							const allElementsWithId = iframeDoc.querySelectorAll(
+								"[data-transflow-id]",
+							);
+							console.log(
+								"📦 iframe 내 data-transflow-id 요소:",
+								Array.from(allElementsWithId).map((el) => ({
+									id: el.getAttribute("data-transflow-id"),
+									tag: el.tagName,
+									selected: selectedElementIds.has(
+										el.getAttribute("data-transflow-id") || "",
+									),
+								})),
+							);
+
+							// 선택되지 않은 요소 제거 (Translation.jsx와 동일)
+							const removeUnselectedElements = (
+								element: HTMLElement,
+							): boolean => {
+								if (element.hasAttribute("data-transflow-id")) {
+									const elementId = element.getAttribute("data-transflow-id");
+									if (elementId && selectedElementIds.has(elementId)) {
+										console.log(
+											"✅ 선택된 요소 발견:",
+											elementId,
+											element.tagName,
+										);
+										return true;
+									}
+								}
+
+								const children = Array.from(element.children) as HTMLElement[];
+								const childrenToKeep: HTMLElement[] = [];
+
+								children.forEach((child) => {
+									if (removeUnselectedElements(child)) {
+										childrenToKeep.push(child);
+									}
+								});
+
+								if (childrenToKeep.length > 0) {
+									const allChildren = Array.from(element.children);
+									allChildren.forEach((child) => {
+										if (!childrenToKeep.includes(child as HTMLElement)) {
+											element.removeChild(child);
+										}
+									});
+									return true;
+								}
+
+								return false;
+							};
+
+							const bodyChildren = Array.from(
+								iframeDoc.body.children,
+							) as HTMLElement[];
+							const bodyChildrenToKeep: HTMLElement[] = [];
+
+							bodyChildren.forEach((child) => {
+								if (removeUnselectedElements(child)) {
+									bodyChildrenToKeep.push(child);
+								}
+							});
+
+							const allBodyChildren = Array.from(iframeDoc.body.children);
+							allBodyChildren.forEach((child) => {
+								if (!bodyChildrenToKeep.includes(child as HTMLElement)) {
+									iframeDoc.body.removeChild(child);
+								}
+							});
+
+							console.log(
+								"✨ 최종 body 자식 요소:",
+								iframeDoc.body.children.length,
+								"개",
+							);
+							console.log(
+								"📄 최종 HTML:",
+								iframeDoc.body.innerHTML.substring(0, 500),
+							);
+
+							// 선택 표시 제거
+							iframeDoc
+								.querySelectorAll(
+									".transflow-selected, .transflow-hovering, .transflow-area-selected",
+								)
+								.forEach((el) => {
+									(el as HTMLElement).classList.remove(
+										"transflow-selected",
+										"transflow-hovering",
+										"transflow-area-selected",
+									);
+								});
+						}
+
+						// 선택된 영역만 남은 HTML (또는 수동 모드에서는 전체)을 onHtmlChange로 저장
+						const selectedOnlyHtml = iframeDoc.documentElement.outerHTML;
+						console.log(
+							"💾 STEP 3 선택된 영역만 저장:",
+							selectedOnlyHtml.substring(0, 200),
+						);
+
+						// 초기 HTML을 currentHtmlRef와 undo stack에 저장
+						currentHtmlRef.current = selectedOnlyHtml;
+						undoStackRef.current = []; // 초기화
+						redoStackRef.current = []; // 초기화
+						// ⭐ 공백 제거 undo stack도 초기화
+						spacingCurrentHtmlRef.current = selectedOnlyHtml;
+						spacingUndoStackRef.current = [];
+						spacingRedoStackRef.current = [];
+
+						onHtmlChange(selectedOnlyHtml);
+
+						// 초기화 완료 표시
+						setIsInitialized(true);
+
+						// 텍스트 편집 모드로 시작 (기본값)
+						if (mode === "text") {
+							// 텍스트 편집 활성화 (Translation.jsx의 enableTextEditing과 동일)
+							const editableElements = iframeDoc.querySelectorAll(
+								"p, h1, h2, h3, h4, h5, h6, span, div, li, ul, ol, blockquote, pre, code, table, tr, td, th, label, a, button, article, section, header, footer, main, aside",
+							);
+
+							editableElements.forEach((el) => {
+								if (
+									el.tagName &&
+									!["SCRIPT", "STYLE", "NOSCRIPT"].includes(el.tagName)
+								) {
+									(el as HTMLElement).contentEditable = "true";
+									(el as HTMLElement).style.cursor = "text";
+								}
+							});
+
+							// 스크립트, 스타일 태그는 편집 불가능하게
+							const scripts = iframeDoc.querySelectorAll(
+								"script, style, noscript",
+							);
+							scripts.forEach((el) => {
+								(el as HTMLElement).contentEditable = "false";
+							});
+
+							// Cmd+Z (Mac) 및 Ctrl+Z (Windows) Undo/Redo 기능
+							const handleKeyDown = (e: KeyboardEvent) => {
+								// Cmd+Z (Mac) 또는 Ctrl+Z (Windows) - Undo
+								if ((e.ctrlKey || e.metaKey) && e.key === "z" && !e.shiftKey) {
+									e.preventDefault();
+									e.stopImmediatePropagation();
+									iframeDoc.execCommand("undo", false);
+									const updatedHtml = iframeDoc.documentElement.outerHTML;
+									onHtmlChange(updatedHtml);
+								}
+								// Cmd+Shift+Z (Mac) 또는 Ctrl+Y (Windows) - Redo
+								else if (
+									(e.ctrlKey || e.metaKey) &&
+									(e.key === "y" || (e.key === "z" && e.shiftKey))
+								) {
+									e.preventDefault();
+									e.stopImmediatePropagation();
+									iframeDoc.execCommand("redo", false);
+									const updatedHtml = iframeDoc.documentElement.outerHTML;
+									onHtmlChange(updatedHtml);
+								}
+
+								// ⭐ 백스페이스 키 처리 (브라우저 기본 동작 허용)
+								if (
+									e.key === "Backspace" &&
+									!e.ctrlKey &&
+									!e.metaKey &&
+									!e.altKey
+								) {
+									// 브라우저가 알아서 처리하게 놔둠 (포커스 유지)
+									console.log("⌫ 백스페이스 (STEP 3 텍스트 편집)");
+								}
+							};
+
+							iframeDoc.addEventListener("keydown", handleKeyDown, true);
+
+							// ⚡ 최적화: input 이벤트 디바운스 (메모리 사용 감소)
+							let inputTimeoutId: NodeJS.Timeout | null = null;
+							const handleInput = () => {
+								// 기존 타이머 취소
+								if (inputTimeoutId) {
+									clearTimeout(inputTimeoutId);
+								}
+
+								// 500ms 후에 HTML 추출 (디바운스)
+								inputTimeoutId = setTimeout(() => {
+									const updatedHtml = iframeDoc.documentElement.outerHTML;
+									onHtmlChange(updatedHtml);
+									inputTimeoutId = null;
+								}, 500);
+							};
+							iframeDoc.body.addEventListener("input", handleInput);
+
+							// ⭐ 붙여넣기 시 웹에서 복사한 HTML 서식 유지
+							const handlePaste = (e: ClipboardEvent) => {
+								e.preventDefault();
+								const html = e.clipboardData?.getData("text/html");
+								const text = e.clipboardData?.getData("text/plain");
+								if (html) {
+									iframeDoc.execCommand("insertHTML", false, html);
+								} else if (text) {
+									iframeDoc.execCommand("insertText", false, text);
+								}
+								const updatedHtml = iframeDoc.documentElement.outerHTML;
+								onHtmlChange(updatedHtml);
+							};
+							iframeDoc.addEventListener("paste", handlePaste);
+						} else {
+							// 컴포넌트 편집 모드
+							const allElements = iframeDoc.querySelectorAll("*");
+
+							// 모든 요소를 편집 불가능하게
+							allElements.forEach((el) => {
+								(el as HTMLElement).contentEditable = "false";
+								(el as HTMLElement).style.cursor = "pointer";
+							});
+
+							// 컴포넌트 선택 스타일 추가
+							const componentStyle = iframeDoc.createElement("style");
+							componentStyle.id = "transflow-component-style";
+							componentStyle.textContent = `
                 div, section, article, header, footer, main, aside, nav {
                   border: 1px dashed #C0C0C0 !important;
                   margin: 2px !important;
@@ -1899,2900 +2406,3638 @@ const Step3PreEdit: React.FC<{
                   border: 2px solid #000000 !important;
                 }
               `;
-              iframeDoc.head.appendChild(componentStyle);
-              
-              // 클릭으로 컴포넌트 선택
-              const handleComponentClick = (e: MouseEvent) => {
-                const target = e.target as HTMLElement;
-                if (!target || target === iframeDoc.body || target === iframeDoc.documentElement) return;
-                if (target.tagName === 'SCRIPT' || target.tagName === 'STYLE' || target.tagName === 'NOSCRIPT') return;
-                
-                e.preventDefault();
-                e.stopPropagation();
-                
-                // 기존 선택 제거
-                allElements.forEach((elem) => {
-                  (elem as HTMLElement).classList.remove('selected-for-delete');
-                });
-                
-                // 새 선택
-                target.classList.add('selected-for-delete');
-                setSelectedElements([target]);
-              };
-              
-              allElements.forEach((el) => {
-                if (el.tagName === 'SCRIPT' || el.tagName === 'STYLE' || el.tagName === 'NOSCRIPT') return;
-                if (el === iframeDoc.body || el === iframeDoc.documentElement) return;
-                
-                (el as HTMLElement).removeEventListener('click', handleComponentClick as EventListener);
-                (el as HTMLElement).addEventListener('click', handleComponentClick as EventListener, true);
-              });
-              
-              if (iframeDoc.body) {
-                iframeDoc.body.addEventListener('click', handleComponentClick as EventListener, true);
-              }
-            }
-          }
-        }, 200);
-      }
-    }
-  }, [html, selectedAreas, isManualPasteMode]); // mode와 onHtmlChange 제거! (초기 렌더링만 수행)
-
-  const handleDelete = () => {
-    if (selectedElements.length > 0 && iframeRef.current && mode === 'component') {
-      const iframe = iframeRef.current;
-      const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-      if (iframeDoc) {
-        console.log('🗑️ 삭제할 요소:', selectedElements.length, '개');
-        
-        // 삭제 전 현재 상태를 undo stack에 저장
-        const currentHtml = iframeDoc.documentElement.outerHTML;
-        if (currentHtmlRef.current && currentHtmlRef.current !== currentHtml) {
-          undoStackRef.current.push(currentHtmlRef.current);
-          redoStackRef.current = []; // 새 작업 시 redo stack 초기화
-          console.log('💾 Step 3 Undo stack에 저장 (삭제 전):', undoStackRef.current.length);
-          console.log('🔄 Step 3 Redo stack 초기화');
-        } else {
-          console.log('⚠️ Step 3 삭제 전 저장 스킵 (currentHtmlRef:', !!currentHtmlRef.current, ', 동일:', currentHtmlRef.current === currentHtml, ')');
-        }
-        
-        // 선택된 모든 요소 삭제
-        selectedElements.forEach(el => {
-          if (el.parentNode) {
-            el.remove();
-          }
-        });
-        
-        const newHtml = iframeDoc.documentElement.outerHTML;
-        currentHtmlRef.current = newHtml;
-        onHtmlChange(newHtml);
-        setSelectedElements([]);
-        
-        console.log('✅ 삭제 완료');
-        
-        // ⭐ 삭제 후 iframe에 포커스를 주어 키보드 단축키가 바로 작동하도록 함
-        setTimeout(() => {
-          // body에 tabIndex 설정하여 포커스 가능하게 만들기
-          if (iframeDoc.body) {
-            iframeDoc.body.setAttribute('tabindex', '-1');
-            iframeDoc.body.focus();
-          }
-          if (iframe.contentWindow) {
-            iframe.contentWindow.focus();
-          }
-          iframe.focus();
-          console.log('🎯 Step 3 iframe에 포커스 설정');
-        }, 100);
-      }
-    }
-  };
-
-  // 일반적인 컨테이너 클래스명 패턴 인식
-  const isLikelyContainer = (element: HTMLElement): boolean => {
-    const className = (element.className || '').toString();
-    const containerPatterns = [
-      /container/i,
-      /wrapper/i,
-      /main-content/i,
-      /content-wrapper/i,
-      /page-content/i,
-      /article-wrapper/i,
-      /section-container/i,
-      /content-container/i,
-      /main-wrapper/i
-    ];
-    return containerPatterns.some(pattern => pattern.test(className));
-  };
-
-  // ⭐ 내부 서식 유지: margin/padding을 건드리지 않을 콘텐츠 요소 (인용구, 목록 등)
-  const CONTENT_PRESERVE_TAGS = new Set(['BLOCKQUOTE', 'UL', 'OL', 'PRE', 'FIGURE', 'FIGCAPTION', 'TABLE']);
-
-  // 공백 제거 함수들
-  const removeSpacing = (type: 'top' | 'bottom' | 'left' | 'right' | 'auto') => {
-    if (!iframeRef.current) return;
-    
-    const iframe = iframeRef.current;
-    const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-    if (!iframeDoc || !iframeDoc.body) return;
-
-    // 수동 공백 제거 모드: 선택한 요소에 직접 margin/padding 0 적용
-    if (mode === 'spacing' && selectedElements.length > 0) {
-      const currentHtml = iframeDoc.documentElement.outerHTML;
-      if (spacingCurrentHtmlRef.current && spacingCurrentHtmlRef.current !== currentHtml) {
-        spacingUndoStackRef.current.push(spacingCurrentHtmlRef.current);
-        spacingRedoStackRef.current = [];
-      }
-      const dirs: Array<'top'|'bottom'|'left'|'right'> = type === 'auto' ? ['top','bottom','left','right'] : [type];
-      selectedElements.forEach(el => {
-        if (!iframeDoc.body?.contains(el)) return;
-        dirs.forEach(d => {
-          if (d === 'top') { el.style.marginTop = '0'; el.style.paddingTop = '0'; }
-          else if (d === 'bottom') { el.style.marginBottom = '0'; el.style.paddingBottom = '0'; }
-          else if (d === 'left') { el.style.marginLeft = '0'; el.style.paddingLeft = '0'; }
-          else if (d === 'right') { el.style.marginRight = '0'; el.style.paddingRight = '0'; }
-        });
-      });
-      const newHtml = iframeDoc.documentElement.outerHTML;
-      spacingCurrentHtmlRef.current = newHtml;
-      currentHtmlRef.current = newHtml;
-      onHtmlChange(newHtml);
-      return;
-    }
-
-    // 🔍 디버깅: 버튼 클릭 전 HTML 및 스타일 정보 저장
-    const beforeHtml = iframeDoc.documentElement.outerHTML;
-    const parentElements = iframeDoc.querySelectorAll('.transflow-spacing-parent');
-    const beforeStyles: any[] = [];
-    parentElements.forEach((el, idx) => {
-      const computedStyle = iframeDoc.defaultView?.getComputedStyle(el as HTMLElement);
-      beforeStyles.push({
-        index: idx,
-        tag: el.tagName,
-        marginLeft: computedStyle?.marginLeft,
-        marginRight: computedStyle?.marginRight,
-        paddingLeft: computedStyle?.paddingLeft,
-        paddingRight: computedStyle?.paddingRight,
-      });
-    });
-    console.log('🔍 [공백 제거 전] 부모 요소 스타일:', beforeStyles);
-    console.log('🔍 [공백 제거 전] HTML 길이:', beforeHtml.length);
-
-    // ⭐ 공백 제거 전 현재 상태를 공백 제거 undo stack에 저장
-    const currentHtml = iframeDoc.documentElement.outerHTML;
-    if (spacingCurrentHtmlRef.current && spacingCurrentHtmlRef.current !== currentHtml) {
-      spacingUndoStackRef.current.push(spacingCurrentHtmlRef.current);
-      spacingRedoStackRef.current = [];
-    }
-
-    // CSS 스타일을 동적으로 추가하기 위한 스타일 태그 생성 또는 업데이트
-    let spacingStyle = iframeDoc.getElementById('transflow-spacing-remover') as HTMLStyleElement;
-    if (!spacingStyle) {
-      spacingStyle = iframeDoc.createElement('style');
-      spacingStyle.id = 'transflow-spacing-remover';
-      // head의 맨 마지막에 추가 (모든 외부 CSS 파일 이후)
-      iframeDoc.head.appendChild(spacingStyle);
-    } else {
-      // 이미 있으면 head의 맨 마지막으로 이동 (외부 CSS 이후에 오도록)
-      spacingStyle.remove();
-      iframeDoc.head.appendChild(spacingStyle);
-    }
-
-    // 선택된 요소들 찾기
-    const selectedElementIds = new Set(selectedAreas.map(area => area.id));
-    const selectedElementsFromStep2 = Array.from(iframeDoc.querySelectorAll('[data-transflow-id]'))
-      .filter(el => selectedElementIds.has(el.getAttribute('data-transflow-id') || ''));
-
-    // 공백 제거 모드일 때는 공백 제거 모드에서 선택한 요소만 사용
-    // 전체 공백 제거 모드일 때는 Step 2에서 선택한 영역 사용
-    const allSelectedElements = selectedElementsFromStep2;  // Step 2 선택 영역에 전체 공백 제거 적용
-
-    console.log('🔍 Step 2에서 선택된 요소 개수:', selectedElementsFromStep2.length);
-    console.log('🔍 전체 공백 제거 적용 대상:', allSelectedElements.length, '개');
-    console.log('🔍 총 선택된 요소 개수:', allSelectedElements.length);
-
-    // 기존 클래스 제거 (재적용을 위해)
-    iframeDoc.querySelectorAll('.transflow-spacing-parent').forEach(el => {
-      el.classList.remove('transflow-spacing-parent');
-    });
-
-    // 선택된 요소들의 부모 요소들에 클래스 추가 (단, blockquote·ul·ol 등 내부 서식 요소는 제외)
-    const parentElementsList: HTMLElement[] = [];
-    allSelectedElements.forEach((selectedEl) => {
-      let parent = selectedEl.parentElement;
-      while (parent && parent !== iframeDoc.body && parent !== iframeDoc.documentElement) {
-        if (CONTENT_PRESERVE_TAGS.has(parent.tagName)) {
-          parent = parent.parentElement;
-          continue;
-        }
-        if (!parent.classList.contains('transflow-spacing-parent')) {
-          parent.classList.add('transflow-spacing-parent');
-          parentElementsList.push(parent as HTMLElement);
-        }
-        parent = parent.parentElement;
-      }
-    });
-
-    // 수동 붙여넣기 등 선택 영역 없을 때: body의 직계 레이아웃 자식만 처리
-    if (parentElementsList.length === 0 && iframeDoc.body) {
-      const layoutTags = new Set(['DIV', 'MAIN', 'SECTION', 'ARTICLE', 'HEADER', 'FOOTER', 'ASIDE']);
-      Array.from(iframeDoc.body.children).forEach((child) => {
-        if (layoutTags.has(child.tagName) && !CONTENT_PRESERVE_TAGS.has(child.tagName)) {
-          (child as HTMLElement).classList.add('transflow-spacing-parent');
-          parentElementsList.push(child as HTMLElement);
-        }
-      });
-    }
-
-    console.log('🔍 부모 요소 개수:', parentElementsList.length);
-
-    // 상태 업데이트
-    if (type === 'auto') {
-      // 자동 모드는 모든 상태를 true로 설정
-      spacingRemovedRef.current = {
-        top: true,
-        bottom: true,
-        left: true,
-        right: true,
-        auto: true,
-      };
-    } else {
-      spacingRemovedRef.current[type] = true;
-    }
-
-    // 모든 적용된 규칙을 기반으로 CSS 재작성
-    const rules: string[] = [];
-    
-    // 선택된 요소의 부모 요소들에만 적용 (선택된 요소 자체는 제외)
-    // 더 구체적인 선택자 사용 + body도 포함하여 외부 CSS와의 충돌 방지
-    if (spacingRemovedRef.current.auto) {
-      // 자동 모드면 모든 마진과 패딩 제거
-      rules.push('body { margin: 0 !important; margin-inline: 0 !important; padding: 0 !important; padding-inline: 0 !important; }');
-      rules.push('html body { margin: 0 !important; margin-inline: 0 !important; padding: 0 !important; padding-inline: 0 !important; }');
-      rules.push('.transflow-spacing-parent { margin: 0 !important; margin-inline: 0 !important; padding: 0 !important; padding-inline: 0 !important; max-width: 100% !important; }');
-      rules.push('section.transflow-spacing-parent { margin: 0 !important; padding: 0 !important; padding-inline: 0 !important; max-width: 100% !important; }');
-      rules.push('div.transflow-spacing-parent { margin: 0 !important; padding: 0 !important; padding-inline: 0 !important; max-width: 100% !important; }');
-      rules.push('body section.transflow-spacing-parent { margin: 0 !important; padding: 0 !important; padding-inline: 0 !important; max-width: 100% !important; }');
-      rules.push('body div.transflow-spacing-parent { margin: 0 !important; padding: 0 !important; padding-inline: 0 !important; max-width: 100% !important; }');
-      // 🔍 wrapper의 width와 max-width도 100%로 설정
-      rules.push('.wrapper.transflow-spacing-parent { width: 100% !important; max-width: 100% !important; margin: 0 !important; padding: 0 !important; }');
-      rules.push('.transflow-spacing-parent.wrapper { width: 100% !important; max-width: 100% !important; margin: 0 !important; padding: 0 !important; }');
-      // 🔍 선택된 요소(article)의 width와 margin 제거 (blockquote·ul·ol 등 내부 서식은 유지)
-      rules.push('[data-transflow-id]:not(blockquote):not(ul):not(ol):not(pre):not(figure):not(table) { margin: 0 !important; width: 100% !important; }');
-      rules.push('#contentPost article:not(blockquote) { margin: 0 !important; width: 100% !important; }');
-      // ⭐ 수동 붙여넣기: .transflow-spacing-parent 내부 article/section/main/div - margin·padding·padding-inline·margin-inline·max-width 제거 (우측 공백 제거)
-      rules.push('.transflow-spacing-parent article { margin: 0 !important; margin-inline: 0 !important; padding: 0 !important; padding-inline: 0 !important; width: 100% !important; max-width: 100% !important; }');
-      rules.push('.transflow-spacing-parent section { margin: 0 !important; margin-inline: 0 !important; padding: 0 !important; padding-inline: 0 !important; max-width: 100% !important; }');
-      rules.push('.transflow-spacing-parent main { margin: 0 !important; margin-inline: 0 !important; padding: 0 !important; padding-inline: 0 !important; max-width: 100% !important; }');
-      rules.push('.transflow-spacing-parent div { margin: 0 !important; margin-inline: 0 !important; padding: 0 !important; padding-inline: 0 !important; max-width: 100% !important; }');
-    } else {
-      // 개별 모드면 각각 적용
-      if (spacingRemovedRef.current.top) {
-        rules.push('body { margin-top: 0 !important; }');
-        rules.push('html body { margin-top: 0 !important; }');
-        rules.push('.transflow-spacing-parent { margin-top: 0 !important; }');
-        rules.push('section.transflow-spacing-parent { margin-top: 0 !important; }');
-        rules.push('div.transflow-spacing-parent { margin-top: 0 !important; }');
-        rules.push('body section.transflow-spacing-parent { margin-top: 0 !important; }');
-        rules.push('body div.transflow-spacing-parent { margin-top: 0 !important; }');
-      }
-      if (spacingRemovedRef.current.bottom) {
-        rules.push('body { margin-bottom: 0 !important; }');
-        rules.push('html body { margin-bottom: 0 !important; }');
-        rules.push('.transflow-spacing-parent { margin-bottom: 0 !important; }');
-        rules.push('section.transflow-spacing-parent { margin-bottom: 0 !important; }');
-        rules.push('div.transflow-spacing-parent { margin-bottom: 0 !important; }');
-        rules.push('body section.transflow-spacing-parent { margin-bottom: 0 !important; }');
-        rules.push('body div.transflow-spacing-parent { margin-bottom: 0 !important; }');
-      }
-      if (spacingRemovedRef.current.left) {
-        // 🔍 왼쪽 공백: padding과 margin 모두 제거 + body 포함
-        rules.push('body { padding-left: 0 !important; margin-left: 0 !important; }');
-        rules.push('html body { padding-left: 0 !important; margin-left: 0 !important; }');
-        rules.push('.transflow-spacing-parent { padding-left: 0 !important; margin-left: 0 !important; }');
-        rules.push('section.transflow-spacing-parent { padding-left: 0 !important; margin-left: 0 !important; }');
-        rules.push('div.transflow-spacing-parent { padding-left: 0 !important; margin-left: 0 !important; }');
-        rules.push('body section.transflow-spacing-parent { padding-left: 0 !important; margin-left: 0 !important; }');
-        rules.push('body div.transflow-spacing-parent { padding-left: 0 !important; margin-left: 0 !important; }');
-        // 🔍 wrapper의 width도 100%로 설정
-        rules.push('.wrapper.transflow-spacing-parent { width: 100% !important; margin-left: 0 !important; }');
-        rules.push('.transflow-spacing-parent.wrapper { width: 100% !important; margin-left: 0 !important; }');
-        // 🔍 선택된 요소의 margin-left 제거 (blockquote 등 내부 서식 유지)
-        rules.push('[data-transflow-id]:not(blockquote):not(ul):not(ol):not(pre):not(figure):not(table) { margin-left: 0 !important; }');
-        rules.push('#contentPost article:not(blockquote) { margin-left: 0 !important; }');
-      }
-      if (spacingRemovedRef.current.right) {
-        // 🔍 오른쪽 공백: padding과 margin 모두 제거 + body 포함
-        rules.push('body { padding-right: 0 !important; margin-right: 0 !important; }');
-        rules.push('html body { padding-right: 0 !important; margin-right: 0 !important; }');
-        rules.push('.transflow-spacing-parent { padding-right: 0 !important; margin-right: 0 !important; }');
-        rules.push('section.transflow-spacing-parent { padding-right: 0 !important; margin-right: 0 !important; }');
-        rules.push('div.transflow-spacing-parent { padding-right: 0 !important; margin-right: 0 !important; }');
-        rules.push('body section.transflow-spacing-parent { padding-right: 0 !important; margin-right: 0 !important; }');
-        rules.push('body div.transflow-spacing-parent { padding-right: 0 !important; margin-right: 0 !important; }');
-        // 🔍 wrapper의 width와 max-width도 100%로 설정
-        rules.push('.wrapper.transflow-spacing-parent { width: 100% !important; max-width: 100% !important; margin-right: 0 !important; }');
-        rules.push('.transflow-spacing-parent.wrapper { width: 100% !important; max-width: 100% !important; margin-right: 0 !important; }');
-        // 🔍 선택된 요소의 width·margin 제거 (blockquote 등 내부 서식 유지)
-        rules.push('[data-transflow-id]:not(blockquote):not(ul):not(ol):not(pre):not(figure):not(table) { margin-right: 0 !important; margin-left: 0 !important; width: 100% !important; }');
-        rules.push('#contentPost article:not(blockquote) { margin-right: 0 !important; margin-left: 0 !important; width: 100% !important; }');
-      }
-    }
-
-    spacingStyle.textContent = rules.join('\n');
-    console.log('🔍 적용된 CSS 규칙:', rules);
-
-    // 🔍 계산된 스타일 기반으로 인라인 스타일 직접 적용 (CSS 규칙보다 우선순위가 높음)
-    // 이 방식은 어떤 CSS 프레임워크를 사용하든 실제 적용된 값을 기준으로 처리하므로 보편적임
-    
-    // Body 처리
-    if (iframeDoc.body) {
-      const bodyComputed = iframeDoc.defaultView?.getComputedStyle(iframeDoc.body);
-      if (bodyComputed) {
-        if (type === 'auto' || type === 'top' || spacingRemovedRef.current.top) {
-          const marginTop = parseFloat(bodyComputed.marginTop);
-          const paddingTop = parseFloat(bodyComputed.paddingTop);
-          if (marginTop > 0 || paddingTop > 0) {
-            iframeDoc.body.style.marginTop = '0';
-            iframeDoc.body.style.paddingTop = '0';
-          }
-        }
-        if (type === 'auto' || type === 'bottom' || spacingRemovedRef.current.bottom) {
-          const marginBottom = parseFloat(bodyComputed.marginBottom);
-          const paddingBottom = parseFloat(bodyComputed.paddingBottom);
-          if (marginBottom > 0 || paddingBottom > 0) {
-            iframeDoc.body.style.marginBottom = '0';
-            iframeDoc.body.style.paddingBottom = '0';
-          }
-        }
-        if (type === 'auto' || type === 'left' || spacingRemovedRef.current.left) {
-          const marginLeft = parseFloat(bodyComputed.marginLeft);
-          const paddingLeft = parseFloat(bodyComputed.paddingLeft);
-          if (marginLeft > 0 || paddingLeft > 0) {
-            iframeDoc.body.style.marginLeft = '0';
-            iframeDoc.body.style.paddingLeft = '0';
-          }
-        }
-        if (type === 'auto' || type === 'right' || spacingRemovedRef.current.right) {
-          const marginRight = parseFloat(bodyComputed.marginRight);
-          const paddingRight = parseFloat(bodyComputed.paddingRight);
-          if (marginRight > 0 || paddingRight > 0) {
-            iframeDoc.body.style.marginRight = '0';
-            iframeDoc.body.style.paddingRight = '0';
-          }
-        }
-      }
-    }
-
-    // 부모 요소들 처리 (계산된 스타일 기반)
-    parentElementsList.forEach((parent) => {
-      const computed = iframeDoc.defaultView?.getComputedStyle(parent);
-      if (!computed) return;
-
-      // 실제 공백 값 확인
-      const marginTop = parseFloat(computed.marginTop);
-      const marginBottom = parseFloat(computed.marginBottom);
-      const marginLeft = parseFloat(computed.marginLeft);
-      const marginRight = parseFloat(computed.marginRight);
-      const paddingTop = parseFloat(computed.paddingTop);
-      const paddingBottom = parseFloat(computed.paddingBottom);
-      const paddingLeft = parseFloat(computed.paddingLeft);
-      const paddingRight = parseFloat(computed.paddingRight);
-
-      // 실제 공백이 있을 때만 제거 (인라인 스타일로 강제 적용)
-      if (type === 'auto' || type === 'top' || spacingRemovedRef.current.top) {
-        if (marginTop > 0 || paddingTop > 0) {
-          parent.style.marginTop = '0';
-          parent.style.paddingTop = '0';
-        }
-      }
-      if (type === 'auto' || type === 'bottom' || spacingRemovedRef.current.bottom) {
-        if (marginBottom > 0 || paddingBottom > 0) {
-          parent.style.marginBottom = '0';
-          parent.style.paddingBottom = '0';
-        }
-      }
-      if (type === 'auto' || type === 'left' || spacingRemovedRef.current.left) {
-        if (marginLeft > 0 || paddingLeft > 0) {
-          parent.style.marginLeft = '0';
-          parent.style.paddingLeft = '0';
-        }
-      }
-      if (type === 'auto' || type === 'right' || spacingRemovedRef.current.right) {
-        if (marginRight > 0 || paddingRight > 0) {
-          parent.style.marginRight = '0';
-          parent.style.paddingRight = '0';
-        }
-      }
-
-      // Width 제한 제거 (컨테이너로 보이거나 width가 제한되어 있으면)
-      const width = computed.width;
-      const maxWidth = computed.maxWidth;
-      const isContainer = isLikelyContainer(parent);
-      
-      // 컨테이너로 보이거나 width가 100%가 아니거나 max-width가 설정되어 있으면 100%로 설정
-      if (isContainer || (width !== '100%' && width !== 'auto' && maxWidth !== 'none' && maxWidth !== '100%')) {
-        parent.style.width = '100%';
-        if (maxWidth !== 'none' && maxWidth !== '100%') {
-          parent.style.maxWidth = '100%';
-        }
-      }
-      
-      // margin: auto로 인한 중앙 정렬 제거
-      if (computed.marginLeft === 'auto' || computed.marginRight === 'auto') {
-        parent.style.marginLeft = '0';
-        parent.style.marginRight = '0';
-      }
-    });
-
-    // 선택된 요소 자체 처리 (blockquote, ul, ol 등 내부 서식 요소는 제외)
-    allSelectedElements.forEach((selectedEl) => {
-      const el = selectedEl as HTMLElement;
-      if (CONTENT_PRESERVE_TAGS.has(el.tagName)) return;
-
-      const computed = iframeDoc.defaultView?.getComputedStyle(el);
-      if (!computed) return;
-
-      // 선택된 요소의 margin과 width 처리
-      if (type === 'auto' || type === 'left' || type === 'right' || 
-          spacingRemovedRef.current.left || spacingRemovedRef.current.right) {
-        const marginLeft = parseFloat(computed.marginLeft);
-        const marginRight = parseFloat(computed.marginRight);
-        const width = computed.width;
-        
-        if (marginLeft > 0 || marginLeft < 0) {
-          el.style.marginLeft = '0';
-        }
-        if (marginRight > 0 || marginRight < 0) {
-          el.style.marginRight = '0';
-        }
-        
-        // width가 100%가 아니면 100%로 설정
-        if (width !== '100%' && width !== 'auto') {
-          el.style.width = '100%';
-        }
-      }
-      
-      // margin: auto 제거
-      if (computed.marginLeft === 'auto' || computed.marginRight === 'auto') {
-        el.style.marginLeft = '0';
-        el.style.marginRight = '0';
-      }
-    });
-
-    // ⭐ margin:auto + max-width로 인한 왼쪽 공백 제거 (수동 붙여넣기 시 entry-header, entry-content 등)
-    if (type === 'auto') {
-      const skipTags = new Set(['SCRIPT', 'STYLE', 'NOSCRIPT', 'HTML', 'HEAD', 'BODY', ...CONTENT_PRESERVE_TAGS]);
-      const layoutElements = iframeDoc.querySelectorAll('header, div, section, article, main, aside, footer');
-      layoutElements.forEach((el) => {
-        if (skipTags.has(el.tagName)) return;
-        const htmlEl = el as HTMLElement;
-        const computed = iframeDoc.defaultView?.getComputedStyle(htmlEl);
-        if (!computed) return;
-        const ml = computed.marginLeft;
-        const mr = computed.marginRight;
-        const mw = computed.maxWidth;
-        const hasMarginAuto = ml === 'auto' || mr === 'auto';
-        const hasNarrowMaxWidth = mw && mw !== 'none' && parseFloat(mw) > 0 && parseFloat(mw) < 2000;
-        if (hasMarginAuto) {
-          htmlEl.style.marginLeft = '0';
-          htmlEl.style.marginRight = '0';
-        }
-        if (hasNarrowMaxWidth) {
-          htmlEl.style.maxWidth = '100%';
-          htmlEl.style.width = '100%';
-        }
-      });
-    }
-
-    // 🔍 디버깅: 버튼 클릭 후 HTML 및 스타일 정보
-    setTimeout(() => {
-      const afterHtml = iframeDoc.documentElement.outerHTML;
-      const afterParentElements = iframeDoc.querySelectorAll('.transflow-spacing-parent');
-      const afterStyles: any[] = [];
-      afterParentElements.forEach((el, idx) => {
-        const computedStyle = iframeDoc.defaultView?.getComputedStyle(el as HTMLElement);
-        afterStyles.push({
-          index: idx,
-          tag: el.tagName,
-          className: el.className,
-          marginLeft: computedStyle?.marginLeft,
-          marginRight: computedStyle?.marginRight,
-          paddingLeft: computedStyle?.paddingLeft,
-          paddingRight: computedStyle?.paddingRight,
-          width: computedStyle?.width,
-          maxWidth: computedStyle?.maxWidth,
-          // 인라인 스타일 확인
-          inlineStyle: (el as HTMLElement).style.cssText,
-        });
-      });
-      console.log('🔍 [공백 제거 후] 부모 요소 스타일:', afterStyles);
-      console.log('🔍 [공백 제거 후] HTML 길이:', afterHtml.length);
-      
-      // 스타일 태그 위치 확인
-      const styleTag = iframeDoc.getElementById('transflow-spacing-remover');
-      console.log('🔍 스타일 태그 위치:', styleTag ? '존재함' : '없음');
-      if (styleTag) {
-        console.log('🔍 스타일 태그 내용:', styleTag.textContent);
-        console.log('🔍 스타일 태그 다음 형제:', styleTag.nextSibling);
-        // head의 마지막 자식인지 확인
-        const isLastChild = styleTag === iframeDoc.head.lastElementChild;
-        console.log('🔍 스타일 태그가 head의 마지막 자식인가?', isLastChild);
-      }
-    }, 100);
-
-    console.log(`✅ ${type === 'auto' ? '자동으로 불필요한 공간 제거' : type + ' 공백 제거'} 완료`);
-
-    // HTML 업데이트
-    const updatedHtml = iframeDoc.documentElement.outerHTML;
-    
-    // ⭐ 공백 제거 후 브라우저 undo history 초기화 (텍스트 편집 undo와 분리)
-    try {
-      // 공백 제거가 완료된 후 iframe을 다시 write하여 브라우저 undo history 초기화
-      iframeDoc.open();
-      iframeDoc.write(updatedHtml);
-      iframeDoc.close();
-      console.log('🔄 브라우저 undo history 초기화 완료 (공백 제거 후)');
-      
-      // contentEditable 상태 복원 (텍스트 편집 모드인 경우)
-      if (mode === 'text') {
-        setTimeout(() => {
-          const editableElements = iframeDoc.querySelectorAll('p, h1, h2, h3, h4, h5, h6, span, div, li, ul, ol, blockquote, pre, code, table, tr, td, th, label, a, button, article, section, header, footer, main, aside');
-          editableElements.forEach((el) => {
-            if (el.tagName && !['SCRIPT', 'STYLE', 'NOSCRIPT'].includes(el.tagName)) {
-              (el as HTMLElement).contentEditable = 'true';
-              (el as HTMLElement).style.cursor = 'text';
-            }
-          });
-        }, 0);
-      }
-    } catch (e) {
-      console.warn('⚠️ 브라우저 undo history 초기화 실패:', e);
-    }
-    
-    // 변경 후 undo stack에 저장 (변경 전 상태는 이미 저장됨)
-    currentHtmlRef.current = updatedHtml;
-    // ⭐ 공백 제거 undo stack도 업데이트
-    spacingCurrentHtmlRef.current = updatedHtml;
-    onHtmlChange(updatedHtml);
-  };
-
-  // 불필요한 그리드 제거 (2열 이상 그리드인데 자식이 1개뿐인 경우 → 1열로 변환)
-  // 소스(style/class) + computed style 모두 검사하여 viewport/브라우저 영향 최소화
-  const removeUnnecessaryGrids = () => {
-    if (!iframeRef.current) return;
-    const iframe = iframeRef.current;
-    const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-    if (!iframeDoc || !iframeDoc.body) return;
-
-    const currentHtml = iframeDoc.documentElement.outerHTML;
-    if (spacingCurrentHtmlRef.current && spacingCurrentHtmlRef.current !== currentHtml) {
-      spacingUndoStackRef.current.push(spacingCurrentHtmlRef.current);
-      spacingRedoStackRef.current = [];
-    }
-
-    const countGridColumns = (gtc: string): number => {
-      if (!gtc || gtc === 'none') return 0;
-      const repeatMatch = gtc.match(/repeat\s*\(\s*(\d+)/);
-      if (repeatMatch) return parseInt(repeatMatch[1], 10);
-      const parts = gtc.split(/[\s,]+/).filter(Boolean);
-      return parts.length >= 2 ? parts.length : 0;
-    };
-
-    const hasMultiColFromSource = (el: HTMLElement): number => {
-      const styleVal = el.style.gridTemplateColumns || el.getAttribute('style') || '';
-      const styleCols = countGridColumns(styleVal);
-      if (styleCols >= 2) return styleCols;
-      const cls = (el.className || '').toString();
-      const gridColsMatch = cls.match(/(?:sm|md|lg|xl|2xl)?:?grid-cols-(\d+)/);
-      if (gridColsMatch) {
-        const n = parseInt(gridColsMatch[1], 10);
-        if (n >= 2) return n;
-      }
-      return 0;
-    };
-
-    let fixedCount = 0;
-    const walk = (root: Element) => {
-      const children = Array.from(root.children);
-      for (const el of children) {
-        const htmlEl = el as HTMLElement;
-        if (['SCRIPT', 'STYLE', 'NOSCRIPT', 'HTML', 'HEAD', 'BODY'].includes(htmlEl.tagName)) continue;
-        const childCount = htmlEl.children.length;
-        let cols = 0;
-        const sourceCols = hasMultiColFromSource(htmlEl);
-        if (sourceCols >= 2) {
-          cols = sourceCols;
-        } else {
-          const computed = iframeDoc.defaultView?.getComputedStyle(htmlEl);
-          if (computed?.display === 'grid') cols = countGridColumns(computed.gridTemplateColumns);
-        }
-        if (cols >= 2 && childCount < cols) {
-          htmlEl.style.setProperty('grid-template-columns', '1fr', 'important');
-          fixedCount++;
-        }
-        walk(htmlEl);
-      }
-    };
-    walk(iframeDoc.body);
-
-    const updatedHtml = iframeDoc.documentElement.outerHTML;
-    spacingCurrentHtmlRef.current = updatedHtml;
-    currentHtmlRef.current = updatedHtml;
-    onHtmlChange(updatedHtml);
-    console.log('✅ 불필요한 그리드 제거 완료:', fixedCount, '개 수정');
-  };
-
-  // HTML 파일 다운로드 함수
-  const downloadHtml = () => {
-    if (!iframeRef.current) return;
-    
-    const iframe = iframeRef.current;
-    const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-    if (!iframeDoc) return;
-
-    // iframe 안의 HTML만 가져오기
-    const htmlContent = iframeDoc.documentElement.outerHTML;
-    
-    // Blob 생성 및 다운로드
-    const blob = new Blob([htmlContent], { type: 'text/html;charset=utf-8' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = `step3-html-${Date.now()}.html`;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
-    
-    console.log('💾 HTML 파일 다운로드 완료');
-  };
-
-  return (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        height: '100%',
-      }}
-    >
-      {/* 툴바 */}
-      <div
-        style={{
-          padding: '8px 16px',
-          borderBottom: '1px solid #C0C0C0',
-          backgroundColor: '#FFFFFF',
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          gap: '8px',
-        }}
-      >
-        <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
-          <div
-            style={{
-              fontSize: '13px',
-              fontWeight: 600,
-              color: '#000000',
-              fontFamily: 'system-ui, Pretendard, sans-serif',
-              marginRight: '16px',
-            }}
-          >
-            번역 전 편집
-          </div>
-          <div style={{ display: 'flex', gap: '4px' }}>
-            <Button
-              variant={mode === 'text' ? 'primary' : 'secondary'}
-              onClick={() => setMode('text')}
-              style={{ fontSize: '12px', padding: '4px 8px' }}
-            >
-              텍스트 편집
-            </Button>
-            <Button
-              variant={mode === 'component' ? 'primary' : 'secondary'}
-              onClick={() => setMode('component')}
-              style={{ fontSize: '12px', padding: '4px 8px' }}
-            >
-              컴포넌트 편집
-            </Button>
-          </div>
-          <div style={{ borderLeft: '1px solid #C0C0C0', height: '24px', margin: '0 4px' }} />
-          {mode === 'text' && (
-            <>
-              <button
-                type="button"
-                onClick={() => {
-                  const iframeDoc = iframeRef.current?.contentDocument || iframeRef.current?.contentWindow?.document;
-                  if (iframeDoc && iframeDoc.body) iframeDoc.body.focus();
-                  iframeDoc?.execCommand('bold', false);
-                  if (iframeDoc) syncIframeHtml(iframeDoc);
-                }}
-                style={{
-                  padding: '4px 8px',
-                  fontSize: '11px',
-                  fontWeight: 'bold',
-                  border: '1px solid #A9A9A9',
-                  borderRadius: '3px',
-                  backgroundColor: '#FFFFFF',
-                  color: '#000000',
-                  cursor: 'pointer',
-                }}
-                title="굵게 (Ctrl+B)"
-              >
-                B
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  const iframeDoc = iframeRef.current?.contentDocument || iframeRef.current?.contentWindow?.document;
-                  if (iframeDoc && iframeDoc.body) iframeDoc.body.focus();
-                  iframeDoc?.execCommand('italic', false);
-                  if (iframeDoc) syncIframeHtml(iframeDoc);
-                }}
-                style={{
-                  padding: '4px 8px',
-                  fontSize: '11px',
-                  fontStyle: 'italic',
-                  border: '1px solid #A9A9A9',
-                  borderRadius: '3px',
-                  backgroundColor: '#FFFFFF',
-                  color: '#000000',
-                  cursor: 'pointer',
-                }}
-                title="기울임 (Ctrl+I)"
-              >
-                I
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  const iframeDoc = iframeRef.current?.contentDocument || iframeRef.current?.contentWindow?.document;
-                  if (iframeDoc && iframeDoc.body) iframeDoc.body.focus();
-                  iframeDoc?.execCommand('underline', false);
-                  if (iframeDoc) syncIframeHtml(iframeDoc);
-                }}
-                style={{
-                  padding: '4px 8px',
-                  fontSize: '11px',
-                  textDecoration: 'underline',
-                  border: '1px solid #A9A9A9',
-                  borderRadius: '3px',
-                  backgroundColor: '#FFFFFF',
-                  color: '#000000',
-                  cursor: 'pointer',
-                }}
-                title="밑줄 (Ctrl+U)"
-              >
-                U
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  const iframeDoc = iframeRef.current?.contentDocument || iframeRef.current?.contentWindow?.document;
-                  if (iframeDoc && iframeDoc.body) iframeDoc.body.focus();
-                  iframeDoc?.execCommand('strikeThrough', false);
-                  if (iframeDoc) syncIframeHtml(iframeDoc);
-                }}
-                style={{
-                  padding: '4px 8px',
-                  fontSize: '11px',
-                  textDecoration: 'line-through',
-                  border: '1px solid #A9A9A9',
-                  borderRadius: '3px',
-                  backgroundColor: '#FFFFFF',
-                  color: '#000000',
-                  cursor: 'pointer',
-                }}
-                title="취소선"
-              >
-                S
-              </button>
-
-              <button
-                type="button"
-                onClick={() => {
-                  const iframeDoc = iframeRef.current?.contentDocument || iframeRef.current?.contentWindow?.document;
-                  if (!iframeDoc) return;
-                  if (iframeDoc.body) {
-                    iframeDoc.body.setAttribute('tabindex', '-1');
-                    iframeDoc.body.focus();
-                  }
-                  iframeDoc.execCommand('removeFormat', false);
-                  // removeFormat이 border-style:solid 만 남기는 문제 수정
-                  setTimeout(() => {
-                    fixDanglingBorderStyle(iframeDoc);
-                    syncIframeHtml(iframeDoc);
-                  }, 0);
-                }}
-                style={{
-                  padding: '4px 8px',
-                  fontSize: '11px',
-                  fontWeight: 600,
-                  border: '1px solid #A9A9A9',
-                  borderRadius: '3px',
-                  backgroundColor: '#FFFFFF',
-                  color: '#000000',
-                  cursor: 'pointer',
-                }}
-                title="서식 지우기 (선택 영역)"
-              >
-                서식 지우기
-              </button>
-
-              <div style={{ width: '1px', height: '20px', backgroundColor: '#C0C0C0', margin: '0 4px' }} />
-
-              <select
-                onChange={(e) => {
-                  const iframeDoc = iframeRef.current?.contentDocument || iframeRef.current?.contentWindow?.document;
-                  if (iframeDoc && e.target.value) {
-                    const fontSize = e.target.value;
-                    const selection = iframeDoc.getSelection();
-
-                    if (selection && selection.rangeCount > 0 && !selection.getRangeAt(0).collapsed) {
-                      const range = selection.getRangeAt(0);
-                      const selectedText = range.toString();
-                      const spanHtml = `<span style="font-size: ${fontSize}pt;">${selectedText}</span>`;
-
-                      try {
-                        iframeDoc.execCommand('insertHTML', false, spanHtml);
-                      } catch (err) {
-                        range.deleteContents();
-                        const tempDiv = iframeDoc.createElement('div');
-                        tempDiv.innerHTML = spanHtml;
-                        const fragment = iframeDoc.createDocumentFragment();
-                        while (tempDiv.firstChild) {
-                          fragment.appendChild(tempDiv.firstChild);
-                        }
-                        range.insertNode(fragment);
-                        range.setStartAfter(fragment.lastChild || range.startContainer);
-                        range.collapse(false);
-                        selection.removeAllRanges();
-                        selection.addRange(range);
-                      }
-                      syncIframeHtml(iframeDoc);
-                    } else {
-                      iframeDoc.execCommand('fontSize', false, '3');
-                      setTimeout(() => {
-                        const fontSizeElements = iframeDoc.querySelectorAll('font[size="3"]');
-                        if (fontSizeElements.length > 0) {
-                          const lastElement = fontSizeElements[fontSizeElements.length - 1] as HTMLElement;
-                          lastElement.style.fontSize = `${fontSize}pt`;
-                          lastElement.removeAttribute('size');
-
-                          const span = iframeDoc.createElement('span');
-                          span.style.fontSize = `${fontSize}pt`;
-                          span.innerHTML = lastElement.innerHTML;
-
-                          if (lastElement.parentNode) {
-                            lastElement.parentNode.replaceChild(span, lastElement);
-                          }
-                        }
-                        syncIframeHtml(iframeDoc);
-                      }, 0);
-                    }
-                  }
-                  e.target.value = '';
-                }}
-                style={{
-                  fontSize: '11px',
-                  padding: '4px 8px',
-                  border: '1px solid #A9A9A9',
-                  borderRadius: '3px',
-                  backgroundColor: '#FFFFFF',
-                  color: '#000000',
-                  cursor: 'pointer',
-                }}
-                title="글자 크기 (pt)"
-              >
-                <option value="">크기</option>
-                <option value="8">8pt</option>
-                <option value="9">9pt</option>
-                <option value="10">10pt</option>
-                <option value="11">11pt</option>
-                <option value="12">12pt</option>
-                <option value="14">14pt</option>
-                <option value="16">16pt</option>
-                <option value="18">18pt</option>
-                <option value="20">20pt</option>
-                <option value="24">24pt</option>
-                <option value="28">28pt</option>
-                <option value="32">32pt</option>
-                <option value="36">36pt</option>
-                <option value="48">48pt</option>
-                <option value="72">72pt</option>
-              </select>
-
-              <select
-                onChange={(e) => {
-                  const iframeDoc = iframeRef.current?.contentDocument || iframeRef.current?.contentWindow?.document;
-                  if (iframeDoc && e.target.value) {
-                    const lineHeight = e.target.value;
-                    const selection = iframeDoc.getSelection();
-
-                    if (selection && selection.rangeCount > 0) {
-                      const range = selection.getRangeAt(0);
-                      let blockElement: HTMLElement | null = null;
-
-                      if (range.commonAncestorContainer.nodeType === 1) {
-                        blockElement = (range.commonAncestorContainer as HTMLElement).closest('p, div, h1, h2, h3, h4, h5, h6, li, blockquote, pre');
-                      } else {
-                        blockElement = range.commonAncestorContainer.parentElement?.closest('p, div, h1, h2, h3, h4, h5, h6, li, blockquote, pre') || null;
-                      }
-
-                      if (blockElement) {
-                        try {
-                          const blockRange = iframeDoc.createRange();
-                          blockRange.selectNodeContents(blockElement);
-                          selection.removeAllRanges();
-                          selection.addRange(blockRange);
-
-                          const originalHtml = blockElement.innerHTML;
-                          const tagName = blockElement.tagName.toLowerCase();
-                          const newHtml = `<${tagName} style="line-height: ${lineHeight};">${originalHtml}</${tagName}>`;
-
-                          iframeDoc.execCommand('insertHTML', false, newHtml);
-                        } catch (err) {
-                          blockElement.style.lineHeight = lineHeight;
-                        }
-                      } else {
-                        const div = iframeDoc.createElement('div');
-                        div.style.lineHeight = lineHeight;
-                        div.innerHTML = '&nbsp;';
-
-                        try {
-                          iframeDoc.execCommand('insertHTML', false, div.outerHTML);
-                        } catch (err) {
-                          range.insertNode(div);
-                        }
-                      }
-                      syncIframeHtml(iframeDoc);
-                    }
-                  }
-                  e.target.value = '';
-                }}
-                style={{
-                  fontSize: '11px',
-                  padding: '4px 8px',
-                  border: '1px solid #A9A9A9',
-                  borderRadius: '3px',
-                  backgroundColor: '#FFFFFF',
-                  color: '#000000',
-                  cursor: 'pointer',
-                  marginLeft: '4px',
-                }}
-                title="줄간격"
-              >
-                <option value="">줄간격</option>
-                <option value="1.0">1.0 (단일)</option>
-                <option value="1.15">1.15</option>
-                <option value="1.5">1.5 (기본)</option>
-                <option value="1.75">1.75</option>
-                <option value="2.0">2.0 (2배)</option>
-                <option value="2.5">2.5</option>
-                <option value="3.0">3.0</option>
-              </select>
-
-              <div style={{ position: 'relative', display: 'inline-block', width: '30px', height: '26px' }}>
-                <input
-                  type="color"
-                  onChange={(e) => {
-                    const iframeDoc = iframeRef.current?.contentDocument || iframeRef.current?.contentWindow?.document;
-                    if (iframeDoc) iframeDoc.execCommand('foreColor', false, e.target.value);
-                    if (iframeDoc) syncIframeHtml(iframeDoc);
-                  }}
-                  style={{
-                    position: 'absolute',
-                    width: '100%',
-                    height: '100%',
-                    opacity: 0,
-                    cursor: 'pointer',
-                    zIndex: 2,
-                  }}
-                  title="글자 색상"
-                />
-                <button
-                  style={{
-                    position: 'absolute',
-                    width: '100%',
-                    height: '100%',
-                    border: '1px solid #A9A9A9',
-                    borderRadius: '3px',
-                    backgroundColor: '#FFFFFF',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    cursor: 'pointer',
-                    padding: 0,
-                    pointerEvents: 'none',
-                  }}
-                  title="글자 색상"
-                  disabled
-                >
-                  <Palette size={16} color="#000000" />
-                </button>
-              </div>
-
-              <div style={{ position: 'relative', display: 'inline-block', width: '30px', height: '26px', marginLeft: '4px' }}>
-                <input
-                  type="color"
-                  onChange={(e) => {
-                    const iframeDoc = iframeRef.current?.contentDocument || iframeRef.current?.contentWindow?.document;
-                    if (iframeDoc) iframeDoc.execCommand('backColor', false, e.target.value);
-                    if (iframeDoc) syncIframeHtml(iframeDoc);
-                  }}
-                  style={{
-                    position: 'absolute',
-                    width: '100%',
-                    height: '100%',
-                    opacity: 0,
-                    cursor: 'pointer',
-                    zIndex: 2,
-                  }}
-                  title="배경 색상"
-                />
-                <button
-                  style={{
-                    position: 'absolute',
-                    width: '100%',
-                    height: '100%',
-                    border: '1px solid #A9A9A9',
-                    borderRadius: '3px',
-                    backgroundColor: '#FFFFFF',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    cursor: 'pointer',
-                    padding: 0,
-                    pointerEvents: 'none',
-                  }}
-                  title="배경 색상"
-                  disabled
-                >
-                  <Highlighter size={16} color="#000000" />
-                </button>
-              </div>
-
-              <div style={{ width: '1px', height: '20px', backgroundColor: '#C0C0C0', margin: '0 4px' }} />
-
-              <button
-                type="button"
-                onClick={() => {
-                  const iframeDoc = iframeRef.current?.contentDocument || iframeRef.current?.contentWindow?.document;
-                  if (!iframeDoc) return;
-                  iframeDoc.execCommand('justifyLeft', false);
-                  syncIframeHtml(iframeDoc);
-                }}
-                style={{
-                  padding: '4px 8px',
-                  fontSize: '11px',
-                  border: '1px solid #A9A9A9',
-                  borderRadius: '3px',
-                  backgroundColor: '#FFFFFF',
-                  color: '#000000',
-                  cursor: 'pointer',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                }}
-                title="왼쪽 정렬"
-              >
-                <AlignLeft size={16} />
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  const iframeDoc = iframeRef.current?.contentDocument || iframeRef.current?.contentWindow?.document;
-                  if (!iframeDoc) return;
-                  iframeDoc.execCommand('justifyCenter', false);
-                  syncIframeHtml(iframeDoc);
-                }}
-                style={{
-                  padding: '4px 8px',
-                  fontSize: '11px',
-                  border: '1px solid #A9A9A9',
-                  borderRadius: '3px',
-                  backgroundColor: '#FFFFFF',
-                  color: '#000000',
-                  cursor: 'pointer',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                }}
-                title="가운데 정렬"
-              >
-                <AlignCenter size={16} />
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  const iframeDoc = iframeRef.current?.contentDocument || iframeRef.current?.contentWindow?.document;
-                  if (!iframeDoc) return;
-                  iframeDoc.execCommand('justifyRight', false);
-                  syncIframeHtml(iframeDoc);
-                }}
-                style={{
-                  padding: '4px 8px',
-                  fontSize: '11px',
-                  border: '1px solid #A9A9A9',
-                  borderRadius: '3px',
-                  backgroundColor: '#FFFFFF',
-                  color: '#000000',
-                  cursor: 'pointer',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                }}
-                title="오른쪽 정렬"
-              >
-                <AlignRight size={16} />
-              </button>
-
-              <button
-                type="button"
-                onClick={() => {
-                  const iframeDoc = iframeRef.current?.contentDocument || iframeRef.current?.contentWindow?.document;
-                  if (!iframeDoc) return;
-                  iframeDoc.execCommand('justifyFull', false);
-                  syncIframeHtml(iframeDoc);
-                }}
-                style={{
-                  padding: '4px 8px',
-                  fontSize: '11px',
-                  border: '1px solid #A9A9A9',
-                  borderRadius: '3px',
-                  backgroundColor: '#FFFFFF',
-                  color: '#000000',
-                  cursor: 'pointer',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                }}
-                title="양쪽 정렬"
-              >
-                <AlignJustify size={16} />
-              </button>
-
-              <div style={{ width: '1px', height: '20px', backgroundColor: '#C0C0C0', margin: '0 4px' }} />
-
-              <button
-                type="button"
-                onClick={() => {
-                  const iframeDoc = iframeRef.current?.contentDocument || iframeRef.current?.contentWindow?.document;
-                  if (!iframeDoc) return;
-                  iframeDoc.execCommand('insertUnorderedList', false);
-                  syncIframeHtml(iframeDoc);
-                }}
-                style={{
-                  padding: '4px 8px',
-                  fontSize: '11px',
-                  border: '1px solid #A9A9A9',
-                  borderRadius: '3px',
-                  backgroundColor: '#FFFFFF',
-                  color: '#000000',
-                  cursor: 'pointer',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                }}
-                title="글머리 기호 목록"
-              >
-                <List size={16} />
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  const iframeDoc = iframeRef.current?.contentDocument || iframeRef.current?.contentWindow?.document;
-                  if (!iframeDoc) return;
-                  iframeDoc.execCommand('insertOrderedList', false);
-                  syncIframeHtml(iframeDoc);
-                }}
-                style={{
-                  padding: '4px 8px',
-                  fontSize: '11px',
-                  border: '1px solid #A9A9A9',
-                  borderRadius: '3px',
-                  backgroundColor: '#FFFFFF',
-                  color: '#000000',
-                  cursor: 'pointer',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                }}
-                title="번호 매기기 목록"
-              >
-                <ListOrdered size={16} />
-              </button>
-
-              <button
-                type="button"
-                onClick={() => {
-                  const iframeDoc = iframeRef.current?.contentDocument || iframeRef.current?.contentWindow?.document;
-                  if (!iframeDoc) return;
-                  const url = prompt('링크 URL을 입력하세요:');
-                  if (url) iframeDoc.execCommand('createLink', false, url);
-                  syncIframeHtml(iframeDoc);
-                }}
-                style={{
-                  padding: '4px 8px',
-                  fontSize: '11px',
-                  border: '1px solid #A9A9A9',
-                  borderRadius: '3px',
-                  backgroundColor: '#FFFFFF',
-                  color: '#000000',
-                  cursor: 'pointer',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                }}
-                title="링크 삽입"
-              >
-                <Link2 size={16} />
-              </button>
-
-              <div style={{ width: '1px', height: '20px', backgroundColor: '#C0C0C0', margin: '0 4px' }} />
-
-              <div style={{ position: 'relative', display: 'inline-block' }}>
-                <input
-                  type="file"
-                  accept="image/*"
-                  onChange={(e) => {
-                    const file = e.target.files?.[0];
-                    if (!file) return;
-                    const reader = new FileReader();
-                    reader.onload = (event) => {
-                      const imageUrl = event.target?.result as string;
-                      const iframeDoc = iframeRef.current?.contentDocument || iframeRef.current?.contentWindow?.document;
-                      if (iframeDoc && imageUrl) {
-                        try {
-                          iframeDoc.execCommand(
-                            'insertHTML',
-                            false,
-                            `<img src="${imageUrl}" alt="" style="max-width: 100%; height: auto;" />`
-                          );
-                        } catch (err) {
-                          const selection = iframeDoc.getSelection();
-                          if (selection && selection.rangeCount > 0) {
-                            const range = selection.getRangeAt(0);
-                            const img = iframeDoc.createElement('img');
-                            img.src = imageUrl;
-                            img.alt = '';
-                            img.style.maxWidth = '100%';
-                            img.style.height = 'auto';
-                            range.insertNode(img);
-                          }
-                        }
-                        syncIframeHtml(iframeDoc);
-                      }
-                    };
-                    reader.readAsDataURL(file);
-                    e.target.value = '';
-                  }}
-                  style={{
-                    position: 'absolute',
-                    width: '100%',
-                    height: '100%',
-                    opacity: 0,
-                    cursor: 'pointer',
-                    zIndex: 2,
-                  }}
-                  title="이미지 삽입"
-                />
-                <button
-                  type="button"
-                  style={{
-                    padding: '4px 8px',
-                    fontSize: '11px',
-                    border: '1px solid #A9A9A9',
-                    borderRadius: '3px',
-                    backgroundColor: '#FFFFFF',
-                    color: '#000000',
-                    cursor: 'pointer',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    pointerEvents: 'none',
-                  }}
-                  title="이미지 삽입"
-                  disabled
-                >
-                  <Image size={16} />
-                </button>
-              </div>
-
-              <button
-                type="button"
-                onClick={() => {
-                  const iframeDoc = iframeRef.current?.contentDocument || iframeRef.current?.contentWindow?.document;
-                  if (!iframeDoc) return;
-                  try {
-                    iframeDoc.execCommand(
-                      'insertHTML',
-                      false,
-                      '<pre style="background-color: #f4f4f4; padding: 10px; border-radius: 4px; overflow-x: auto;"><code></code></pre>'
-                    );
-                  } catch (err) {
-                    iframeDoc.execCommand('formatBlock', false, 'pre');
-                    const selection = iframeDoc.getSelection();
-                    if (selection && selection.rangeCount > 0) {
-                      const range = selection.getRangeAt(0);
-                      const preElement =
-                        range.commonAncestorContainer.nodeType === 1
-                          ? range.commonAncestorContainer as HTMLElement
-                          : (range.commonAncestorContainer.parentElement as HTMLElement);
-                      if (preElement && preElement.tagName === 'PRE') {
-                        preElement.style.backgroundColor = '#f4f4f4';
-                        preElement.style.padding = '10px';
-                        preElement.style.borderRadius = '4px';
-                        preElement.style.overflowX = 'auto';
-                      }
-                    }
-                  }
-                  syncIframeHtml(iframeDoc);
-                }}
-                style={{
-                  padding: '4px 8px',
-                  fontSize: '11px',
-                  border: '1px solid #A9A9A9',
-                  borderRadius: '3px',
-                  backgroundColor: '#FFFFFF',
-                  color: '#000000',
-                  cursor: 'pointer',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                }}
-                title="코드 블록"
-              >
-                <Code size={16} />
-              </button>
-
-              <div style={{ position: 'relative', display: 'inline-block' }} ref={step3MoreMenuRef} data-more-menu>
-                <button
-                  type="button"
-                  onClick={() => setStep3ShowMoreMenu(!step3ShowMoreMenu)}
-                  style={{
-                    padding: '4px 8px',
-                    fontSize: '11px',
-                    border: '1px solid #A9A9A9',
-                    borderRadius: '3px',
-                    backgroundColor: step3ShowMoreMenu ? '#E0E0E0' : '#FFFFFF',
-                    color: '#000000',
-                    cursor: 'pointer',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                  }}
-                  title="더보기"
-                >
-                  <MoreVertical size={16} />
-                </button>
-
-                {step3ShowMoreMenu && (
-                  <div
-                    style={{
-                      position: 'absolute',
-                      top: '100%',
-                      right: 0,
-                      marginTop: '4px',
-                      backgroundColor: '#FFFFFF',
-                      border: '1px solid #A9A9A9',
-                      borderRadius: '4px',
-                      boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
-                      zIndex: 1000,
-                      display: 'flex',
-                      flexDirection: 'row',
-                      gap: '4px',
-                      padding: '4px',
-                    }}
-                    onClick={(e) => e.stopPropagation()}
-                    data-more-menu
-                  >
-                    <button
-                      type="button"
-                      onClick={() => {
-                        const iframeDoc = iframeRef.current?.contentDocument || iframeRef.current?.contentWindow?.document;
-                        if (iframeDoc) iframeDoc.execCommand('formatBlock', false, 'blockquote');
-                        if (iframeDoc) syncIframeHtml(iframeDoc);
-                        setStep3ShowMoreMenu(false);
-                      }}
-                      style={{
-                        padding: '4px 8px',
-                        fontSize: '11px',
-                        border: '1px solid #A9A9A9',
-                        borderRadius: '3px',
-                        backgroundColor: '#FFFFFF',
-                        color: '#000000',
-                        cursor: 'pointer',
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                      }}
-                      title="인용문"
-                    >
-                      <Quote size={16} />
-                    </button>
-
-                    <button
-                      type="button"
-                      onClick={() => {
-                        const iframeDoc = iframeRef.current?.contentDocument || iframeRef.current?.contentWindow?.document;
-                        if (iframeDoc) iframeDoc.execCommand('insertHorizontalRule', false);
-                        if (iframeDoc) syncIframeHtml(iframeDoc);
-                        setStep3ShowMoreMenu(false);
-                      }}
-                      style={{
-                        padding: '4px 8px',
-                        fontSize: '11px',
-                        border: '1px solid #A9A9A9',
-                        borderRadius: '3px',
-                        backgroundColor: '#FFFFFF',
-                        color: '#000000',
-                        cursor: 'pointer',
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                      }}
-                      title="구분선"
-                    >
-                      <Minus size={16} />
-                    </button>
-
-                    <button
-                      type="button"
-                      onClick={() => {
-                        const iframeDoc = iframeRef.current?.contentDocument || iframeRef.current?.contentWindow?.document;
-                        if (!iframeDoc) return;
-
-                        const rows = prompt('행 수를 입력하세요 (기본값: 3):', '3');
-                        const cols = prompt('열 수를 입력하세요 (기본값: 3):', '3');
-                        const rowCount = parseInt(rows || '3', 10);
-                        const colCount = parseInt(cols || '3', 10);
-
-                        if (rowCount > 0 && colCount > 0) {
-                          let tableHtml = '<table border="1" style="border-collapse: collapse; width: 100%;">';
-                          for (let i = 0; i < rowCount; i++) {
-                            tableHtml += '<tr>';
-                            for (let j = 0; j < colCount; j++) {
-                              tableHtml += '<td style="padding: 8px; border: 1px solid #000;">&nbsp;</td>';
-                            }
-                            tableHtml += '</tr>';
-                          }
-                          tableHtml += '</table>';
-
-                          try {
-                            iframeDoc.execCommand('insertHTML', false, tableHtml);
-                          } catch (err) {
-                            const selection = iframeDoc.getSelection();
-                            if (selection && selection.rangeCount > 0) {
-                              const range = selection.getRangeAt(0);
-                              const tempDiv = iframeDoc.createElement('div');
-                              tempDiv.innerHTML = tableHtml;
-                              const fragment = iframeDoc.createDocumentFragment();
-                              while (tempDiv.firstChild) {
-                                fragment.appendChild(tempDiv.firstChild);
-                              }
-                              range.insertNode(fragment);
-                            }
-                          }
-                          syncIframeHtml(iframeDoc);
-                        }
-                        setStep3ShowMoreMenu(false);
-                      }}
-                      style={{
-                        padding: '4px 8px',
-                        fontSize: '11px',
-                        border: '1px solid #A9A9A9',
-                        borderRadius: '3px',
-                        backgroundColor: '#FFFFFF',
-                        color: '#000000',
-                        cursor: 'pointer',
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                      }}
-                      title="표"
-                    >
-                      <Table size={16} />
-                    </button>
-
-                    <button
-                      type="button"
-                      onClick={() => {
-                        const iframeDoc = iframeRef.current?.contentDocument || iframeRef.current?.contentWindow?.document;
-                        if (!iframeDoc) return;
-
-                        const selection = iframeDoc.getSelection();
-                        if (selection && selection.rangeCount > 0 && !selection.getRangeAt(0).collapsed) {
-                          const range = selection.getRangeAt(0);
-                          const selectedText = range.toString();
-                          try {
-                            iframeDoc.execCommand('insertHTML', false, `<sup>${selectedText}</sup>`);
-                          } catch (err) {
-                            const sup = iframeDoc.createElement('sup');
-                            sup.textContent = selectedText;
-                            range.deleteContents();
-                            range.insertNode(sup);
-                          }
-                        } else {
-                          try {
-                            iframeDoc.execCommand('insertHTML', false, '<sup></sup>');
-                          } catch (err) {
-                            const sel = iframeDoc.getSelection();
-                            if (sel && sel.rangeCount > 0) {
-                              const range = sel.getRangeAt(0);
-                              const sup = iframeDoc.createElement('sup');
-                              sup.innerHTML = '&nbsp;';
-                              range.insertNode(sup);
-                            }
-                          }
-                        }
-                        syncIframeHtml(iframeDoc);
-                        setStep3ShowMoreMenu(false);
-                      }}
-                      style={{
-                        padding: '4px 8px',
-                        fontSize: '11px',
-                        border: '1px solid #A9A9A9',
-                        borderRadius: '3px',
-                        backgroundColor: '#FFFFFF',
-                        color: '#000000',
-                        cursor: 'pointer',
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                      }}
-                      title="위 첨자"
-                    >
-                      <Superscript size={16} />
-                    </button>
-
-                    <button
-                      type="button"
-                      onClick={() => {
-                        const iframeDoc = iframeRef.current?.contentDocument || iframeRef.current?.contentWindow?.document;
-                        if (!iframeDoc) return;
-
-                        const selection = iframeDoc.getSelection();
-                        if (selection && selection.rangeCount > 0 && !selection.getRangeAt(0).collapsed) {
-                          const range = selection.getRangeAt(0);
-                          const selectedText = range.toString();
-                          try {
-                            iframeDoc.execCommand('insertHTML', false, `<sub>${selectedText}</sub>`);
-                          } catch (err) {
-                            const sub = iframeDoc.createElement('sub');
-                            sub.textContent = selectedText;
-                            range.deleteContents();
-                            range.insertNode(sub);
-                          }
-                        } else {
-                          try {
-                            iframeDoc.execCommand('insertHTML', false, '<sub></sub>');
-                          } catch (err) {
-                            const sel = iframeDoc.getSelection();
-                            if (sel && sel.rangeCount > 0) {
-                              const range = sel.getRangeAt(0);
-                              const sub = iframeDoc.createElement('sub');
-                              sub.innerHTML = '&nbsp;';
-                              range.insertNode(sub);
-                            }
-                          }
-                        }
-                        syncIframeHtml(iframeDoc);
-                        setStep3ShowMoreMenu(false);
-                      }}
-                      style={{
-                        padding: '4px 8px',
-                        fontSize: '11px',
-                        border: '1px solid #A9A9A9',
-                        borderRadius: '3px',
-                        backgroundColor: '#FFFFFF',
-                        color: '#000000',
-                        cursor: 'pointer',
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                      }}
-                      title="아래 첨자"
-                    >
-                      <Subscript size={16} />
-                    </button>
-                  </div>
-                )}
-              </div>
-              <div style={{ width: '1px', height: '20px', backgroundColor: '#C0C0C0', margin: '0 4px' }} />
-            </>
-          )}
-          <div style={{ display: 'flex', gap: '4px' }}>
-            <Button
-              variant="secondary"
-              onClick={() => {
-                const iframe = iframeRef.current;
-                const iframeDoc = iframe?.contentDocument || iframe?.contentWindow?.document;
-                if (!iframeDoc) return;
-
-                // ⭐ 모드에 따라 다른 undo 동작
-                if (mode === 'text') {
-                  iframeDoc.execCommand('undo', false);
-                  const updatedHtml = iframeDoc.documentElement.outerHTML;
-                  currentHtmlRef.current = updatedHtml;
-                  onHtmlChange(updatedHtml);
-                  console.log('↶ 텍스트 편집 실행 취소 완료 (browser undo)');
-                } else if (mode === 'spacing') {
-                  if (spacingUndoStackRef.current.length > 0) {
-                    // 공백 제거 undo: 전체 공백 제거 실행 취소
-                    // 현재 상태를 redo stack에 저장
-                    const currentHtml = iframeDoc.documentElement.outerHTML;
-                    spacingRedoStackRef.current.push(currentHtml);
-                    
-                    // undo stack에서 이전 상태 가져오기
-                    const previousHtml = spacingUndoStackRef.current.pop() || '';
-                    
-                    // iframe에 이전 HTML 적용
-                    iframeDoc.open();
-                    iframeDoc.write(previousHtml);
-                    iframeDoc.close();
-                    
-                    // currentHtmlRef 업데이트
-                    currentHtmlRef.current = previousHtml;
-                    spacingCurrentHtmlRef.current = previousHtml;
-                    onHtmlChange(previousHtml);
-                    
-                    // 공백 제거 모드 다시 초기화
-                    setTimeout(() => {
-                      // 공백 제거 모드 재활성화는 useEffect에서 처리됨
-                    }, 0);
-                    
-                    console.log('↶ 공백 제거 실행 취소 완료. 남은 undo:', spacingUndoStackRef.current.length);
-                  }
-                } else if (mode === 'component') {
-                  // 컴포넌트 편집 모드: 컴포넌트 편집 undo stack 사용
-                  if (undoStackRef.current.length > 0) {
-                    // 현재 상태를 redo stack에 저장
-                    const currentHtml = iframeDoc.documentElement.outerHTML;
-                    redoStackRef.current.push(currentHtml);
-                    
-                    // undo stack에서 이전 상태 가져오기
-                    const previousHtml = undoStackRef.current.pop() || '';
-                    
-                    // iframe에 이전 HTML 적용
-                    iframeDoc.open();
-                    iframeDoc.write(previousHtml);
-                    iframeDoc.close();
-                    
-                    // currentHtmlRef 업데이트
-                    currentHtmlRef.current = previousHtml;
-                    onHtmlChange(previousHtml);
-                    
-                    // 컴포넌트 편집 모드 다시 초기화
-                    setTimeout(() => {
-                      const newIframeDoc = iframe?.contentDocument || iframe?.contentWindow?.document;
-                      if (!newIframeDoc) return;
-                      
-                      // contentEditable 비활성화
-                      const editableElements = newIframeDoc.querySelectorAll('[contenteditable="true"]');
-                      editableElements.forEach((el) => {
-                        (el as HTMLElement).contentEditable = 'false';
-                        (el as HTMLElement).style.cursor = 'default';
-                      });
-                      
-                      // 컴포넌트 클릭 핸들러 추가
-                      const componentElements = newIframeDoc.querySelectorAll('div, section, article, header, footer, main, aside, nav, p, h1, h2, h3, h4, h5, h6');
-                      
-                      const handleComponentClick = (e: Event) => {
-                        e.stopPropagation();
-                        e.preventDefault();
-                        
-                        const target = e.target as HTMLElement;
-                        if (!target || ['SCRIPT', 'STYLE', 'NOSCRIPT', 'HTML', 'HEAD', 'BODY'].includes(target.tagName)) return;
-                        
-                        const isSelected = target.classList.contains('component-selected');
-                        
-                        if (isSelected) {
-                          target.classList.remove('component-selected');
-                          target.style.outline = '1px dashed #C0C0C0';
-                          target.style.boxShadow = 'none';
-                          target.style.backgroundColor = '';
-                          setSelectedElements(prev => prev.filter(el => el !== target));
-                        } else {
-                          target.classList.add('component-selected');
-                          target.style.outline = '4px solid #28a745';
-                          target.style.outlineOffset = '3px';
-                          target.style.backgroundColor = 'rgba(40, 167, 69, 0.25)';
-                          target.style.boxShadow = '0 0 0 4px rgba(40, 167, 69, 0.4), 0 4px 12px rgba(40, 167, 69, 0.5)';
-                          target.style.transition = 'all 0.2s ease';
-                          setSelectedElements(prev => [...prev, target]);
-                        }
-                      };
-                      
-                      componentElements.forEach((el) => {
-                        if (el.tagName && !['SCRIPT', 'STYLE', 'NOSCRIPT', 'HTML', 'HEAD', 'BODY'].includes(el.tagName)) {
-                          const htmlEl = el as HTMLElement;
-                          htmlEl.setAttribute('data-component-editable', 'true');
-                          htmlEl.style.cursor = 'pointer';
-                          htmlEl.style.outline = '1px dashed #C0C0C0';
-                          
-                          // 기존 핸들러 제거 후 새로 추가
-                          const existingHandler = componentClickHandlersRef.current.get(htmlEl);
-                          if (existingHandler) {
-                            htmlEl.removeEventListener('click', existingHandler, true);
-                          }
-                          htmlEl.addEventListener('click', handleComponentClick, true);
-                          componentClickHandlersRef.current.set(htmlEl, handleComponentClick);
-                        }
-                      });
-                      
-                      // 링크 클릭 방지 핸들러 추가
-                      const allLinks = newIframeDoc.querySelectorAll('a');
-                      const preventLinkNavigation = (e: Event) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        e.stopImmediatePropagation();
-                        return false;
-                      };
-                      
-                      allLinks.forEach(link => {
-                        const htmlLink = link as HTMLElement;
-                        const existingLinkHandler = linkClickHandlersRef.current.get(htmlLink);
-                        if (existingLinkHandler) {
-                          htmlLink.removeEventListener('click', existingLinkHandler, true);
-                        }
-                        htmlLink.addEventListener('click', preventLinkNavigation, true);
-                        linkClickHandlersRef.current.set(htmlLink, preventLinkNavigation);
-                        htmlLink.style.cursor = 'pointer';
-                      });
-                      
-                      // iframe 포커스 설정
-                      if (newIframeDoc.body) {
-                        newIframeDoc.body.setAttribute('tabindex', '-1');
-                        newIframeDoc.body.focus();
-                      }
-                    }, 100);
-                    
-                    setSelectedElements([]);
-                    
-                    console.log('↶ 컴포넌트 편집 실행 취소 완료. 남은 undo:', undoStackRef.current.length);
-                  } else {
-                    console.log('⚠️ 컴포넌트 편집 undo stack이 비어있습니다');
-                  }
-                }
-              }}
-              style={{ fontSize: '12px', padding: '4px 8px' }}
-            >
-              <Undo2 size={16} color="#000000" />
-            </Button>
-            <Button
-              variant="secondary"
-              onClick={() => {
-                const iframe = iframeRef.current;
-                const iframeDoc = iframe?.contentDocument || iframe?.contentWindow?.document;
-                if (!iframeDoc) return;
-
-                // ⭐ 모드에 따라 다른 redo 동작
-                if (mode === 'text') {
-                  iframeDoc.execCommand('redo', false);
-                  const updatedHtml = iframeDoc.documentElement.outerHTML;
-                  currentHtmlRef.current = updatedHtml;
-                  onHtmlChange(updatedHtml);
-                  console.log('↷ 텍스트 편집 다시 실행 완료 (browser redo)');
-                } else if (mode === 'spacing') {
-                  if (spacingRedoStackRef.current.length > 0) {
-                    // 공백 제거 redo: 전체 공백 제거 다시 실행
-                    // 현재 상태를 undo stack에 저장
-                    const currentHtml = iframeDoc.documentElement.outerHTML;
-                    spacingUndoStackRef.current.push(currentHtml);
-                    
-                    // redo stack에서 다음 상태 가져오기
-                    const nextHtml = spacingRedoStackRef.current.pop() || '';
-                    
-                    // iframe에 다음 HTML 적용
-                    iframeDoc.open();
-                    iframeDoc.write(nextHtml);
-                    iframeDoc.close();
-                    
-                    // currentHtmlRef 업데이트
-                    currentHtmlRef.current = nextHtml;
-                    spacingCurrentHtmlRef.current = nextHtml;
-                    onHtmlChange(nextHtml);
-                    
-                    // 공백 제거 모드 다시 초기화
-                    setTimeout(() => {
-                      // 공백 제거 모드 재활성화는 useEffect에서 처리됨
-                    }, 0);
-                    
-                    console.log('↷ 공백 제거 다시 실행 완료. 남은 redo:', spacingRedoStackRef.current.length);
-                  }
-                } else if (mode === 'component') {
-                  // 컴포넌트 편집 모드: 컴포넌트 편집 redo stack 사용
-                  if (redoStackRef.current.length > 0) {
-                    // 현재 상태를 undo stack에 저장
-                    const currentHtml = iframeDoc.documentElement.outerHTML;
-                    undoStackRef.current.push(currentHtml);
-                    
-                    // redo stack에서 다음 상태 가져오기
-                    const nextHtml = redoStackRef.current.pop() || '';
-                    
-                    // iframe에 다음 HTML 적용
-                    iframeDoc.open();
-                    iframeDoc.write(nextHtml);
-                    iframeDoc.close();
-                    
-                    // currentHtmlRef 업데이트
-                    currentHtmlRef.current = nextHtml;
-                    onHtmlChange(nextHtml);
-                    
-                    // 컴포넌트 편집 모드 다시 초기화
-                    setTimeout(() => {
-                      const newIframeDoc = iframe?.contentDocument || iframe?.contentWindow?.document;
-                      if (!newIframeDoc) return;
-                      
-                      // contentEditable 비활성화
-                      const editableElements = newIframeDoc.querySelectorAll('[contenteditable="true"]');
-                      editableElements.forEach((el) => {
-                        (el as HTMLElement).contentEditable = 'false';
-                        (el as HTMLElement).style.cursor = 'default';
-                      });
-                      
-                      // 컴포넌트 클릭 핸들러 추가
-                      const componentElements = newIframeDoc.querySelectorAll('div, section, article, header, footer, main, aside, nav, p, h1, h2, h3, h4, h5, h6');
-                      
-                      const handleComponentClick = (e: Event) => {
-                        e.stopPropagation();
-                        e.preventDefault();
-                        
-                        const target = e.target as HTMLElement;
-                        if (!target || ['SCRIPT', 'STYLE', 'NOSCRIPT', 'HTML', 'HEAD', 'BODY'].includes(target.tagName)) return;
-                        
-                        const isSelected = target.classList.contains('component-selected');
-                        
-                        if (isSelected) {
-                          target.classList.remove('component-selected');
-                          target.style.outline = '1px dashed #C0C0C0';
-                          target.style.boxShadow = 'none';
-                          target.style.backgroundColor = '';
-                          setSelectedElements(prev => prev.filter(el => el !== target));
-                        } else {
-                          target.classList.add('component-selected');
-                          target.style.outline = '4px solid #28a745';
-                          target.style.outlineOffset = '3px';
-                          target.style.backgroundColor = 'rgba(40, 167, 69, 0.25)';
-                          target.style.boxShadow = '0 0 0 4px rgba(40, 167, 69, 0.4), 0 4px 12px rgba(40, 167, 69, 0.5)';
-                          target.style.transition = 'all 0.2s ease';
-                          setSelectedElements(prev => [...prev, target]);
-                        }
-                      };
-                      
-                      componentElements.forEach((el) => {
-                        if (el.tagName && !['SCRIPT', 'STYLE', 'NOSCRIPT', 'HTML', 'HEAD', 'BODY'].includes(el.tagName)) {
-                          const htmlEl = el as HTMLElement;
-                          htmlEl.setAttribute('data-component-editable', 'true');
-                          htmlEl.style.cursor = 'pointer';
-                          htmlEl.style.outline = '1px dashed #C0C0C0';
-                          
-                          // 기존 핸들러 제거 후 새로 추가
-                          const existingHandler = componentClickHandlersRef.current.get(htmlEl);
-                          if (existingHandler) {
-                            htmlEl.removeEventListener('click', existingHandler, true);
-                          }
-                          htmlEl.addEventListener('click', handleComponentClick, true);
-                          componentClickHandlersRef.current.set(htmlEl, handleComponentClick);
-                        }
-                      });
-                      
-                      // 링크 클릭 방지 핸들러 추가
-                      const allLinks = newIframeDoc.querySelectorAll('a');
-                      const preventLinkNavigation = (e: Event) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        e.stopImmediatePropagation();
-                        return false;
-                      };
-                      
-                      allLinks.forEach(link => {
-                        const htmlLink = link as HTMLElement;
-                        const existingLinkHandler = linkClickHandlersRef.current.get(htmlLink);
-                        if (existingLinkHandler) {
-                          htmlLink.removeEventListener('click', existingLinkHandler, true);
-                        }
-                        htmlLink.addEventListener('click', preventLinkNavigation, true);
-                        linkClickHandlersRef.current.set(htmlLink, preventLinkNavigation);
-                        htmlLink.style.cursor = 'pointer';
-                      });
-                      
-                      // iframe 포커스 설정
-                      if (newIframeDoc.body) {
-                        newIframeDoc.body.setAttribute('tabindex', '-1');
-                        newIframeDoc.body.focus();
-                      }
-                    }, 100);
-                    
-                    setSelectedElements([]);
-                    
-                    console.log('↷ 컴포넌트 편집 다시 실행 완료. 남은 redo:', redoStackRef.current.length);
-                  } else {
-                    console.log('⚠️ 컴포넌트 편집 redo stack이 비어있습니다');
-                  }
-                }
-              }}
-              style={{ fontSize: '12px', padding: '4px 8px' }}
-            >
-              <Redo2 size={16} color="#000000" />
-            </Button>
-          </div>
-          <div style={{ borderLeft: '1px solid #C0C0C0', height: '24px', margin: '0 4px' }} />
-          <div style={{ display: 'flex', gap: '4px' }}>
-            <Button
-              variant={mode === 'spacing' ? 'primary' : 'secondary'}
-              onClick={() => setMode('spacing')}
-              style={{ fontSize: '12px', padding: '4px 8px' }}
-            >
-              수동 공백 제거
-            </Button>
-            <Button
-              variant="primary"
-              onClick={() => removeSpacing('auto')}
-              style={{ fontSize: '12px', padding: '4px 8px' }}
-            >
-              전체 공백 제거
-            </Button>
-            <Button
-              variant="primary"
-              onClick={() => removeUnnecessaryGrids()}
-              style={{ fontSize: '12px', padding: '4px 8px' }}
-            >
-              불필요한 그리드 제거
-            </Button>
-            {/* 오른쪽 유틸 메뉴 */}
-            <div style={{ marginLeft: 'auto', position: 'relative' }} ref={step3UtilityMenuRef}>
-              <button
-                type="button"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setStep3UtilityMenuOpen((prev) => !prev);
-                }}
-                style={{
-                  padding: '4px 10px',
-                  fontSize: '12px',
-                  border: '1px solid #A9A9A9',
-                  borderRadius: '3px',
-                  backgroundColor: '#FFFFFF',
-                  color: '#000000',
-                  cursor: 'pointer',
-                  fontWeight: 600,
-                  lineHeight: 1,
-                }}
-                title="더 보기"
-              >
-                ...
-              </button>
-              {step3UtilityMenuOpen && (
-                <div
-                  style={{
-                    position: 'absolute',
-                    right: 0,
-                    top: '30px',
-                    backgroundColor: '#FFFFFF',
-                    border: '1px solid #C0C0C0',
-                    borderRadius: '6px',
-                    boxShadow: '0 10px 20px rgba(0, 0, 0, 0.08)',
-                    padding: '6px',
-                    zIndex: 1000,
-                    minWidth: '160px',
-                  }}
-                >
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      const iframe = iframeRef.current;
-                      const iframeDoc = iframe?.contentDocument || iframe?.contentWindow?.document;
-                      if (iframeDoc) {
-                        iframeDoc.open();
-                        iframeDoc.write(MANUAL_PASTE_HTML);
-                        iframeDoc.close();
-                        const updatedHtml = iframeDoc.documentElement.outerHTML;
-                        currentHtmlRef.current = updatedHtml;
-                        onHtmlChange(updatedHtml);
-                        setTimeout(() => {
-                          const div = iframeDoc.querySelector('[contenteditable="true"]') as HTMLElement;
-                          if (div) div.focus();
-                        }, 50);
-                      }
-                      onClearForManualPaste?.();
-                      setStep3UtilityMenuOpen(false);
-                    }}
-                    style={{
-                      width: '100%',
-                      textAlign: 'left',
-                      padding: '8px 10px',
-                      border: 'none',
-                      background: 'none',
-                      cursor: 'pointer',
-                      fontSize: '12px',
-                      color: '#000000',
-                      borderRadius: '4px',
-                    }}
-                    title="초기화"
-                  >
-                    초기화
-                  </button>
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      downloadHtml();
-                      setStep3UtilityMenuOpen(false);
-                    }}
-                    style={{
-                      width: '100%',
-                      textAlign: 'left',
-                      padding: '8px 10px',
-                      border: 'none',
-                      background: 'none',
-                      cursor: 'pointer',
-                      fontSize: '12px',
-                      color: '#000000',
-                      borderRadius: '4px',
-                    }}
-                    title="HTML 다운로드"
-                  >
-                    💾 HTML 다운로드
-                  </button>
-                </div>
-              )}
-            </div>
-          </div>
-        </div>
-
-        {mode === 'spacing' && (() => {
-          const first = selectedElements[0];
-          const iframeDoc = iframeRef.current?.contentDocument || iframeRef.current?.contentWindow?.document;
-          let top = 0, bottom = 0, left = 0, right = 0;
-          if (first && iframeDoc?.body?.contains(first)) {
-            const c = iframeDoc.defaultView?.getComputedStyle(first);
-            if (c) {
-              top = (parseFloat(c.marginTop) || 0) + (parseFloat(c.paddingTop) || 0);
-              bottom = (parseFloat(c.marginBottom) || 0) + (parseFloat(c.paddingBottom) || 0);
-              left = (parseFloat(c.marginLeft) || 0) + (parseFloat(c.paddingLeft) || 0);
-              right = (parseFloat(c.marginRight) || 0) + (parseFloat(c.paddingRight) || 0);
-            }
-          }
-          return (
-            <div style={{ display: 'flex', gap: '8px', alignItems: 'center', flexWrap: 'wrap' }}>
-              <span style={{ fontSize: '12px', color: '#696969', marginRight: '4px' }}>
-                {selectedElements.length}개 선택됨
-              </span>
-              {selectedElements.length > 0 && (
-                <>
-                  <span style={{ fontSize: '12px', color: '#333' }}>윗 여백: {top}px</span>
-                  <span style={{ fontSize: '12px', color: '#333' }}>아래 여백: {bottom}px</span>
-                  <span style={{ fontSize: '12px', color: '#333' }}>왼쪽 여백: {left}px</span>
-                  <span style={{ fontSize: '12px', color: '#333' }}>우측 여백: {right}px</span>
-                  <Button variant="secondary" onClick={() => removeSpacing('top')} style={{ fontSize: '11px', padding: '2px 6px' }}>윗 공백 제거</Button>
-                  <Button variant="secondary" onClick={() => removeSpacing('bottom')} style={{ fontSize: '11px', padding: '2px 6px' }}>아래 공백 제거</Button>
-                  <Button variant="secondary" onClick={() => removeSpacing('left')} style={{ fontSize: '11px', padding: '2px 6px' }}>왼쪽 공백 제거</Button>
-                  <Button variant="secondary" onClick={() => removeSpacing('right')} style={{ fontSize: '11px', padding: '2px 6px' }}>우측 공백 제거</Button>
-                </>
-              )}
-            </div>
-          );
-        })()}
-
-        {mode === 'component' && (
-          <div style={{ display: 'flex', gap: '4px', alignItems: 'center' }}>
-            <span style={{ fontSize: '12px', color: '#696969', marginRight: '4px' }}>
-              {selectedElements.length}개 선택됨
-            </span>
-                <Button
-                  variant="secondary"
-                  onClick={() => {
-                    if (!iframeRef.current) return;
-                    const iframeDoc = iframeRef.current.contentDocument || iframeRef.current.contentWindow?.document;
-                    if (iframeDoc) {
-                      selectedElements.forEach(el => {
-                        el.classList.remove('component-selected');
-                        el.style.outline = '';
-                        el.style.boxShadow = '';
-                        el.style.backgroundColor = '';
-                        el.style.outlineOffset = '';
-                      });
-                    }
-                    setSelectedElements([]);
-                  }}
-                  disabled={selectedElements.length === 0}
-                  style={{ fontSize: '12px', padding: '4px 8px' }}
-                  title="전체 선택 취소"
-                >
-                  선택 취소
-                </Button>
-                <Button
-                  variant="primary"
-                  onClick={handleDelete}
-                  disabled={selectedElements.length === 0}
-                  style={{ fontSize: '12px', padding: '4px 8px' }}
-                  title={`${selectedElements.length}개 요소 삭제`}
-                >
-                  삭제
-                </Button>
-          </div>
-        )}
-      </div>
-
-      {/* 에디터 영역 */}
-      <div
-        style={{
-          flex: 1,
-          border: '1px solid #C0C0C0',
-          borderRadius: '8px',
-          overflow: 'hidden',
-          backgroundColor: '#FFFFFF',
-        }}
-      >
-        <iframe
-          ref={iframeRef}
-          style={{
-            width: '100%',
-            height: '100%',
-            border: 'none',
-          }}
-          title="Pre-edit HTML"
-        />
-      </div>
-    </div>
-  );
+							iframeDoc.head.appendChild(componentStyle);
+
+							// 클릭으로 컴포넌트 선택
+							const handleComponentClick = (e: MouseEvent) => {
+								const target = e.target as HTMLElement;
+								if (
+									!target ||
+									target === iframeDoc.body ||
+									target === iframeDoc.documentElement
+								)
+									return;
+								if (
+									target.tagName === "SCRIPT" ||
+									target.tagName === "STYLE" ||
+									target.tagName === "NOSCRIPT"
+								)
+									return;
+
+								e.preventDefault();
+								e.stopPropagation();
+
+								// 기존 선택 제거
+								allElements.forEach((elem) => {
+									(elem as HTMLElement).classList.remove("selected-for-delete");
+								});
+
+								// 새 선택
+								target.classList.add("selected-for-delete");
+								setSelectedElements([target]);
+							};
+
+							allElements.forEach((el) => {
+								if (
+									el.tagName === "SCRIPT" ||
+									el.tagName === "STYLE" ||
+									el.tagName === "NOSCRIPT"
+								)
+									return;
+								if (el === iframeDoc.body || el === iframeDoc.documentElement)
+									return;
+
+								(el as HTMLElement).removeEventListener(
+									"click",
+									handleComponentClick as EventListener,
+								);
+								(el as HTMLElement).addEventListener(
+									"click",
+									handleComponentClick as EventListener,
+									true,
+								);
+							});
+
+							if (iframeDoc.body) {
+								iframeDoc.body.addEventListener(
+									"click",
+									handleComponentClick as EventListener,
+									true,
+								);
+							}
+						}
+					}
+				}, 200);
+			}
+		}
+	}, [html, selectedAreas, isManualPasteMode]); // mode와 onHtmlChange 제거! (초기 렌더링만 수행)
+
+	const handleDelete = () => {
+		if (
+			selectedElements.length > 0 &&
+			iframeRef.current &&
+			mode === "component"
+		) {
+			const iframe = iframeRef.current;
+			const iframeDoc =
+				iframe.contentDocument || iframe.contentWindow?.document;
+			if (iframeDoc) {
+				console.log("🗑️ 삭제할 요소:", selectedElements.length, "개");
+
+				// 삭제 전 현재 상태를 undo stack에 저장
+				const currentHtml = iframeDoc.documentElement.outerHTML;
+				if (currentHtmlRef.current && currentHtmlRef.current !== currentHtml) {
+					undoStackRef.current.push(currentHtmlRef.current);
+					redoStackRef.current = []; // 새 작업 시 redo stack 초기화
+					console.log(
+						"💾 Step 3 Undo stack에 저장 (삭제 전):",
+						undoStackRef.current.length,
+					);
+					console.log("🔄 Step 3 Redo stack 초기화");
+				} else {
+					console.log(
+						"⚠️ Step 3 삭제 전 저장 스킵 (currentHtmlRef:",
+						!!currentHtmlRef.current,
+						", 동일:",
+						currentHtmlRef.current === currentHtml,
+						")",
+					);
+				}
+
+				// 선택된 모든 요소 삭제
+				selectedElements.forEach((el) => {
+					if (el.parentNode) {
+						el.remove();
+					}
+				});
+
+				const newHtml = iframeDoc.documentElement.outerHTML;
+				currentHtmlRef.current = newHtml;
+				onHtmlChange(newHtml);
+				setSelectedElements([]);
+
+				console.log("✅ 삭제 완료");
+
+				// ⭐ 삭제 후 iframe에 포커스를 주어 키보드 단축키가 바로 작동하도록 함
+				setTimeout(() => {
+					// body에 tabIndex 설정하여 포커스 가능하게 만들기
+					if (iframeDoc.body) {
+						iframeDoc.body.setAttribute("tabindex", "-1");
+						iframeDoc.body.focus();
+					}
+					if (iframe.contentWindow) {
+						iframe.contentWindow.focus();
+					}
+					iframe.focus();
+					console.log("🎯 Step 3 iframe에 포커스 설정");
+				}, 100);
+			}
+		}
+	};
+
+	// 일반적인 컨테이너 클래스명 패턴 인식
+	const isLikelyContainer = (element: HTMLElement): boolean => {
+		const className = (element.className || "").toString();
+		const containerPatterns = [
+			/container/i,
+			/wrapper/i,
+			/main-content/i,
+			/content-wrapper/i,
+			/page-content/i,
+			/article-wrapper/i,
+			/section-container/i,
+			/content-container/i,
+			/main-wrapper/i,
+		];
+		return containerPatterns.some((pattern) => pattern.test(className));
+	};
+
+	// ⭐ 내부 서식 유지: margin/padding을 건드리지 않을 콘텐츠 요소 (인용구, 목록 등)
+	const CONTENT_PRESERVE_TAGS = new Set([
+		"BLOCKQUOTE",
+		"UL",
+		"OL",
+		"PRE",
+		"FIGURE",
+		"FIGCAPTION",
+		"TABLE",
+	]);
+
+	// 공백 제거 함수들
+	const removeSpacing = (
+		type: "top" | "bottom" | "left" | "right" | "auto",
+	) => {
+		if (!iframeRef.current) return;
+
+		const iframe = iframeRef.current;
+		const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
+		if (!iframeDoc || !iframeDoc.body) return;
+
+		// 수동 공백 제거 모드: 선택한 요소에 직접 margin/padding 0 적용
+		if (mode === "spacing" && selectedElements.length > 0) {
+			const currentHtml = iframeDoc.documentElement.outerHTML;
+			if (
+				spacingCurrentHtmlRef.current &&
+				spacingCurrentHtmlRef.current !== currentHtml
+			) {
+				spacingUndoStackRef.current.push(spacingCurrentHtmlRef.current);
+				spacingRedoStackRef.current = [];
+			}
+			const dirs: Array<"top" | "bottom" | "left" | "right"> =
+				type === "auto" ? ["top", "bottom", "left", "right"] : [type];
+			selectedElements.forEach((el) => {
+				if (!iframeDoc.body?.contains(el)) return;
+				dirs.forEach((d) => {
+					if (d === "top") {
+						el.style.marginTop = "0";
+						el.style.paddingTop = "0";
+					} else if (d === "bottom") {
+						el.style.marginBottom = "0";
+						el.style.paddingBottom = "0";
+					} else if (d === "left") {
+						el.style.marginLeft = "0";
+						el.style.paddingLeft = "0";
+					} else if (d === "right") {
+						el.style.marginRight = "0";
+						el.style.paddingRight = "0";
+					}
+				});
+			});
+			const newHtml = iframeDoc.documentElement.outerHTML;
+			spacingCurrentHtmlRef.current = newHtml;
+			currentHtmlRef.current = newHtml;
+			onHtmlChange(newHtml);
+			return;
+		}
+
+		// 🔍 디버깅: 버튼 클릭 전 HTML 및 스타일 정보 저장
+		const beforeHtml = iframeDoc.documentElement.outerHTML;
+		const parentElements = iframeDoc.querySelectorAll(
+			".transflow-spacing-parent",
+		);
+		const beforeStyles: any[] = [];
+		parentElements.forEach((el, idx) => {
+			const computedStyle = iframeDoc.defaultView?.getComputedStyle(
+				el as HTMLElement,
+			);
+			beforeStyles.push({
+				index: idx,
+				tag: el.tagName,
+				marginLeft: computedStyle?.marginLeft,
+				marginRight: computedStyle?.marginRight,
+				paddingLeft: computedStyle?.paddingLeft,
+				paddingRight: computedStyle?.paddingRight,
+			});
+		});
+		console.log("🔍 [공백 제거 전] 부모 요소 스타일:", beforeStyles);
+		console.log("🔍 [공백 제거 전] HTML 길이:", beforeHtml.length);
+
+		// ⭐ 공백 제거 전 현재 상태를 공백 제거 undo stack에 저장
+		const currentHtml = iframeDoc.documentElement.outerHTML;
+		if (
+			spacingCurrentHtmlRef.current &&
+			spacingCurrentHtmlRef.current !== currentHtml
+		) {
+			spacingUndoStackRef.current.push(spacingCurrentHtmlRef.current);
+			spacingRedoStackRef.current = [];
+		}
+
+		// CSS 스타일을 동적으로 추가하기 위한 스타일 태그 생성 또는 업데이트
+		let spacingStyle = iframeDoc.getElementById(
+			"transflow-spacing-remover",
+		) as HTMLStyleElement;
+		if (!spacingStyle) {
+			spacingStyle = iframeDoc.createElement("style");
+			spacingStyle.id = "transflow-spacing-remover";
+			// head의 맨 마지막에 추가 (모든 외부 CSS 파일 이후)
+			iframeDoc.head.appendChild(spacingStyle);
+		} else {
+			// 이미 있으면 head의 맨 마지막으로 이동 (외부 CSS 이후에 오도록)
+			spacingStyle.remove();
+			iframeDoc.head.appendChild(spacingStyle);
+		}
+
+		// 선택된 요소들 찾기
+		const selectedElementIds = new Set(selectedAreas.map((area) => area.id));
+		const selectedElementsFromStep2 = Array.from(
+			iframeDoc.querySelectorAll("[data-transflow-id]"),
+		).filter((el) =>
+			selectedElementIds.has(el.getAttribute("data-transflow-id") || ""),
+		);
+
+		// 공백 제거 모드일 때는 공백 제거 모드에서 선택한 요소만 사용
+		// 전체 공백 제거 모드일 때는 Step 2에서 선택한 영역 사용
+		const allSelectedElements = selectedElementsFromStep2; // Step 2 선택 영역에 전체 공백 제거 적용
+
+		console.log(
+			"🔍 Step 2에서 선택된 요소 개수:",
+			selectedElementsFromStep2.length,
+		);
+		console.log(
+			"🔍 전체 공백 제거 적용 대상:",
+			allSelectedElements.length,
+			"개",
+		);
+		console.log("🔍 총 선택된 요소 개수:", allSelectedElements.length);
+
+		// 기존 클래스 제거 (재적용을 위해)
+		iframeDoc.querySelectorAll(".transflow-spacing-parent").forEach((el) => {
+			el.classList.remove("transflow-spacing-parent");
+		});
+
+		// 선택된 요소들의 부모 요소들에 클래스 추가 (단, blockquote·ul·ol 등 내부 서식 요소는 제외)
+		const parentElementsList: HTMLElement[] = [];
+		allSelectedElements.forEach((selectedEl) => {
+			let parent = selectedEl.parentElement;
+			while (
+				parent &&
+				parent !== iframeDoc.body &&
+				parent !== iframeDoc.documentElement
+			) {
+				if (CONTENT_PRESERVE_TAGS.has(parent.tagName)) {
+					parent = parent.parentElement;
+					continue;
+				}
+				if (!parent.classList.contains("transflow-spacing-parent")) {
+					parent.classList.add("transflow-spacing-parent");
+					parentElementsList.push(parent as HTMLElement);
+				}
+				parent = parent.parentElement;
+			}
+		});
+
+		// 수동 붙여넣기 등 선택 영역 없을 때: body의 직계 레이아웃 자식만 처리
+		if (parentElementsList.length === 0 && iframeDoc.body) {
+			const layoutTags = new Set([
+				"DIV",
+				"MAIN",
+				"SECTION",
+				"ARTICLE",
+				"HEADER",
+				"FOOTER",
+				"ASIDE",
+			]);
+			Array.from(iframeDoc.body.children).forEach((child) => {
+				if (
+					layoutTags.has(child.tagName) &&
+					!CONTENT_PRESERVE_TAGS.has(child.tagName)
+				) {
+					(child as HTMLElement).classList.add("transflow-spacing-parent");
+					parentElementsList.push(child as HTMLElement);
+				}
+			});
+		}
+
+		console.log("🔍 부모 요소 개수:", parentElementsList.length);
+
+		// 상태 업데이트
+		if (type === "auto") {
+			// 자동 모드는 모든 상태를 true로 설정
+			spacingRemovedRef.current = {
+				top: true,
+				bottom: true,
+				left: true,
+				right: true,
+				auto: true,
+			};
+		} else {
+			spacingRemovedRef.current[type] = true;
+		}
+
+		// 모든 적용된 규칙을 기반으로 CSS 재작성
+		const rules: string[] = [];
+
+		// 선택된 요소의 부모 요소들에만 적용 (선택된 요소 자체는 제외)
+		// 더 구체적인 선택자 사용 + body도 포함하여 외부 CSS와의 충돌 방지
+		if (spacingRemovedRef.current.auto) {
+			// 자동 모드면 모든 마진과 패딩 제거
+			rules.push(
+				"body { margin: 0 !important; margin-inline: 0 !important; padding: 0 !important; padding-inline: 0 !important; }",
+			);
+			rules.push(
+				"html body { margin: 0 !important; margin-inline: 0 !important; padding: 0 !important; padding-inline: 0 !important; }",
+			);
+			rules.push(
+				".transflow-spacing-parent { margin: 0 !important; margin-inline: 0 !important; padding: 0 !important; padding-inline: 0 !important; max-width: 100% !important; }",
+			);
+			rules.push(
+				"section.transflow-spacing-parent { margin: 0 !important; padding: 0 !important; padding-inline: 0 !important; max-width: 100% !important; }",
+			);
+			rules.push(
+				"div.transflow-spacing-parent { margin: 0 !important; padding: 0 !important; padding-inline: 0 !important; max-width: 100% !important; }",
+			);
+			rules.push(
+				"body section.transflow-spacing-parent { margin: 0 !important; padding: 0 !important; padding-inline: 0 !important; max-width: 100% !important; }",
+			);
+			rules.push(
+				"body div.transflow-spacing-parent { margin: 0 !important; padding: 0 !important; padding-inline: 0 !important; max-width: 100% !important; }",
+			);
+			// 🔍 wrapper의 width와 max-width도 100%로 설정
+			rules.push(
+				".wrapper.transflow-spacing-parent { width: 100% !important; max-width: 100% !important; margin: 0 !important; padding: 0 !important; }",
+			);
+			rules.push(
+				".transflow-spacing-parent.wrapper { width: 100% !important; max-width: 100% !important; margin: 0 !important; padding: 0 !important; }",
+			);
+			// 🔍 선택된 요소(article)의 width와 margin 제거 (blockquote·ul·ol 등 내부 서식은 유지)
+			rules.push(
+				"[data-transflow-id]:not(blockquote):not(ul):not(ol):not(pre):not(figure):not(table) { margin: 0 !important; width: 100% !important; }",
+			);
+			rules.push(
+				"#contentPost article:not(blockquote) { margin: 0 !important; width: 100% !important; }",
+			);
+			// ⭐ 수동 붙여넣기: .transflow-spacing-parent 내부 article/section/main/div - margin·padding·padding-inline·margin-inline·max-width 제거 (우측 공백 제거)
+			rules.push(
+				".transflow-spacing-parent article { margin: 0 !important; margin-inline: 0 !important; padding: 0 !important; padding-inline: 0 !important; width: 100% !important; max-width: 100% !important; }",
+			);
+			rules.push(
+				".transflow-spacing-parent section { margin: 0 !important; margin-inline: 0 !important; padding: 0 !important; padding-inline: 0 !important; max-width: 100% !important; }",
+			);
+			rules.push(
+				".transflow-spacing-parent main { margin: 0 !important; margin-inline: 0 !important; padding: 0 !important; padding-inline: 0 !important; max-width: 100% !important; }",
+			);
+			rules.push(
+				".transflow-spacing-parent div { margin: 0 !important; margin-inline: 0 !important; padding: 0 !important; padding-inline: 0 !important; max-width: 100% !important; }",
+			);
+		} else {
+			// 개별 모드면 각각 적용
+			if (spacingRemovedRef.current.top) {
+				rules.push("body { margin-top: 0 !important; }");
+				rules.push("html body { margin-top: 0 !important; }");
+				rules.push(".transflow-spacing-parent { margin-top: 0 !important; }");
+				rules.push(
+					"section.transflow-spacing-parent { margin-top: 0 !important; }",
+				);
+				rules.push(
+					"div.transflow-spacing-parent { margin-top: 0 !important; }",
+				);
+				rules.push(
+					"body section.transflow-spacing-parent { margin-top: 0 !important; }",
+				);
+				rules.push(
+					"body div.transflow-spacing-parent { margin-top: 0 !important; }",
+				);
+			}
+			if (spacingRemovedRef.current.bottom) {
+				rules.push("body { margin-bottom: 0 !important; }");
+				rules.push("html body { margin-bottom: 0 !important; }");
+				rules.push(
+					".transflow-spacing-parent { margin-bottom: 0 !important; }",
+				);
+				rules.push(
+					"section.transflow-spacing-parent { margin-bottom: 0 !important; }",
+				);
+				rules.push(
+					"div.transflow-spacing-parent { margin-bottom: 0 !important; }",
+				);
+				rules.push(
+					"body section.transflow-spacing-parent { margin-bottom: 0 !important; }",
+				);
+				rules.push(
+					"body div.transflow-spacing-parent { margin-bottom: 0 !important; }",
+				);
+			}
+			if (spacingRemovedRef.current.left) {
+				// 🔍 왼쪽 공백: padding과 margin 모두 제거 + body 포함
+				rules.push(
+					"body { padding-left: 0 !important; margin-left: 0 !important; }",
+				);
+				rules.push(
+					"html body { padding-left: 0 !important; margin-left: 0 !important; }",
+				);
+				rules.push(
+					".transflow-spacing-parent { padding-left: 0 !important; margin-left: 0 !important; }",
+				);
+				rules.push(
+					"section.transflow-spacing-parent { padding-left: 0 !important; margin-left: 0 !important; }",
+				);
+				rules.push(
+					"div.transflow-spacing-parent { padding-left: 0 !important; margin-left: 0 !important; }",
+				);
+				rules.push(
+					"body section.transflow-spacing-parent { padding-left: 0 !important; margin-left: 0 !important; }",
+				);
+				rules.push(
+					"body div.transflow-spacing-parent { padding-left: 0 !important; margin-left: 0 !important; }",
+				);
+				// 🔍 wrapper의 width도 100%로 설정
+				rules.push(
+					".wrapper.transflow-spacing-parent { width: 100% !important; margin-left: 0 !important; }",
+				);
+				rules.push(
+					".transflow-spacing-parent.wrapper { width: 100% !important; margin-left: 0 !important; }",
+				);
+				// 🔍 선택된 요소의 margin-left 제거 (blockquote 등 내부 서식 유지)
+				rules.push(
+					"[data-transflow-id]:not(blockquote):not(ul):not(ol):not(pre):not(figure):not(table) { margin-left: 0 !important; }",
+				);
+				rules.push(
+					"#contentPost article:not(blockquote) { margin-left: 0 !important; }",
+				);
+			}
+			if (spacingRemovedRef.current.right) {
+				// 🔍 오른쪽 공백: padding과 margin 모두 제거 + body 포함
+				rules.push(
+					"body { padding-right: 0 !important; margin-right: 0 !important; }",
+				);
+				rules.push(
+					"html body { padding-right: 0 !important; margin-right: 0 !important; }",
+				);
+				rules.push(
+					".transflow-spacing-parent { padding-right: 0 !important; margin-right: 0 !important; }",
+				);
+				rules.push(
+					"section.transflow-spacing-parent { padding-right: 0 !important; margin-right: 0 !important; }",
+				);
+				rules.push(
+					"div.transflow-spacing-parent { padding-right: 0 !important; margin-right: 0 !important; }",
+				);
+				rules.push(
+					"body section.transflow-spacing-parent { padding-right: 0 !important; margin-right: 0 !important; }",
+				);
+				rules.push(
+					"body div.transflow-spacing-parent { padding-right: 0 !important; margin-right: 0 !important; }",
+				);
+				// 🔍 wrapper의 width와 max-width도 100%로 설정
+				rules.push(
+					".wrapper.transflow-spacing-parent { width: 100% !important; max-width: 100% !important; margin-right: 0 !important; }",
+				);
+				rules.push(
+					".transflow-spacing-parent.wrapper { width: 100% !important; max-width: 100% !important; margin-right: 0 !important; }",
+				);
+				// 🔍 선택된 요소의 width·margin 제거 (blockquote 등 내부 서식 유지)
+				rules.push(
+					"[data-transflow-id]:not(blockquote):not(ul):not(ol):not(pre):not(figure):not(table) { margin-right: 0 !important; margin-left: 0 !important; width: 100% !important; }",
+				);
+				rules.push(
+					"#contentPost article:not(blockquote) { margin-right: 0 !important; margin-left: 0 !important; width: 100% !important; }",
+				);
+			}
+		}
+
+		spacingStyle.textContent = rules.join("\n");
+		console.log("🔍 적용된 CSS 규칙:", rules);
+
+		// 🔍 계산된 스타일 기반으로 인라인 스타일 직접 적용 (CSS 규칙보다 우선순위가 높음)
+		// 이 방식은 어떤 CSS 프레임워크를 사용하든 실제 적용된 값을 기준으로 처리하므로 보편적임
+
+		// Body 처리
+		if (iframeDoc.body) {
+			const bodyComputed = iframeDoc.defaultView?.getComputedStyle(
+				iframeDoc.body,
+			);
+			if (bodyComputed) {
+				if (
+					type === "auto" ||
+					type === "top" ||
+					spacingRemovedRef.current.top
+				) {
+					const marginTop = Number.parseFloat(bodyComputed.marginTop);
+					const paddingTop = Number.parseFloat(bodyComputed.paddingTop);
+					if (marginTop > 0 || paddingTop > 0) {
+						iframeDoc.body.style.marginTop = "0";
+						iframeDoc.body.style.paddingTop = "0";
+					}
+				}
+				if (
+					type === "auto" ||
+					type === "bottom" ||
+					spacingRemovedRef.current.bottom
+				) {
+					const marginBottom = Number.parseFloat(bodyComputed.marginBottom);
+					const paddingBottom = Number.parseFloat(bodyComputed.paddingBottom);
+					if (marginBottom > 0 || paddingBottom > 0) {
+						iframeDoc.body.style.marginBottom = "0";
+						iframeDoc.body.style.paddingBottom = "0";
+					}
+				}
+				if (
+					type === "auto" ||
+					type === "left" ||
+					spacingRemovedRef.current.left
+				) {
+					const marginLeft = Number.parseFloat(bodyComputed.marginLeft);
+					const paddingLeft = Number.parseFloat(bodyComputed.paddingLeft);
+					if (marginLeft > 0 || paddingLeft > 0) {
+						iframeDoc.body.style.marginLeft = "0";
+						iframeDoc.body.style.paddingLeft = "0";
+					}
+				}
+				if (
+					type === "auto" ||
+					type === "right" ||
+					spacingRemovedRef.current.right
+				) {
+					const marginRight = Number.parseFloat(bodyComputed.marginRight);
+					const paddingRight = Number.parseFloat(bodyComputed.paddingRight);
+					if (marginRight > 0 || paddingRight > 0) {
+						iframeDoc.body.style.marginRight = "0";
+						iframeDoc.body.style.paddingRight = "0";
+					}
+				}
+			}
+		}
+
+		// 부모 요소들 처리 (계산된 스타일 기반)
+		parentElementsList.forEach((parent) => {
+			const computed = iframeDoc.defaultView?.getComputedStyle(parent);
+			if (!computed) return;
+
+			// 실제 공백 값 확인
+			const marginTop = Number.parseFloat(computed.marginTop);
+			const marginBottom = Number.parseFloat(computed.marginBottom);
+			const marginLeft = Number.parseFloat(computed.marginLeft);
+			const marginRight = Number.parseFloat(computed.marginRight);
+			const paddingTop = Number.parseFloat(computed.paddingTop);
+			const paddingBottom = Number.parseFloat(computed.paddingBottom);
+			const paddingLeft = Number.parseFloat(computed.paddingLeft);
+			const paddingRight = Number.parseFloat(computed.paddingRight);
+
+			// 실제 공백이 있을 때만 제거 (인라인 스타일로 강제 적용)
+			if (type === "auto" || type === "top" || spacingRemovedRef.current.top) {
+				if (marginTop > 0 || paddingTop > 0) {
+					parent.style.marginTop = "0";
+					parent.style.paddingTop = "0";
+				}
+			}
+			if (
+				type === "auto" ||
+				type === "bottom" ||
+				spacingRemovedRef.current.bottom
+			) {
+				if (marginBottom > 0 || paddingBottom > 0) {
+					parent.style.marginBottom = "0";
+					parent.style.paddingBottom = "0";
+				}
+			}
+			if (
+				type === "auto" ||
+				type === "left" ||
+				spacingRemovedRef.current.left
+			) {
+				if (marginLeft > 0 || paddingLeft > 0) {
+					parent.style.marginLeft = "0";
+					parent.style.paddingLeft = "0";
+				}
+			}
+			if (
+				type === "auto" ||
+				type === "right" ||
+				spacingRemovedRef.current.right
+			) {
+				if (marginRight > 0 || paddingRight > 0) {
+					parent.style.marginRight = "0";
+					parent.style.paddingRight = "0";
+				}
+			}
+
+			// Width 제한 제거 (컨테이너로 보이거나 width가 제한되어 있으면)
+			const width = computed.width;
+			const maxWidth = computed.maxWidth;
+			const isContainer = isLikelyContainer(parent);
+
+			// 컨테이너로 보이거나 width가 100%가 아니거나 max-width가 설정되어 있으면 100%로 설정
+			if (
+				isContainer ||
+				(width !== "100%" &&
+					width !== "auto" &&
+					maxWidth !== "none" &&
+					maxWidth !== "100%")
+			) {
+				parent.style.width = "100%";
+				if (maxWidth !== "none" && maxWidth !== "100%") {
+					parent.style.maxWidth = "100%";
+				}
+			}
+
+			// margin: auto로 인한 중앙 정렬 제거
+			if (computed.marginLeft === "auto" || computed.marginRight === "auto") {
+				parent.style.marginLeft = "0";
+				parent.style.marginRight = "0";
+			}
+		});
+
+		// 선택된 요소 자체 처리 (blockquote, ul, ol 등 내부 서식 요소는 제외)
+		allSelectedElements.forEach((selectedEl) => {
+			const el = selectedEl as HTMLElement;
+			if (CONTENT_PRESERVE_TAGS.has(el.tagName)) return;
+
+			const computed = iframeDoc.defaultView?.getComputedStyle(el);
+			if (!computed) return;
+
+			// 선택된 요소의 margin과 width 처리
+			if (
+				type === "auto" ||
+				type === "left" ||
+				type === "right" ||
+				spacingRemovedRef.current.left ||
+				spacingRemovedRef.current.right
+			) {
+				const marginLeft = Number.parseFloat(computed.marginLeft);
+				const marginRight = Number.parseFloat(computed.marginRight);
+				const width = computed.width;
+
+				if (marginLeft > 0 || marginLeft < 0) {
+					el.style.marginLeft = "0";
+				}
+				if (marginRight > 0 || marginRight < 0) {
+					el.style.marginRight = "0";
+				}
+
+				// width가 100%가 아니면 100%로 설정
+				if (width !== "100%" && width !== "auto") {
+					el.style.width = "100%";
+				}
+			}
+
+			// margin: auto 제거
+			if (computed.marginLeft === "auto" || computed.marginRight === "auto") {
+				el.style.marginLeft = "0";
+				el.style.marginRight = "0";
+			}
+		});
+
+		// ⭐ margin:auto + max-width로 인한 왼쪽 공백 제거 (수동 붙여넣기 시 entry-header, entry-content 등)
+		if (type === "auto") {
+			const skipTags = new Set([
+				"SCRIPT",
+				"STYLE",
+				"NOSCRIPT",
+				"HTML",
+				"HEAD",
+				"BODY",
+				...CONTENT_PRESERVE_TAGS,
+			]);
+			const layoutElements = iframeDoc.querySelectorAll(
+				"header, div, section, article, main, aside, footer",
+			);
+			layoutElements.forEach((el) => {
+				if (skipTags.has(el.tagName)) return;
+				const htmlEl = el as HTMLElement;
+				const computed = iframeDoc.defaultView?.getComputedStyle(htmlEl);
+				if (!computed) return;
+				const ml = computed.marginLeft;
+				const mr = computed.marginRight;
+				const mw = computed.maxWidth;
+				const hasMarginAuto = ml === "auto" || mr === "auto";
+				const hasNarrowMaxWidth =
+					mw &&
+					mw !== "none" &&
+					Number.parseFloat(mw) > 0 &&
+					Number.parseFloat(mw) < 2000;
+				if (hasMarginAuto) {
+					htmlEl.style.marginLeft = "0";
+					htmlEl.style.marginRight = "0";
+				}
+				if (hasNarrowMaxWidth) {
+					htmlEl.style.maxWidth = "100%";
+					htmlEl.style.width = "100%";
+				}
+			});
+		}
+
+		// 🔍 디버깅: 버튼 클릭 후 HTML 및 스타일 정보
+		setTimeout(() => {
+			const afterHtml = iframeDoc.documentElement.outerHTML;
+			const afterParentElements = iframeDoc.querySelectorAll(
+				".transflow-spacing-parent",
+			);
+			const afterStyles: any[] = [];
+			afterParentElements.forEach((el, idx) => {
+				const computedStyle = iframeDoc.defaultView?.getComputedStyle(
+					el as HTMLElement,
+				);
+				afterStyles.push({
+					index: idx,
+					tag: el.tagName,
+					className: el.className,
+					marginLeft: computedStyle?.marginLeft,
+					marginRight: computedStyle?.marginRight,
+					paddingLeft: computedStyle?.paddingLeft,
+					paddingRight: computedStyle?.paddingRight,
+					width: computedStyle?.width,
+					maxWidth: computedStyle?.maxWidth,
+					// 인라인 스타일 확인
+					inlineStyle: (el as HTMLElement).style.cssText,
+				});
+			});
+			console.log("🔍 [공백 제거 후] 부모 요소 스타일:", afterStyles);
+			console.log("🔍 [공백 제거 후] HTML 길이:", afterHtml.length);
+
+			// 스타일 태그 위치 확인
+			const styleTag = iframeDoc.getElementById("transflow-spacing-remover");
+			console.log("🔍 스타일 태그 위치:", styleTag ? "존재함" : "없음");
+			if (styleTag) {
+				console.log("🔍 스타일 태그 내용:", styleTag.textContent);
+				console.log("🔍 스타일 태그 다음 형제:", styleTag.nextSibling);
+				// head의 마지막 자식인지 확인
+				const isLastChild = styleTag === iframeDoc.head.lastElementChild;
+				console.log("🔍 스타일 태그가 head의 마지막 자식인가?", isLastChild);
+			}
+		}, 100);
+
+		console.log(
+			`✅ ${type === "auto" ? "자동으로 불필요한 공간 제거" : type + " 공백 제거"} 완료`,
+		);
+
+		// HTML 업데이트
+		const updatedHtml = iframeDoc.documentElement.outerHTML;
+
+		// ⭐ 공백 제거 후 브라우저 undo history 초기화 (텍스트 편집 undo와 분리)
+		try {
+			// 공백 제거가 완료된 후 iframe을 다시 write하여 브라우저 undo history 초기화
+			iframeDoc.open();
+			iframeDoc.write(updatedHtml);
+			iframeDoc.close();
+			console.log("🔄 브라우저 undo history 초기화 완료 (공백 제거 후)");
+
+			// contentEditable 상태 복원 (텍스트 편집 모드인 경우)
+			if (mode === "text") {
+				setTimeout(() => {
+					const editableElements = iframeDoc.querySelectorAll(
+						"p, h1, h2, h3, h4, h5, h6, span, div, li, ul, ol, blockquote, pre, code, table, tr, td, th, label, a, button, article, section, header, footer, main, aside",
+					);
+					editableElements.forEach((el) => {
+						if (
+							el.tagName &&
+							!["SCRIPT", "STYLE", "NOSCRIPT"].includes(el.tagName)
+						) {
+							(el as HTMLElement).contentEditable = "true";
+							(el as HTMLElement).style.cursor = "text";
+						}
+					});
+				}, 0);
+			}
+		} catch (e) {
+			console.warn("⚠️ 브라우저 undo history 초기화 실패:", e);
+		}
+
+		// 변경 후 undo stack에 저장 (변경 전 상태는 이미 저장됨)
+		currentHtmlRef.current = updatedHtml;
+		// ⭐ 공백 제거 undo stack도 업데이트
+		spacingCurrentHtmlRef.current = updatedHtml;
+		onHtmlChange(updatedHtml);
+	};
+
+	// 불필요한 그리드 제거 (2열 이상 그리드인데 자식이 1개뿐인 경우 → 1열로 변환)
+	// 소스(style/class) + computed style 모두 검사하여 viewport/브라우저 영향 최소화
+	const removeUnnecessaryGrids = () => {
+		if (!iframeRef.current) return;
+		const iframe = iframeRef.current;
+		const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
+		if (!iframeDoc || !iframeDoc.body) return;
+
+		const currentHtml = iframeDoc.documentElement.outerHTML;
+		if (
+			spacingCurrentHtmlRef.current &&
+			spacingCurrentHtmlRef.current !== currentHtml
+		) {
+			spacingUndoStackRef.current.push(spacingCurrentHtmlRef.current);
+			spacingRedoStackRef.current = [];
+		}
+
+		const countGridColumns = (gtc: string): number => {
+			if (!gtc || gtc === "none") return 0;
+			const repeatMatch = gtc.match(/repeat\s*\(\s*(\d+)/);
+			if (repeatMatch) return Number.parseInt(repeatMatch[1], 10);
+			const parts = gtc.split(/[\s,]+/).filter(Boolean);
+			return parts.length >= 2 ? parts.length : 0;
+		};
+
+		const hasMultiColFromSource = (el: HTMLElement): number => {
+			const styleVal =
+				el.style.gridTemplateColumns || el.getAttribute("style") || "";
+			const styleCols = countGridColumns(styleVal);
+			if (styleCols >= 2) return styleCols;
+			const cls = (el.className || "").toString();
+			const gridColsMatch = cls.match(/(?:sm|md|lg|xl|2xl)?:?grid-cols-(\d+)/);
+			if (gridColsMatch) {
+				const n = Number.parseInt(gridColsMatch[1], 10);
+				if (n >= 2) return n;
+			}
+			return 0;
+		};
+
+		let fixedCount = 0;
+		const walk = (root: Element) => {
+			const children = Array.from(root.children);
+			for (const el of children) {
+				const htmlEl = el as HTMLElement;
+				if (
+					["SCRIPT", "STYLE", "NOSCRIPT", "HTML", "HEAD", "BODY"].includes(
+						htmlEl.tagName,
+					)
+				)
+					continue;
+				const childCount = htmlEl.children.length;
+				let cols = 0;
+				const sourceCols = hasMultiColFromSource(htmlEl);
+				if (sourceCols >= 2) {
+					cols = sourceCols;
+				} else {
+					const computed = iframeDoc.defaultView?.getComputedStyle(htmlEl);
+					if (computed?.display === "grid")
+						cols = countGridColumns(computed.gridTemplateColumns);
+				}
+				if (cols >= 2 && childCount < cols) {
+					htmlEl.style.setProperty("grid-template-columns", "1fr", "important");
+					fixedCount++;
+				}
+				walk(htmlEl);
+			}
+		};
+		walk(iframeDoc.body);
+
+		const updatedHtml = iframeDoc.documentElement.outerHTML;
+		spacingCurrentHtmlRef.current = updatedHtml;
+		currentHtmlRef.current = updatedHtml;
+		onHtmlChange(updatedHtml);
+		console.log("✅ 불필요한 그리드 제거 완료:", fixedCount, "개 수정");
+	};
+
+	// HTML 파일 다운로드 함수
+	const downloadHtml = () => {
+		if (!iframeRef.current) return;
+
+		const iframe = iframeRef.current;
+		const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
+		if (!iframeDoc) return;
+
+		// iframe 안의 HTML만 가져오기
+		const htmlContent = iframeDoc.documentElement.outerHTML;
+
+		// Blob 생성 및 다운로드
+		const blob = new Blob([htmlContent], { type: "text/html;charset=utf-8" });
+		const url = URL.createObjectURL(blob);
+		const a = document.createElement("a");
+		a.href = url;
+		a.download = `step3-html-${Date.now()}.html`;
+		document.body.appendChild(a);
+		a.click();
+		document.body.removeChild(a);
+		URL.revokeObjectURL(url);
+
+		console.log("💾 HTML 파일 다운로드 완료");
+	};
+
+	return (
+		<div
+			style={{
+				display: "flex",
+				flexDirection: "column",
+				height: "100%",
+			}}
+		>
+			{/* 툴바 */}
+			<div
+				style={{
+					padding: "8px 16px",
+					borderBottom: "1px solid #C0C0C0",
+					backgroundColor: "#FFFFFF",
+					display: "flex",
+					justifyContent: "space-between",
+					alignItems: "center",
+					gap: "8px",
+				}}
+			>
+				<div style={{ display: "flex", gap: "8px", alignItems: "center" }}>
+					<div
+						style={{
+							fontSize: "13px",
+							fontWeight: 600,
+							color: "#000000",
+							fontFamily: "system-ui, Pretendard, sans-serif",
+							marginRight: "16px",
+						}}
+					>
+						번역 전 편집
+					</div>
+					<div style={{ display: "flex", gap: "4px" }}>
+						<Button
+							variant={mode === "text" ? "primary" : "secondary"}
+							onClick={() => setMode("text")}
+							style={{ fontSize: "12px", padding: "4px 8px" }}
+						>
+							텍스트 편집
+						</Button>
+						<Button
+							variant={mode === "component" ? "primary" : "secondary"}
+							onClick={() => setMode("component")}
+							style={{ fontSize: "12px", padding: "4px 8px" }}
+						>
+							컴포넌트 편집
+						</Button>
+					</div>
+					<div
+						style={{
+							borderLeft: "1px solid #C0C0C0",
+							height: "24px",
+							margin: "0 4px",
+						}}
+					/>
+					{mode === "text" && (
+						<>
+							<button
+								type="button"
+								onClick={() => {
+									const iframeDoc =
+										iframeRef.current?.contentDocument ||
+										iframeRef.current?.contentWindow?.document;
+									if (iframeDoc && iframeDoc.body) iframeDoc.body.focus();
+									iframeDoc?.execCommand("bold", false);
+									if (iframeDoc) syncIframeHtml(iframeDoc);
+								}}
+								style={{
+									padding: "4px 8px",
+									fontSize: "11px",
+									fontWeight: "bold",
+									border: "1px solid #A9A9A9",
+									borderRadius: "3px",
+									backgroundColor: "#FFFFFF",
+									color: "#000000",
+									cursor: "pointer",
+								}}
+								title="굵게 (Ctrl+B)"
+							>
+								B
+							</button>
+							<button
+								type="button"
+								onClick={() => {
+									const iframeDoc =
+										iframeRef.current?.contentDocument ||
+										iframeRef.current?.contentWindow?.document;
+									if (iframeDoc && iframeDoc.body) iframeDoc.body.focus();
+									iframeDoc?.execCommand("italic", false);
+									if (iframeDoc) syncIframeHtml(iframeDoc);
+								}}
+								style={{
+									padding: "4px 8px",
+									fontSize: "11px",
+									fontStyle: "italic",
+									border: "1px solid #A9A9A9",
+									borderRadius: "3px",
+									backgroundColor: "#FFFFFF",
+									color: "#000000",
+									cursor: "pointer",
+								}}
+								title="기울임 (Ctrl+I)"
+							>
+								I
+							</button>
+							<button
+								type="button"
+								onClick={() => {
+									const iframeDoc =
+										iframeRef.current?.contentDocument ||
+										iframeRef.current?.contentWindow?.document;
+									if (iframeDoc && iframeDoc.body) iframeDoc.body.focus();
+									iframeDoc?.execCommand("underline", false);
+									if (iframeDoc) syncIframeHtml(iframeDoc);
+								}}
+								style={{
+									padding: "4px 8px",
+									fontSize: "11px",
+									textDecoration: "underline",
+									border: "1px solid #A9A9A9",
+									borderRadius: "3px",
+									backgroundColor: "#FFFFFF",
+									color: "#000000",
+									cursor: "pointer",
+								}}
+								title="밑줄 (Ctrl+U)"
+							>
+								U
+							</button>
+							<button
+								type="button"
+								onClick={() => {
+									const iframeDoc =
+										iframeRef.current?.contentDocument ||
+										iframeRef.current?.contentWindow?.document;
+									if (iframeDoc && iframeDoc.body) iframeDoc.body.focus();
+									iframeDoc?.execCommand("strikeThrough", false);
+									if (iframeDoc) syncIframeHtml(iframeDoc);
+								}}
+								style={{
+									padding: "4px 8px",
+									fontSize: "11px",
+									textDecoration: "line-through",
+									border: "1px solid #A9A9A9",
+									borderRadius: "3px",
+									backgroundColor: "#FFFFFF",
+									color: "#000000",
+									cursor: "pointer",
+								}}
+								title="취소선"
+							>
+								S
+							</button>
+
+							<button
+								type="button"
+								onClick={() => {
+									const iframeDoc =
+										iframeRef.current?.contentDocument ||
+										iframeRef.current?.contentWindow?.document;
+									if (!iframeDoc) return;
+									if (iframeDoc.body) {
+										iframeDoc.body.setAttribute("tabindex", "-1");
+										iframeDoc.body.focus();
+									}
+									iframeDoc.execCommand("removeFormat", false);
+									// removeFormat이 border-style:solid 만 남기는 문제 수정
+									setTimeout(() => {
+										fixDanglingBorderStyle(iframeDoc);
+										syncIframeHtml(iframeDoc);
+									}, 0);
+								}}
+								style={{
+									padding: "4px 8px",
+									fontSize: "11px",
+									fontWeight: 600,
+									border: "1px solid #A9A9A9",
+									borderRadius: "3px",
+									backgroundColor: "#FFFFFF",
+									color: "#000000",
+									cursor: "pointer",
+								}}
+								title="서식 지우기 (선택 영역)"
+							>
+								서식 지우기
+							</button>
+
+							<div
+								style={{
+									width: "1px",
+									height: "20px",
+									backgroundColor: "#C0C0C0",
+									margin: "0 4px",
+								}}
+							/>
+
+							<select
+								onChange={(e) => {
+									const iframeDoc =
+										iframeRef.current?.contentDocument ||
+										iframeRef.current?.contentWindow?.document;
+									if (iframeDoc && e.target.value) {
+										const fontSize = e.target.value;
+										const selection = iframeDoc.getSelection();
+
+										if (
+											selection &&
+											selection.rangeCount > 0 &&
+											!selection.getRangeAt(0).collapsed
+										) {
+											const range = selection.getRangeAt(0);
+											const selectedText = range.toString();
+											const spanHtml = `<span style="font-size: ${fontSize}pt;">${selectedText}</span>`;
+
+											try {
+												iframeDoc.execCommand("insertHTML", false, spanHtml);
+											} catch (err) {
+												range.deleteContents();
+												const tempDiv = iframeDoc.createElement("div");
+												tempDiv.innerHTML = spanHtml;
+												const fragment = iframeDoc.createDocumentFragment();
+												while (tempDiv.firstChild) {
+													fragment.appendChild(tempDiv.firstChild);
+												}
+												range.insertNode(fragment);
+												range.setStartAfter(
+													fragment.lastChild || range.startContainer,
+												);
+												range.collapse(false);
+												selection.removeAllRanges();
+												selection.addRange(range);
+											}
+											syncIframeHtml(iframeDoc);
+										} else {
+											iframeDoc.execCommand("fontSize", false, "3");
+											setTimeout(() => {
+												const fontSizeElements =
+													iframeDoc.querySelectorAll('font[size="3"]');
+												if (fontSizeElements.length > 0) {
+													const lastElement = fontSizeElements[
+														fontSizeElements.length - 1
+													] as HTMLElement;
+													lastElement.style.fontSize = `${fontSize}pt`;
+													lastElement.removeAttribute("size");
+
+													const span = iframeDoc.createElement("span");
+													span.style.fontSize = `${fontSize}pt`;
+													span.innerHTML = lastElement.innerHTML;
+
+													if (lastElement.parentNode) {
+														lastElement.parentNode.replaceChild(
+															span,
+															lastElement,
+														);
+													}
+												}
+												syncIframeHtml(iframeDoc);
+											}, 0);
+										}
+									}
+									e.target.value = "";
+								}}
+								style={{
+									fontSize: "11px",
+									padding: "4px 8px",
+									border: "1px solid #A9A9A9",
+									borderRadius: "3px",
+									backgroundColor: "#FFFFFF",
+									color: "#000000",
+									cursor: "pointer",
+								}}
+								title="글자 크기 (pt)"
+							>
+								<option value="">크기</option>
+								<option value="8">8pt</option>
+								<option value="9">9pt</option>
+								<option value="10">10pt</option>
+								<option value="11">11pt</option>
+								<option value="12">12pt</option>
+								<option value="14">14pt</option>
+								<option value="16">16pt</option>
+								<option value="18">18pt</option>
+								<option value="20">20pt</option>
+								<option value="24">24pt</option>
+								<option value="28">28pt</option>
+								<option value="32">32pt</option>
+								<option value="36">36pt</option>
+								<option value="48">48pt</option>
+								<option value="72">72pt</option>
+							</select>
+
+							<select
+								onChange={(e) => {
+									const iframeDoc =
+										iframeRef.current?.contentDocument ||
+										iframeRef.current?.contentWindow?.document;
+									if (iframeDoc && e.target.value) {
+										const lineHeight = e.target.value;
+										const selection = iframeDoc.getSelection();
+
+										if (selection && selection.rangeCount > 0) {
+											const range = selection.getRangeAt(0);
+											let blockElement: HTMLElement | null = null;
+
+											if (range.commonAncestorContainer.nodeType === 1) {
+												blockElement = (
+													range.commonAncestorContainer as HTMLElement
+												).closest(
+													"p, div, h1, h2, h3, h4, h5, h6, li, blockquote, pre",
+												);
+											} else {
+												blockElement =
+													range.commonAncestorContainer.parentElement?.closest(
+														"p, div, h1, h2, h3, h4, h5, h6, li, blockquote, pre",
+													) || null;
+											}
+
+											if (blockElement) {
+												try {
+													const blockRange = iframeDoc.createRange();
+													blockRange.selectNodeContents(blockElement);
+													selection.removeAllRanges();
+													selection.addRange(blockRange);
+
+													const originalHtml = blockElement.innerHTML;
+													const tagName = blockElement.tagName.toLowerCase();
+													const newHtml = `<${tagName} style="line-height: ${lineHeight};">${originalHtml}</${tagName}>`;
+
+													iframeDoc.execCommand("insertHTML", false, newHtml);
+												} catch (err) {
+													blockElement.style.lineHeight = lineHeight;
+												}
+											} else {
+												const div = iframeDoc.createElement("div");
+												div.style.lineHeight = lineHeight;
+												div.innerHTML = "&nbsp;";
+
+												try {
+													iframeDoc.execCommand(
+														"insertHTML",
+														false,
+														div.outerHTML,
+													);
+												} catch (err) {
+													range.insertNode(div);
+												}
+											}
+											syncIframeHtml(iframeDoc);
+										}
+									}
+									e.target.value = "";
+								}}
+								style={{
+									fontSize: "11px",
+									padding: "4px 8px",
+									border: "1px solid #A9A9A9",
+									borderRadius: "3px",
+									backgroundColor: "#FFFFFF",
+									color: "#000000",
+									cursor: "pointer",
+									marginLeft: "4px",
+								}}
+								title="줄간격"
+							>
+								<option value="">줄간격</option>
+								<option value="1.0">1.0 (단일)</option>
+								<option value="1.15">1.15</option>
+								<option value="1.5">1.5 (기본)</option>
+								<option value="1.75">1.75</option>
+								<option value="2.0">2.0 (2배)</option>
+								<option value="2.5">2.5</option>
+								<option value="3.0">3.0</option>
+							</select>
+
+							<div
+								style={{
+									position: "relative",
+									display: "inline-block",
+									width: "30px",
+									height: "26px",
+								}}
+							>
+								<input
+									type="color"
+									onChange={(e) => {
+										const iframeDoc =
+											iframeRef.current?.contentDocument ||
+											iframeRef.current?.contentWindow?.document;
+										if (iframeDoc)
+											iframeDoc.execCommand("foreColor", false, e.target.value);
+										if (iframeDoc) syncIframeHtml(iframeDoc);
+									}}
+									style={{
+										position: "absolute",
+										width: "100%",
+										height: "100%",
+										opacity: 0,
+										cursor: "pointer",
+										zIndex: 2,
+									}}
+									title="글자 색상"
+								/>
+								<button
+									style={{
+										position: "absolute",
+										width: "100%",
+										height: "100%",
+										border: "1px solid #A9A9A9",
+										borderRadius: "3px",
+										backgroundColor: "#FFFFFF",
+										display: "flex",
+										alignItems: "center",
+										justifyContent: "center",
+										cursor: "pointer",
+										padding: 0,
+										pointerEvents: "none",
+									}}
+									title="글자 색상"
+									disabled
+								>
+									<Palette size={16} color="#000000" />
+								</button>
+							</div>
+
+							<div
+								style={{
+									position: "relative",
+									display: "inline-block",
+									width: "30px",
+									height: "26px",
+									marginLeft: "4px",
+								}}
+							>
+								<input
+									type="color"
+									onChange={(e) => {
+										const iframeDoc =
+											iframeRef.current?.contentDocument ||
+											iframeRef.current?.contentWindow?.document;
+										if (iframeDoc)
+											iframeDoc.execCommand("backColor", false, e.target.value);
+										if (iframeDoc) syncIframeHtml(iframeDoc);
+									}}
+									style={{
+										position: "absolute",
+										width: "100%",
+										height: "100%",
+										opacity: 0,
+										cursor: "pointer",
+										zIndex: 2,
+									}}
+									title="배경 색상"
+								/>
+								<button
+									style={{
+										position: "absolute",
+										width: "100%",
+										height: "100%",
+										border: "1px solid #A9A9A9",
+										borderRadius: "3px",
+										backgroundColor: "#FFFFFF",
+										display: "flex",
+										alignItems: "center",
+										justifyContent: "center",
+										cursor: "pointer",
+										padding: 0,
+										pointerEvents: "none",
+									}}
+									title="배경 색상"
+									disabled
+								>
+									<Highlighter size={16} color="#000000" />
+								</button>
+							</div>
+
+							<div
+								style={{
+									width: "1px",
+									height: "20px",
+									backgroundColor: "#C0C0C0",
+									margin: "0 4px",
+								}}
+							/>
+
+							<button
+								type="button"
+								onClick={() => {
+									const iframeDoc =
+										iframeRef.current?.contentDocument ||
+										iframeRef.current?.contentWindow?.document;
+									if (!iframeDoc) return;
+									iframeDoc.execCommand("justifyLeft", false);
+									syncIframeHtml(iframeDoc);
+								}}
+								style={{
+									padding: "4px 8px",
+									fontSize: "11px",
+									border: "1px solid #A9A9A9",
+									borderRadius: "3px",
+									backgroundColor: "#FFFFFF",
+									color: "#000000",
+									cursor: "pointer",
+									display: "flex",
+									alignItems: "center",
+									justifyContent: "center",
+								}}
+								title="왼쪽 정렬"
+							>
+								<AlignLeft size={16} />
+							</button>
+							<button
+								type="button"
+								onClick={() => {
+									const iframeDoc =
+										iframeRef.current?.contentDocument ||
+										iframeRef.current?.contentWindow?.document;
+									if (!iframeDoc) return;
+									iframeDoc.execCommand("justifyCenter", false);
+									syncIframeHtml(iframeDoc);
+								}}
+								style={{
+									padding: "4px 8px",
+									fontSize: "11px",
+									border: "1px solid #A9A9A9",
+									borderRadius: "3px",
+									backgroundColor: "#FFFFFF",
+									color: "#000000",
+									cursor: "pointer",
+									display: "flex",
+									alignItems: "center",
+									justifyContent: "center",
+								}}
+								title="가운데 정렬"
+							>
+								<AlignCenter size={16} />
+							</button>
+							<button
+								type="button"
+								onClick={() => {
+									const iframeDoc =
+										iframeRef.current?.contentDocument ||
+										iframeRef.current?.contentWindow?.document;
+									if (!iframeDoc) return;
+									iframeDoc.execCommand("justifyRight", false);
+									syncIframeHtml(iframeDoc);
+								}}
+								style={{
+									padding: "4px 8px",
+									fontSize: "11px",
+									border: "1px solid #A9A9A9",
+									borderRadius: "3px",
+									backgroundColor: "#FFFFFF",
+									color: "#000000",
+									cursor: "pointer",
+									display: "flex",
+									alignItems: "center",
+									justifyContent: "center",
+								}}
+								title="오른쪽 정렬"
+							>
+								<AlignRight size={16} />
+							</button>
+
+							<button
+								type="button"
+								onClick={() => {
+									const iframeDoc =
+										iframeRef.current?.contentDocument ||
+										iframeRef.current?.contentWindow?.document;
+									if (!iframeDoc) return;
+									iframeDoc.execCommand("justifyFull", false);
+									syncIframeHtml(iframeDoc);
+								}}
+								style={{
+									padding: "4px 8px",
+									fontSize: "11px",
+									border: "1px solid #A9A9A9",
+									borderRadius: "3px",
+									backgroundColor: "#FFFFFF",
+									color: "#000000",
+									cursor: "pointer",
+									display: "flex",
+									alignItems: "center",
+									justifyContent: "center",
+								}}
+								title="양쪽 정렬"
+							>
+								<AlignJustify size={16} />
+							</button>
+
+							<div
+								style={{
+									width: "1px",
+									height: "20px",
+									backgroundColor: "#C0C0C0",
+									margin: "0 4px",
+								}}
+							/>
+
+							<button
+								type="button"
+								onClick={() => {
+									const iframeDoc =
+										iframeRef.current?.contentDocument ||
+										iframeRef.current?.contentWindow?.document;
+									if (!iframeDoc) return;
+									iframeDoc.execCommand("insertUnorderedList", false);
+									syncIframeHtml(iframeDoc);
+								}}
+								style={{
+									padding: "4px 8px",
+									fontSize: "11px",
+									border: "1px solid #A9A9A9",
+									borderRadius: "3px",
+									backgroundColor: "#FFFFFF",
+									color: "#000000",
+									cursor: "pointer",
+									display: "flex",
+									alignItems: "center",
+									justifyContent: "center",
+								}}
+								title="글머리 기호 목록"
+							>
+								<List size={16} />
+							</button>
+							<button
+								type="button"
+								onClick={() => {
+									const iframeDoc =
+										iframeRef.current?.contentDocument ||
+										iframeRef.current?.contentWindow?.document;
+									if (!iframeDoc) return;
+									iframeDoc.execCommand("insertOrderedList", false);
+									syncIframeHtml(iframeDoc);
+								}}
+								style={{
+									padding: "4px 8px",
+									fontSize: "11px",
+									border: "1px solid #A9A9A9",
+									borderRadius: "3px",
+									backgroundColor: "#FFFFFF",
+									color: "#000000",
+									cursor: "pointer",
+									display: "flex",
+									alignItems: "center",
+									justifyContent: "center",
+								}}
+								title="번호 매기기 목록"
+							>
+								<ListOrdered size={16} />
+							</button>
+
+							<button
+								type="button"
+								onClick={() => {
+									const iframeDoc =
+										iframeRef.current?.contentDocument ||
+										iframeRef.current?.contentWindow?.document;
+									if (!iframeDoc) return;
+									const url = prompt("링크 URL을 입력하세요:");
+									if (url) iframeDoc.execCommand("createLink", false, url);
+									syncIframeHtml(iframeDoc);
+								}}
+								style={{
+									padding: "4px 8px",
+									fontSize: "11px",
+									border: "1px solid #A9A9A9",
+									borderRadius: "3px",
+									backgroundColor: "#FFFFFF",
+									color: "#000000",
+									cursor: "pointer",
+									display: "flex",
+									alignItems: "center",
+									justifyContent: "center",
+								}}
+								title="링크 삽입"
+							>
+								<Link2 size={16} />
+							</button>
+
+							<div
+								style={{
+									width: "1px",
+									height: "20px",
+									backgroundColor: "#C0C0C0",
+									margin: "0 4px",
+								}}
+							/>
+
+							<div style={{ position: "relative", display: "inline-block" }}>
+								<input
+									type="file"
+									accept="image/*"
+									onChange={(e) => {
+										const file = e.target.files?.[0];
+										if (!file) return;
+										const reader = new FileReader();
+										reader.onload = (event) => {
+											const imageUrl = event.target?.result as string;
+											const iframeDoc =
+												iframeRef.current?.contentDocument ||
+												iframeRef.current?.contentWindow?.document;
+											if (iframeDoc && imageUrl) {
+												try {
+													iframeDoc.execCommand(
+														"insertHTML",
+														false,
+														`<img src="${imageUrl}" alt="" style="max-width: 100%; height: auto;" />`,
+													);
+												} catch (err) {
+													const selection = iframeDoc.getSelection();
+													if (selection && selection.rangeCount > 0) {
+														const range = selection.getRangeAt(0);
+														const img = iframeDoc.createElement("img");
+														img.src = imageUrl;
+														img.alt = "";
+														img.style.maxWidth = "100%";
+														img.style.height = "auto";
+														range.insertNode(img);
+													}
+												}
+												syncIframeHtml(iframeDoc);
+											}
+										};
+										reader.readAsDataURL(file);
+										e.target.value = "";
+									}}
+									style={{
+										position: "absolute",
+										width: "100%",
+										height: "100%",
+										opacity: 0,
+										cursor: "pointer",
+										zIndex: 2,
+									}}
+									title="이미지 삽입"
+								/>
+								<button
+									type="button"
+									style={{
+										padding: "4px 8px",
+										fontSize: "11px",
+										border: "1px solid #A9A9A9",
+										borderRadius: "3px",
+										backgroundColor: "#FFFFFF",
+										color: "#000000",
+										cursor: "pointer",
+										display: "flex",
+										alignItems: "center",
+										justifyContent: "center",
+										pointerEvents: "none",
+									}}
+									title="이미지 삽입"
+									disabled
+								>
+									<Image size={16} />
+								</button>
+							</div>
+
+							<button
+								type="button"
+								onClick={() => {
+									const iframeDoc =
+										iframeRef.current?.contentDocument ||
+										iframeRef.current?.contentWindow?.document;
+									if (!iframeDoc) return;
+									try {
+										iframeDoc.execCommand(
+											"insertHTML",
+											false,
+											'<pre style="background-color: #f4f4f4; padding: 10px; border-radius: 4px; overflow-x: auto;"><code></code></pre>',
+										);
+									} catch (err) {
+										iframeDoc.execCommand("formatBlock", false, "pre");
+										const selection = iframeDoc.getSelection();
+										if (selection && selection.rangeCount > 0) {
+											const range = selection.getRangeAt(0);
+											const preElement =
+												range.commonAncestorContainer.nodeType === 1
+													? (range.commonAncestorContainer as HTMLElement)
+													: (range.commonAncestorContainer
+															.parentElement as HTMLElement);
+											if (preElement && preElement.tagName === "PRE") {
+												preElement.style.backgroundColor = "#f4f4f4";
+												preElement.style.padding = "10px";
+												preElement.style.borderRadius = "4px";
+												preElement.style.overflowX = "auto";
+											}
+										}
+									}
+									syncIframeHtml(iframeDoc);
+								}}
+								style={{
+									padding: "4px 8px",
+									fontSize: "11px",
+									border: "1px solid #A9A9A9",
+									borderRadius: "3px",
+									backgroundColor: "#FFFFFF",
+									color: "#000000",
+									cursor: "pointer",
+									display: "flex",
+									alignItems: "center",
+									justifyContent: "center",
+								}}
+								title="코드 블록"
+							>
+								<Code size={16} />
+							</button>
+
+							<div
+								style={{ position: "relative", display: "inline-block" }}
+								ref={step3MoreMenuRef}
+								data-more-menu
+							>
+								<button
+									type="button"
+									onClick={() => setStep3ShowMoreMenu(!step3ShowMoreMenu)}
+									style={{
+										padding: "4px 8px",
+										fontSize: "11px",
+										border: "1px solid #A9A9A9",
+										borderRadius: "3px",
+										backgroundColor: step3ShowMoreMenu ? "#E0E0E0" : "#FFFFFF",
+										color: "#000000",
+										cursor: "pointer",
+										display: "flex",
+										alignItems: "center",
+										justifyContent: "center",
+									}}
+									title="더보기"
+								>
+									<MoreVertical size={16} />
+								</button>
+
+								{step3ShowMoreMenu && (
+									<div
+										style={{
+											position: "absolute",
+											top: "100%",
+											right: 0,
+											marginTop: "4px",
+											backgroundColor: "#FFFFFF",
+											border: "1px solid #A9A9A9",
+											borderRadius: "4px",
+											boxShadow: "0 2px 8px rgba(0,0,0,0.15)",
+											zIndex: 1000,
+											display: "flex",
+											flexDirection: "row",
+											gap: "4px",
+											padding: "4px",
+										}}
+										onClick={(e) => e.stopPropagation()}
+										data-more-menu
+									>
+										<button
+											type="button"
+											onClick={() => {
+												const iframeDoc =
+													iframeRef.current?.contentDocument ||
+													iframeRef.current?.contentWindow?.document;
+												if (iframeDoc)
+													iframeDoc.execCommand(
+														"formatBlock",
+														false,
+														"blockquote",
+													);
+												if (iframeDoc) syncIframeHtml(iframeDoc);
+												setStep3ShowMoreMenu(false);
+											}}
+											style={{
+												padding: "4px 8px",
+												fontSize: "11px",
+												border: "1px solid #A9A9A9",
+												borderRadius: "3px",
+												backgroundColor: "#FFFFFF",
+												color: "#000000",
+												cursor: "pointer",
+												display: "flex",
+												alignItems: "center",
+												justifyContent: "center",
+											}}
+											title="인용문"
+										>
+											<Quote size={16} />
+										</button>
+
+										<button
+											type="button"
+											onClick={() => {
+												const iframeDoc =
+													iframeRef.current?.contentDocument ||
+													iframeRef.current?.contentWindow?.document;
+												if (iframeDoc)
+													iframeDoc.execCommand("insertHorizontalRule", false);
+												if (iframeDoc) syncIframeHtml(iframeDoc);
+												setStep3ShowMoreMenu(false);
+											}}
+											style={{
+												padding: "4px 8px",
+												fontSize: "11px",
+												border: "1px solid #A9A9A9",
+												borderRadius: "3px",
+												backgroundColor: "#FFFFFF",
+												color: "#000000",
+												cursor: "pointer",
+												display: "flex",
+												alignItems: "center",
+												justifyContent: "center",
+											}}
+											title="구분선"
+										>
+											<Minus size={16} />
+										</button>
+
+										<button
+											type="button"
+											onClick={() => {
+												const iframeDoc =
+													iframeRef.current?.contentDocument ||
+													iframeRef.current?.contentWindow?.document;
+												if (!iframeDoc) return;
+
+												const rows = prompt(
+													"행 수를 입력하세요 (기본값: 3):",
+													"3",
+												);
+												const cols = prompt(
+													"열 수를 입력하세요 (기본값: 3):",
+													"3",
+												);
+												const rowCount = Number.parseInt(rows || "3", 10);
+												const colCount = Number.parseInt(cols || "3", 10);
+
+												if (rowCount > 0 && colCount > 0) {
+													let tableHtml =
+														'<table border="1" style="border-collapse: collapse; width: 100%;">';
+													for (let i = 0; i < rowCount; i++) {
+														tableHtml += "<tr>";
+														for (let j = 0; j < colCount; j++) {
+															tableHtml +=
+																'<td style="padding: 8px; border: 1px solid #000;">&nbsp;</td>';
+														}
+														tableHtml += "</tr>";
+													}
+													tableHtml += "</table>";
+
+													try {
+														iframeDoc.execCommand(
+															"insertHTML",
+															false,
+															tableHtml,
+														);
+													} catch (err) {
+														const selection = iframeDoc.getSelection();
+														if (selection && selection.rangeCount > 0) {
+															const range = selection.getRangeAt(0);
+															const tempDiv = iframeDoc.createElement("div");
+															tempDiv.innerHTML = tableHtml;
+															const fragment =
+																iframeDoc.createDocumentFragment();
+															while (tempDiv.firstChild) {
+																fragment.appendChild(tempDiv.firstChild);
+															}
+															range.insertNode(fragment);
+														}
+													}
+													syncIframeHtml(iframeDoc);
+												}
+												setStep3ShowMoreMenu(false);
+											}}
+											style={{
+												padding: "4px 8px",
+												fontSize: "11px",
+												border: "1px solid #A9A9A9",
+												borderRadius: "3px",
+												backgroundColor: "#FFFFFF",
+												color: "#000000",
+												cursor: "pointer",
+												display: "flex",
+												alignItems: "center",
+												justifyContent: "center",
+											}}
+											title="표"
+										>
+											<Table size={16} />
+										</button>
+
+										<button
+											type="button"
+											onClick={() => {
+												const iframeDoc =
+													iframeRef.current?.contentDocument ||
+													iframeRef.current?.contentWindow?.document;
+												if (!iframeDoc) return;
+
+												const selection = iframeDoc.getSelection();
+												if (
+													selection &&
+													selection.rangeCount > 0 &&
+													!selection.getRangeAt(0).collapsed
+												) {
+													const range = selection.getRangeAt(0);
+													const selectedText = range.toString();
+													try {
+														iframeDoc.execCommand(
+															"insertHTML",
+															false,
+															`<sup>${selectedText}</sup>`,
+														);
+													} catch (err) {
+														const sup = iframeDoc.createElement("sup");
+														sup.textContent = selectedText;
+														range.deleteContents();
+														range.insertNode(sup);
+													}
+												} else {
+													try {
+														iframeDoc.execCommand(
+															"insertHTML",
+															false,
+															"<sup></sup>",
+														);
+													} catch (err) {
+														const sel = iframeDoc.getSelection();
+														if (sel && sel.rangeCount > 0) {
+															const range = sel.getRangeAt(0);
+															const sup = iframeDoc.createElement("sup");
+															sup.innerHTML = "&nbsp;";
+															range.insertNode(sup);
+														}
+													}
+												}
+												syncIframeHtml(iframeDoc);
+												setStep3ShowMoreMenu(false);
+											}}
+											style={{
+												padding: "4px 8px",
+												fontSize: "11px",
+												border: "1px solid #A9A9A9",
+												borderRadius: "3px",
+												backgroundColor: "#FFFFFF",
+												color: "#000000",
+												cursor: "pointer",
+												display: "flex",
+												alignItems: "center",
+												justifyContent: "center",
+											}}
+											title="위 첨자"
+										>
+											<Superscript size={16} />
+										</button>
+
+										<button
+											type="button"
+											onClick={() => {
+												const iframeDoc =
+													iframeRef.current?.contentDocument ||
+													iframeRef.current?.contentWindow?.document;
+												if (!iframeDoc) return;
+
+												const selection = iframeDoc.getSelection();
+												if (
+													selection &&
+													selection.rangeCount > 0 &&
+													!selection.getRangeAt(0).collapsed
+												) {
+													const range = selection.getRangeAt(0);
+													const selectedText = range.toString();
+													try {
+														iframeDoc.execCommand(
+															"insertHTML",
+															false,
+															`<sub>${selectedText}</sub>`,
+														);
+													} catch (err) {
+														const sub = iframeDoc.createElement("sub");
+														sub.textContent = selectedText;
+														range.deleteContents();
+														range.insertNode(sub);
+													}
+												} else {
+													try {
+														iframeDoc.execCommand(
+															"insertHTML",
+															false,
+															"<sub></sub>",
+														);
+													} catch (err) {
+														const sel = iframeDoc.getSelection();
+														if (sel && sel.rangeCount > 0) {
+															const range = sel.getRangeAt(0);
+															const sub = iframeDoc.createElement("sub");
+															sub.innerHTML = "&nbsp;";
+															range.insertNode(sub);
+														}
+													}
+												}
+												syncIframeHtml(iframeDoc);
+												setStep3ShowMoreMenu(false);
+											}}
+											style={{
+												padding: "4px 8px",
+												fontSize: "11px",
+												border: "1px solid #A9A9A9",
+												borderRadius: "3px",
+												backgroundColor: "#FFFFFF",
+												color: "#000000",
+												cursor: "pointer",
+												display: "flex",
+												alignItems: "center",
+												justifyContent: "center",
+											}}
+											title="아래 첨자"
+										>
+											<Subscript size={16} />
+										</button>
+									</div>
+								)}
+							</div>
+							<div
+								style={{
+									width: "1px",
+									height: "20px",
+									backgroundColor: "#C0C0C0",
+									margin: "0 4px",
+								}}
+							/>
+						</>
+					)}
+					<div style={{ display: "flex", gap: "4px" }}>
+						<Button
+							variant="secondary"
+							onClick={() => {
+								const iframe = iframeRef.current;
+								const iframeDoc =
+									iframe?.contentDocument || iframe?.contentWindow?.document;
+								if (!iframeDoc) return;
+
+								// ⭐ 모드에 따라 다른 undo 동작
+								if (mode === "text") {
+									iframeDoc.execCommand("undo", false);
+									const updatedHtml = iframeDoc.documentElement.outerHTML;
+									currentHtmlRef.current = updatedHtml;
+									onHtmlChange(updatedHtml);
+									console.log("↶ 텍스트 편집 실행 취소 완료 (browser undo)");
+								} else if (mode === "spacing") {
+									if (spacingUndoStackRef.current.length > 0) {
+										// 공백 제거 undo: 전체 공백 제거 실행 취소
+										// 현재 상태를 redo stack에 저장
+										const currentHtml = iframeDoc.documentElement.outerHTML;
+										spacingRedoStackRef.current.push(currentHtml);
+
+										// undo stack에서 이전 상태 가져오기
+										const previousHtml =
+											spacingUndoStackRef.current.pop() || "";
+
+										// iframe에 이전 HTML 적용
+										iframeDoc.open();
+										iframeDoc.write(previousHtml);
+										iframeDoc.close();
+
+										// currentHtmlRef 업데이트
+										currentHtmlRef.current = previousHtml;
+										spacingCurrentHtmlRef.current = previousHtml;
+										onHtmlChange(previousHtml);
+
+										// 공백 제거 모드 다시 초기화
+										setTimeout(() => {
+											// 공백 제거 모드 재활성화는 useEffect에서 처리됨
+										}, 0);
+
+										console.log(
+											"↶ 공백 제거 실행 취소 완료. 남은 undo:",
+											spacingUndoStackRef.current.length,
+										);
+									}
+								} else if (mode === "component") {
+									// 컴포넌트 편집 모드: 컴포넌트 편집 undo stack 사용
+									if (undoStackRef.current.length > 0) {
+										// 현재 상태를 redo stack에 저장
+										const currentHtml = iframeDoc.documentElement.outerHTML;
+										redoStackRef.current.push(currentHtml);
+
+										// undo stack에서 이전 상태 가져오기
+										const previousHtml = undoStackRef.current.pop() || "";
+
+										// iframe에 이전 HTML 적용
+										iframeDoc.open();
+										iframeDoc.write(previousHtml);
+										iframeDoc.close();
+
+										// currentHtmlRef 업데이트
+										currentHtmlRef.current = previousHtml;
+										onHtmlChange(previousHtml);
+
+										// 컴포넌트 편집 모드 다시 초기화
+										setTimeout(() => {
+											const newIframeDoc =
+												iframe?.contentDocument ||
+												iframe?.contentWindow?.document;
+											if (!newIframeDoc) return;
+
+											// contentEditable 비활성화
+											const editableElements = newIframeDoc.querySelectorAll(
+												'[contenteditable="true"]',
+											);
+											editableElements.forEach((el) => {
+												(el as HTMLElement).contentEditable = "false";
+												(el as HTMLElement).style.cursor = "default";
+											});
+
+											// 컴포넌트 클릭 핸들러 추가
+											const componentElements = newIframeDoc.querySelectorAll(
+												"div, section, article, header, footer, main, aside, nav, p, h1, h2, h3, h4, h5, h6",
+											);
+
+											const handleComponentClick = (e: Event) => {
+												e.stopPropagation();
+												e.preventDefault();
+
+												const target = e.target as HTMLElement;
+												if (
+													!target ||
+													[
+														"SCRIPT",
+														"STYLE",
+														"NOSCRIPT",
+														"HTML",
+														"HEAD",
+														"BODY",
+													].includes(target.tagName)
+												)
+													return;
+
+												const isSelected =
+													target.classList.contains("component-selected");
+
+												if (isSelected) {
+													target.classList.remove("component-selected");
+													target.style.outline = "1px dashed #C0C0C0";
+													target.style.boxShadow = "none";
+													target.style.backgroundColor = "";
+													setSelectedElements((prev) =>
+														prev.filter((el) => el !== target),
+													);
+												} else {
+													target.classList.add("component-selected");
+													target.style.outline = "4px solid #28a745";
+													target.style.outlineOffset = "3px";
+													target.style.backgroundColor =
+														"rgba(40, 167, 69, 0.25)";
+													target.style.boxShadow =
+														"0 0 0 4px rgba(40, 167, 69, 0.4), 0 4px 12px rgba(40, 167, 69, 0.5)";
+													target.style.transition = "all 0.2s ease";
+													setSelectedElements((prev) => [...prev, target]);
+												}
+											};
+
+											componentElements.forEach((el) => {
+												if (
+													el.tagName &&
+													![
+														"SCRIPT",
+														"STYLE",
+														"NOSCRIPT",
+														"HTML",
+														"HEAD",
+														"BODY",
+													].includes(el.tagName)
+												) {
+													const htmlEl = el as HTMLElement;
+													htmlEl.setAttribute(
+														"data-component-editable",
+														"true",
+													);
+													htmlEl.style.cursor = "pointer";
+													htmlEl.style.outline = "1px dashed #C0C0C0";
+
+													// 기존 핸들러 제거 후 새로 추가
+													const existingHandler =
+														componentClickHandlersRef.current.get(htmlEl);
+													if (existingHandler) {
+														htmlEl.removeEventListener(
+															"click",
+															existingHandler,
+															true,
+														);
+													}
+													htmlEl.addEventListener(
+														"click",
+														handleComponentClick,
+														true,
+													);
+													componentClickHandlersRef.current.set(
+														htmlEl,
+														handleComponentClick,
+													);
+												}
+											});
+
+											// 링크 클릭 방지 핸들러 추가
+											const allLinks = newIframeDoc.querySelectorAll("a");
+											const preventLinkNavigation = (e: Event) => {
+												e.preventDefault();
+												e.stopPropagation();
+												e.stopImmediatePropagation();
+												return false;
+											};
+
+											allLinks.forEach((link) => {
+												const htmlLink = link as HTMLElement;
+												const existingLinkHandler =
+													linkClickHandlersRef.current.get(htmlLink);
+												if (existingLinkHandler) {
+													htmlLink.removeEventListener(
+														"click",
+														existingLinkHandler,
+														true,
+													);
+												}
+												htmlLink.addEventListener(
+													"click",
+													preventLinkNavigation,
+													true,
+												);
+												linkClickHandlersRef.current.set(
+													htmlLink,
+													preventLinkNavigation,
+												);
+												htmlLink.style.cursor = "pointer";
+											});
+
+											// iframe 포커스 설정
+											if (newIframeDoc.body) {
+												newIframeDoc.body.setAttribute("tabindex", "-1");
+												newIframeDoc.body.focus();
+											}
+										}, 100);
+
+										setSelectedElements([]);
+
+										console.log(
+											"↶ 컴포넌트 편집 실행 취소 완료. 남은 undo:",
+											undoStackRef.current.length,
+										);
+									} else {
+										console.log("⚠️ 컴포넌트 편집 undo stack이 비어있습니다");
+									}
+								}
+							}}
+							style={{ fontSize: "12px", padding: "4px 8px" }}
+						>
+							<Undo2 size={16} color="#000000" />
+						</Button>
+						<Button
+							variant="secondary"
+							onClick={() => {
+								const iframe = iframeRef.current;
+								const iframeDoc =
+									iframe?.contentDocument || iframe?.contentWindow?.document;
+								if (!iframeDoc) return;
+
+								// ⭐ 모드에 따라 다른 redo 동작
+								if (mode === "text") {
+									iframeDoc.execCommand("redo", false);
+									const updatedHtml = iframeDoc.documentElement.outerHTML;
+									currentHtmlRef.current = updatedHtml;
+									onHtmlChange(updatedHtml);
+									console.log("↷ 텍스트 편집 다시 실행 완료 (browser redo)");
+								} else if (mode === "spacing") {
+									if (spacingRedoStackRef.current.length > 0) {
+										// 공백 제거 redo: 전체 공백 제거 다시 실행
+										// 현재 상태를 undo stack에 저장
+										const currentHtml = iframeDoc.documentElement.outerHTML;
+										spacingUndoStackRef.current.push(currentHtml);
+
+										// redo stack에서 다음 상태 가져오기
+										const nextHtml = spacingRedoStackRef.current.pop() || "";
+
+										// iframe에 다음 HTML 적용
+										iframeDoc.open();
+										iframeDoc.write(nextHtml);
+										iframeDoc.close();
+
+										// currentHtmlRef 업데이트
+										currentHtmlRef.current = nextHtml;
+										spacingCurrentHtmlRef.current = nextHtml;
+										onHtmlChange(nextHtml);
+
+										// 공백 제거 모드 다시 초기화
+										setTimeout(() => {
+											// 공백 제거 모드 재활성화는 useEffect에서 처리됨
+										}, 0);
+
+										console.log(
+											"↷ 공백 제거 다시 실행 완료. 남은 redo:",
+											spacingRedoStackRef.current.length,
+										);
+									}
+								} else if (mode === "component") {
+									// 컴포넌트 편집 모드: 컴포넌트 편집 redo stack 사용
+									if (redoStackRef.current.length > 0) {
+										// 현재 상태를 undo stack에 저장
+										const currentHtml = iframeDoc.documentElement.outerHTML;
+										undoStackRef.current.push(currentHtml);
+
+										// redo stack에서 다음 상태 가져오기
+										const nextHtml = redoStackRef.current.pop() || "";
+
+										// iframe에 다음 HTML 적용
+										iframeDoc.open();
+										iframeDoc.write(nextHtml);
+										iframeDoc.close();
+
+										// currentHtmlRef 업데이트
+										currentHtmlRef.current = nextHtml;
+										onHtmlChange(nextHtml);
+
+										// 컴포넌트 편집 모드 다시 초기화
+										setTimeout(() => {
+											const newIframeDoc =
+												iframe?.contentDocument ||
+												iframe?.contentWindow?.document;
+											if (!newIframeDoc) return;
+
+											// contentEditable 비활성화
+											const editableElements = newIframeDoc.querySelectorAll(
+												'[contenteditable="true"]',
+											);
+											editableElements.forEach((el) => {
+												(el as HTMLElement).contentEditable = "false";
+												(el as HTMLElement).style.cursor = "default";
+											});
+
+											// 컴포넌트 클릭 핸들러 추가
+											const componentElements = newIframeDoc.querySelectorAll(
+												"div, section, article, header, footer, main, aside, nav, p, h1, h2, h3, h4, h5, h6",
+											);
+
+											const handleComponentClick = (e: Event) => {
+												e.stopPropagation();
+												e.preventDefault();
+
+												const target = e.target as HTMLElement;
+												if (
+													!target ||
+													[
+														"SCRIPT",
+														"STYLE",
+														"NOSCRIPT",
+														"HTML",
+														"HEAD",
+														"BODY",
+													].includes(target.tagName)
+												)
+													return;
+
+												const isSelected =
+													target.classList.contains("component-selected");
+
+												if (isSelected) {
+													target.classList.remove("component-selected");
+													target.style.outline = "1px dashed #C0C0C0";
+													target.style.boxShadow = "none";
+													target.style.backgroundColor = "";
+													setSelectedElements((prev) =>
+														prev.filter((el) => el !== target),
+													);
+												} else {
+													target.classList.add("component-selected");
+													target.style.outline = "4px solid #28a745";
+													target.style.outlineOffset = "3px";
+													target.style.backgroundColor =
+														"rgba(40, 167, 69, 0.25)";
+													target.style.boxShadow =
+														"0 0 0 4px rgba(40, 167, 69, 0.4), 0 4px 12px rgba(40, 167, 69, 0.5)";
+													target.style.transition = "all 0.2s ease";
+													setSelectedElements((prev) => [...prev, target]);
+												}
+											};
+
+											componentElements.forEach((el) => {
+												if (
+													el.tagName &&
+													![
+														"SCRIPT",
+														"STYLE",
+														"NOSCRIPT",
+														"HTML",
+														"HEAD",
+														"BODY",
+													].includes(el.tagName)
+												) {
+													const htmlEl = el as HTMLElement;
+													htmlEl.setAttribute(
+														"data-component-editable",
+														"true",
+													);
+													htmlEl.style.cursor = "pointer";
+													htmlEl.style.outline = "1px dashed #C0C0C0";
+
+													// 기존 핸들러 제거 후 새로 추가
+													const existingHandler =
+														componentClickHandlersRef.current.get(htmlEl);
+													if (existingHandler) {
+														htmlEl.removeEventListener(
+															"click",
+															existingHandler,
+															true,
+														);
+													}
+													htmlEl.addEventListener(
+														"click",
+														handleComponentClick,
+														true,
+													);
+													componentClickHandlersRef.current.set(
+														htmlEl,
+														handleComponentClick,
+													);
+												}
+											});
+
+											// 링크 클릭 방지 핸들러 추가
+											const allLinks = newIframeDoc.querySelectorAll("a");
+											const preventLinkNavigation = (e: Event) => {
+												e.preventDefault();
+												e.stopPropagation();
+												e.stopImmediatePropagation();
+												return false;
+											};
+
+											allLinks.forEach((link) => {
+												const htmlLink = link as HTMLElement;
+												const existingLinkHandler =
+													linkClickHandlersRef.current.get(htmlLink);
+												if (existingLinkHandler) {
+													htmlLink.removeEventListener(
+														"click",
+														existingLinkHandler,
+														true,
+													);
+												}
+												htmlLink.addEventListener(
+													"click",
+													preventLinkNavigation,
+													true,
+												);
+												linkClickHandlersRef.current.set(
+													htmlLink,
+													preventLinkNavigation,
+												);
+												htmlLink.style.cursor = "pointer";
+											});
+
+											// iframe 포커스 설정
+											if (newIframeDoc.body) {
+												newIframeDoc.body.setAttribute("tabindex", "-1");
+												newIframeDoc.body.focus();
+											}
+										}, 100);
+
+										setSelectedElements([]);
+
+										console.log(
+											"↷ 컴포넌트 편집 다시 실행 완료. 남은 redo:",
+											redoStackRef.current.length,
+										);
+									} else {
+										console.log("⚠️ 컴포넌트 편집 redo stack이 비어있습니다");
+									}
+								}
+							}}
+							style={{ fontSize: "12px", padding: "4px 8px" }}
+						>
+							<Redo2 size={16} color="#000000" />
+						</Button>
+					</div>
+					<div
+						style={{
+							borderLeft: "1px solid #C0C0C0",
+							height: "24px",
+							margin: "0 4px",
+						}}
+					/>
+					<div style={{ display: "flex", gap: "4px" }}>
+						<Button
+							variant={mode === "spacing" ? "primary" : "secondary"}
+							onClick={() => setMode("spacing")}
+							style={{ fontSize: "12px", padding: "4px 8px" }}
+						>
+							수동 공백 제거
+						</Button>
+						<Button
+							variant="primary"
+							onClick={() => removeSpacing("auto")}
+							style={{ fontSize: "12px", padding: "4px 8px" }}
+						>
+							전체 공백 제거
+						</Button>
+						<Button
+							variant="primary"
+							onClick={() => removeUnnecessaryGrids()}
+							style={{ fontSize: "12px", padding: "4px 8px" }}
+						>
+							불필요한 그리드 제거
+						</Button>
+						{/* 오른쪽 유틸 메뉴 */}
+						<div
+							style={{ marginLeft: "auto", position: "relative" }}
+							ref={step3UtilityMenuRef}
+						>
+							<button
+								type="button"
+								onClick={(e) => {
+									e.stopPropagation();
+									setStep3UtilityMenuOpen((prev) => !prev);
+								}}
+								style={{
+									padding: "4px 10px",
+									fontSize: "12px",
+									border: "1px solid #A9A9A9",
+									borderRadius: "3px",
+									backgroundColor: "#FFFFFF",
+									color: "#000000",
+									cursor: "pointer",
+									fontWeight: 600,
+									lineHeight: 1,
+								}}
+								title="더 보기"
+							>
+								...
+							</button>
+							{step3UtilityMenuOpen && (
+								<div
+									style={{
+										position: "absolute",
+										right: 0,
+										top: "30px",
+										backgroundColor: "#FFFFFF",
+										border: "1px solid #C0C0C0",
+										borderRadius: "6px",
+										boxShadow: "0 10px 20px rgba(0, 0, 0, 0.08)",
+										padding: "6px",
+										zIndex: 1000,
+										minWidth: "160px",
+									}}
+								>
+									<button
+										type="button"
+										onClick={(e) => {
+											e.stopPropagation();
+											const iframe = iframeRef.current;
+											const iframeDoc =
+												iframe?.contentDocument ||
+												iframe?.contentWindow?.document;
+											if (iframeDoc) {
+												iframeDoc.open();
+												iframeDoc.write(MANUAL_PASTE_HTML);
+												iframeDoc.close();
+												const updatedHtml = iframeDoc.documentElement.outerHTML;
+												currentHtmlRef.current = updatedHtml;
+												onHtmlChange(updatedHtml);
+												setTimeout(() => {
+													const div = iframeDoc.querySelector(
+														'[contenteditable="true"]',
+													) as HTMLElement;
+													if (div) div.focus();
+												}, 50);
+											}
+											onClearForManualPaste?.();
+											setStep3UtilityMenuOpen(false);
+										}}
+										style={{
+											width: "100%",
+											textAlign: "left",
+											padding: "8px 10px",
+											border: "none",
+											background: "none",
+											cursor: "pointer",
+											fontSize: "12px",
+											color: "#000000",
+											borderRadius: "4px",
+										}}
+										title="초기화"
+									>
+										초기화
+									</button>
+									<button
+										type="button"
+										onClick={(e) => {
+											e.stopPropagation();
+											downloadHtml();
+											setStep3UtilityMenuOpen(false);
+										}}
+										style={{
+											width: "100%",
+											textAlign: "left",
+											padding: "8px 10px",
+											border: "none",
+											background: "none",
+											cursor: "pointer",
+											fontSize: "12px",
+											color: "#000000",
+											borderRadius: "4px",
+										}}
+										title="HTML 다운로드"
+									>
+										💾 HTML 다운로드
+									</button>
+								</div>
+							)}
+						</div>
+					</div>
+				</div>
+
+				{mode === "spacing" &&
+					(() => {
+						const first = selectedElements[0];
+						const iframeDoc =
+							iframeRef.current?.contentDocument ||
+							iframeRef.current?.contentWindow?.document;
+						let top = 0,
+							bottom = 0,
+							left = 0,
+							right = 0;
+						if (first && iframeDoc?.body?.contains(first)) {
+							const c = iframeDoc.defaultView?.getComputedStyle(first);
+							if (c) {
+								top =
+									(Number.parseFloat(c.marginTop) || 0) +
+									(Number.parseFloat(c.paddingTop) || 0);
+								bottom =
+									(Number.parseFloat(c.marginBottom) || 0) +
+									(Number.parseFloat(c.paddingBottom) || 0);
+								left =
+									(Number.parseFloat(c.marginLeft) || 0) +
+									(Number.parseFloat(c.paddingLeft) || 0);
+								right =
+									(Number.parseFloat(c.marginRight) || 0) +
+									(Number.parseFloat(c.paddingRight) || 0);
+							}
+						}
+						return (
+							<div
+								style={{
+									display: "flex",
+									gap: "8px",
+									alignItems: "center",
+									flexWrap: "wrap",
+								}}
+							>
+								<span
+									style={{
+										fontSize: "12px",
+										color: "#696969",
+										marginRight: "4px",
+									}}
+								>
+									{selectedElements.length}개 선택됨
+								</span>
+								{selectedElements.length > 0 && (
+									<>
+										<span style={{ fontSize: "12px", color: "#333" }}>
+											윗 여백: {top}px
+										</span>
+										<span style={{ fontSize: "12px", color: "#333" }}>
+											아래 여백: {bottom}px
+										</span>
+										<span style={{ fontSize: "12px", color: "#333" }}>
+											왼쪽 여백: {left}px
+										</span>
+										<span style={{ fontSize: "12px", color: "#333" }}>
+											우측 여백: {right}px
+										</span>
+										<Button
+											variant="secondary"
+											onClick={() => removeSpacing("top")}
+											style={{ fontSize: "11px", padding: "2px 6px" }}
+										>
+											윗 공백 제거
+										</Button>
+										<Button
+											variant="secondary"
+											onClick={() => removeSpacing("bottom")}
+											style={{ fontSize: "11px", padding: "2px 6px" }}
+										>
+											아래 공백 제거
+										</Button>
+										<Button
+											variant="secondary"
+											onClick={() => removeSpacing("left")}
+											style={{ fontSize: "11px", padding: "2px 6px" }}
+										>
+											왼쪽 공백 제거
+										</Button>
+										<Button
+											variant="secondary"
+											onClick={() => removeSpacing("right")}
+											style={{ fontSize: "11px", padding: "2px 6px" }}
+										>
+											우측 공백 제거
+										</Button>
+									</>
+								)}
+							</div>
+						);
+					})()}
+
+				{mode === "component" && (
+					<div style={{ display: "flex", gap: "4px", alignItems: "center" }}>
+						<span
+							style={{ fontSize: "12px", color: "#696969", marginRight: "4px" }}
+						>
+							{selectedElements.length}개 선택됨
+						</span>
+						<Button
+							variant="secondary"
+							onClick={() => {
+								if (!iframeRef.current) return;
+								const iframeDoc =
+									iframeRef.current.contentDocument ||
+									iframeRef.current.contentWindow?.document;
+								if (iframeDoc) {
+									selectedElements.forEach((el) => {
+										el.classList.remove("component-selected");
+										el.style.outline = "";
+										el.style.boxShadow = "";
+										el.style.backgroundColor = "";
+										el.style.outlineOffset = "";
+									});
+								}
+								setSelectedElements([]);
+							}}
+							disabled={selectedElements.length === 0}
+							style={{ fontSize: "12px", padding: "4px 8px" }}
+							title="전체 선택 취소"
+						>
+							선택 취소
+						</Button>
+						<Button
+							variant="primary"
+							onClick={handleDelete}
+							disabled={selectedElements.length === 0}
+							style={{ fontSize: "12px", padding: "4px 8px" }}
+							title={`${selectedElements.length}개 요소 삭제`}
+						>
+							삭제
+						</Button>
+					</div>
+				)}
+			</div>
+
+			{/* 에디터 영역 */}
+			<div
+				style={{
+					flex: 1,
+					border: "1px solid #C0C0C0",
+					borderRadius: "8px",
+					overflow: "hidden",
+					backgroundColor: "#FFFFFF",
+				}}
+			>
+				<iframe
+					ref={iframeRef}
+					style={{
+						width: "100%",
+						height: "100%",
+						border: "none",
+					}}
+					title="Pre-edit HTML"
+				/>
+			</div>
+		</div>
+	);
 };
 
 // STEP 6: 문서 생성
 const Step6CreateDocument = React.forwardRef<
-  { handleDraftSave: () => void; handlePublish: () => void },
-  {
-    draft: TranslationDraft;
-    onCreateDocument: (data: { title: string; categoryId?: number; estimatedLength?: number; status: string }) => void;
-    onSaveDraft?: (data: { title: string; categoryId?: number; estimatedLength?: number }) => void;
-    step6Data?: { title?: string; categoryId?: number; estimatedLength?: number };
-    isCreating: boolean;
-  }
+	{ handleDraftSave: () => void; handlePublish: () => void },
+	{
+		draft: TranslationDraft;
+		onCreateDocument: (data: {
+			title: string;
+			categoryId?: number;
+			estimatedLength?: number;
+			status: string;
+		}) => void;
+		onSaveDraft?: (data: {
+			title: string;
+			categoryId?: number;
+			estimatedLength?: number;
+		}) => void;
+		step6Data?: {
+			title?: string;
+			categoryId?: number;
+			estimatedLength?: number;
+		};
+		isCreating: boolean;
+	}
 >(({ draft, onCreateDocument, onSaveDraft, step6Data, isCreating }, ref) => {
-  const [title, setTitle] = useState(step6Data?.title || '');
-  const [categoryId, setCategoryId] = useState<string>(step6Data?.categoryId?.toString() || '');
-  const [estimatedLength, setEstimatedLength] = useState<number>(step6Data?.estimatedLength || 0);
-  const [titleError, setTitleError] = useState<string>('');
-  const [categories, setCategories] = useState<Array<{ id: number; name: string }>>([]);
-  const [categoriesLoading, setCategoriesLoading] = useState(true);
+	const [title, setTitle] = useState(step6Data?.title || "");
+	const [categoryId, setCategoryId] = useState<string>(
+		step6Data?.categoryId?.toString() || "",
+	);
+	const [estimatedLength, setEstimatedLength] = useState<number>(
+		step6Data?.estimatedLength || 0,
+	);
+	const [titleError, setTitleError] = useState<string>("");
+	const [categories, setCategories] = useState<
+		Array<{ id: number; name: string }>
+	>([]);
+	const [categoriesLoading, setCategoriesLoading] = useState(true);
 
-  // step6Data가 있으면 복원 (임시저장에서 불러올 때)
-  useEffect(() => {
-    if (step6Data) {
-      if (step6Data.title) setTitle(step6Data.title);
-      if (step6Data.categoryId) setCategoryId(step6Data.categoryId.toString());
-      if (step6Data.estimatedLength) setEstimatedLength(step6Data.estimatedLength);
-    }
-  }, [step6Data]);
+	// step6Data가 있으면 복원 (임시저장에서 불러올 때)
+	useEffect(() => {
+		if (step6Data) {
+			if (step6Data.title) setTitle(step6Data.title);
+			if (step6Data.categoryId) setCategoryId(step6Data.categoryId.toString());
+			if (step6Data.estimatedLength)
+				setEstimatedLength(step6Data.estimatedLength);
+		}
+	}, [step6Data]);
 
-  // 문서 제목 자동 파싱 및 번역
-  useEffect(() => {
-    if (draft.originalHtml && !title && !step6Data?.title && draft.targetLang) {
-      const parseAndTranslateTitle = async () => {
-        try {
-          const parser = new DOMParser();
-          const doc = parser.parseFromString(draft.originalHtml, 'text/html');
-          
-          // title 태그 또는 h1 태그에서 제목 추출
-          const titleTag = doc.querySelector('title');
-          const h1Tag = doc.querySelector('h1');
-          
-          let extractedTitle = '';
-          if (titleTag && titleTag.textContent) {
-            extractedTitle = titleTag.textContent.trim();
-          } else if (h1Tag && h1Tag.textContent) {
-            extractedTitle = h1Tag.textContent.trim();
-          } else if (draft.url) {
-            // URL에서 제목 추출 (마지막 fallback)
-            const urlParts = draft.url.split('/').filter(Boolean);
-            extractedTitle = urlParts[urlParts.length - 1] || '번역 문서';
-          }
-          
-          // 제목이 없으면 기본값
-          if (!extractedTitle) {
-            setTitle('번역 문서');
-            return;
-          }
-          
-          // 너무 긴 제목은 잘라내기 (번역 전)
-          if (extractedTitle.length > 100) {
-            extractedTitle = extractedTitle.substring(0, 100) + '...';
-          }
-          
-          // 목표 번역 언어로 번역
-          if (draft.targetLang && draft.targetLang !== 'ko' && extractedTitle) {
-            try {
-              // 제목을 간단한 HTML로 감싸서 번역 API 사용
-              const htmlToTranslate = `<p>${extractedTitle}</p>`;
-              const translatedResponse = await translationApi.translateHtml({
-                html: htmlToTranslate,
-                targetLang: draft.targetLang,
-                sourceLang: draft.sourceLang || 'auto',
-              });
-              
-              if (translatedResponse.translatedHtml) {
-                const translatedDoc = parser.parseFromString(translatedResponse.translatedHtml, 'text/html');
-                const translatedText = translatedDoc.querySelector('p')?.textContent?.trim() || extractedTitle;
-                setTitle(translatedText);
-                console.log('✅ 자동 추출 및 번역된 제목:', translatedText, '(원문:', extractedTitle, ')');
-              } else {
-                setTitle(extractedTitle);
-                console.log('✅ 자동 추출된 제목 (번역 실패):', extractedTitle);
-              }
-            } catch (translateError) {
-              console.warn('제목 번역 실패:', translateError);
-              setTitle(extractedTitle);
-              console.log('✅ 자동 추출된 제목 (번역 오류):', extractedTitle);
-            }
-          } else {
-            // 번역할 필요 없으면 그대로 사용
-            setTitle(extractedTitle);
-            console.log('✅ 자동 추출된 제목:', extractedTitle);
-          }
-        } catch (error) {
-          console.warn('제목 파싱 실패:', error);
-          setTitle('번역 문서');
-        }
-      };
-      
-      parseAndTranslateTitle();
-    }
-  }, [draft.originalHtml, draft.url, draft.targetLang, draft.sourceLang]);
+	// 문서 제목 자동 파싱 및 번역
+	useEffect(() => {
+		if (draft.originalHtml && !title && !step6Data?.title && draft.targetLang) {
+			const parseAndTranslateTitle = async () => {
+				try {
+					const parser = new DOMParser();
+					const doc = parser.parseFromString(draft.originalHtml, "text/html");
 
-  // 예상 분량 자동 계산 (Version 1의 body 글자 수)
-  useEffect(() => {
-    if (draft.translatedHtml) {
-      try {
-        const parser = new DOMParser();
-        const doc = parser.parseFromString(draft.translatedHtml, 'text/html');
-        const body = doc.body;
-        
-        // body의 텍스트만 추출 (공백 제거)
-        const textContent = body.textContent || body.innerText || '';
-        const length = textContent.replace(/\s+/g, '').length;
-        setEstimatedLength(length);
-        console.log('✅ 예상 분량 계산 완료:', length, '자');
-      } catch (error) {
-        console.warn('분량 계산 실패:', error);
-        setEstimatedLength(0);
-      }
-    }
-  }, [draft.translatedHtml]);
+					// title 태그 또는 h1 태그에서 제목 추출
+					const titleTag = doc.querySelector("title");
+					const h1Tag = doc.querySelector("h1");
 
-  // 카테고리 목록 로드
-  useEffect(() => {
-    const loadCategories = async () => {
-      try {
-        setCategoriesLoading(true);
-        const { categoryApi } = await import('../services/categoryApi');
-        const categoryList = await categoryApi.getAllCategories();
-        setCategories(categoryList.map(cat => ({ id: cat.id, name: cat.name })));
-        console.log('✅ 카테고리 목록 로드 완료:', categoryList.length, '개');
-      } catch (error) {
-        console.error('카테고리 목록 로드 실패:', error);
-        setCategories([]);
-      } finally {
-        setCategoriesLoading(false);
-      }
-    };
-    
-    loadCategories();
-  }, []);
+					let extractedTitle = "";
+					if (titleTag && titleTag.textContent) {
+						extractedTitle = titleTag.textContent.trim();
+					} else if (h1Tag && h1Tag.textContent) {
+						extractedTitle = h1Tag.textContent.trim();
+					} else if (draft.url) {
+						// URL에서 제목 추출 (마지막 fallback)
+						const urlParts = draft.url.split("/").filter(Boolean);
+						extractedTitle = urlParts[urlParts.length - 1] || "번역 문서";
+					}
 
-  // 외부에서 호출 가능한 함수들 (하단 버튼용)
-  React.useImperativeHandle(ref, () => ({
-    handleDraftSave: () => {
-      if (!title.trim()) {
-        setTitleError('문서 제목을 입력해주세요.');
-        return;
-      }
-      setTitleError('');
-      onCreateDocument({
-        title: title.trim(),
-        categoryId: categoryId ? parseInt(categoryId) : undefined,
-        estimatedLength: estimatedLength > 0 ? estimatedLength : undefined,
-        status: 'DRAFT',
-      });
-    },
-    handlePublish: () => {
-      if (!title.trim()) {
-        setTitleError('문서 제목을 입력해주세요.');
-        return;
-      }
-      setTitleError('');
-      onCreateDocument({
-        title: title.trim(),
-        categoryId: categoryId ? parseInt(categoryId) : undefined,
-        estimatedLength: estimatedLength > 0 ? estimatedLength : undefined,
-        status: 'PENDING_TRANSLATION',
-      });
-    },
-  }));
+					// 제목이 없으면 기본값
+					if (!extractedTitle) {
+						setTitle("번역 문서");
+						return;
+					}
 
-  return (
-    <div
-      data-step6
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        height: '100%',
-        padding: '32px',
-      }}
-    >
-      <div
-        style={{
-          maxWidth: '600px',
-          width: '100%',
-          padding: '32px',
-          border: '1px solid #C0C0C0',
-          borderRadius: '8px',
-          backgroundColor: '#FFFFFF',
-        }}
-      >
-        <h3
-          style={{
-            fontSize: '16px',
-            fontWeight: 600,
-            color: '#000000',
-            fontFamily: 'system-ui, Pretendard, sans-serif',
-            marginBottom: '24px',
-          }}
-        >
-          문서 정보 입력
-        </h3>
+					// 너무 긴 제목은 잘라내기 (번역 전)
+					if (extractedTitle.length > 100) {
+						extractedTitle = extractedTitle.substring(0, 100) + "...";
+					}
 
-        {/* 문서 제목 */}
-        <div style={{ marginBottom: '24px' }}>
-          <label
-            style={{
-              fontSize: '13px',
-              fontWeight: 600,
-              color: '#000000',
-              fontFamily: 'system-ui, Pretendard, sans-serif',
-              display: 'block',
-              marginBottom: '8px',
-            }}
-          >
-            문서 제목 <span style={{ color: '#FF0000' }}>*</span>
-          </label>
-          <input
-            type="text"
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-            placeholder="번역 문서의 제목을 입력하세요"
-            style={{
-              width: '100%',
-              padding: '10px 12px',
-              fontSize: '13px',
-              border: '1px solid #C0C0C0',
-              borderRadius: '4px',
-              backgroundColor: '#FFFFFF',
-              fontFamily: 'system-ui, Pretendard, sans-serif',
-            }}
-            disabled={isCreating}
-          />
-          {titleError && (
-            <span style={{ fontSize: '12px', color: '#FF0000', marginTop: '4px', display: 'block' }}>
-              {titleError}
-            </span>
-          )}
-        </div>
+					// 목표 번역 언어로 번역
+					if (draft.targetLang && draft.targetLang !== "ko" && extractedTitle) {
+						try {
+							// 제목을 간단한 HTML로 감싸서 번역 API 사용
+							const htmlToTranslate = `<p>${extractedTitle}</p>`;
+							const translatedResponse = await translationApi.translateHtml({
+								html: htmlToTranslate,
+								targetLang: draft.targetLang,
+								sourceLang: draft.sourceLang || "auto",
+							});
 
-        {/* 원본 URL */}
-        <div style={{ marginBottom: '24px' }}>
-          <label
-            style={{
-              fontSize: '13px',
-              fontWeight: 600,
-              color: '#000000',
-              fontFamily: 'system-ui, Pretendard, sans-serif',
-              display: 'block',
-              marginBottom: '8px',
-            }}
-          >
-            원본 URL
-          </label>
-          <input
-            type="text"
-            value={draft.url}
-            readOnly
-            style={{
-              width: '100%',
-              padding: '10px 12px',
-              fontSize: '13px',
-              border: '1px solid #C0C0C0',
-              borderRadius: '4px',
-              backgroundColor: '#F8F9FA',
-              fontFamily: 'system-ui, Pretendard, sans-serif',
-              color: '#696969',
-            }}
-          />
-        </div>
+							if (translatedResponse.translatedHtml) {
+								const translatedDoc = parser.parseFromString(
+									translatedResponse.translatedHtml,
+									"text/html",
+								);
+								const translatedText =
+									translatedDoc.querySelector("p")?.textContent?.trim() ||
+									extractedTitle;
+								setTitle(translatedText);
+								console.log(
+									"✅ 자동 추출 및 번역된 제목:",
+									translatedText,
+									"(원문:",
+									extractedTitle,
+									")",
+								);
+							} else {
+								setTitle(extractedTitle);
+								console.log("✅ 자동 추출된 제목 (번역 실패):", extractedTitle);
+							}
+						} catch (translateError) {
+							console.warn("제목 번역 실패:", translateError);
+							setTitle(extractedTitle);
+							console.log("✅ 자동 추출된 제목 (번역 오류):", extractedTitle);
+						}
+					} else {
+						// 번역할 필요 없으면 그대로 사용
+						setTitle(extractedTitle);
+						console.log("✅ 자동 추출된 제목:", extractedTitle);
+					}
+				} catch (error) {
+					console.warn("제목 파싱 실패:", error);
+					setTitle("번역 문서");
+				}
+			};
 
-        {/* 언어 정보 */}
-        <div style={{ marginBottom: '24px', display: 'flex', gap: '16px' }}>
-          <div style={{ flex: 1 }}>
-            <label
-              style={{
-                fontSize: '13px',
-                fontWeight: 600,
-                color: '#000000',
-                fontFamily: 'system-ui, Pretendard, sans-serif',
-                display: 'block',
-                marginBottom: '8px',
-              }}
-            >
-              원문 언어
-            </label>
-            <input
-              type="text"
-              value={draft.sourceLang || 'auto'}
-              readOnly
-              style={{
-                width: '100%',
-                padding: '10px 12px',
-                fontSize: '13px',
-                border: '1px solid #C0C0C0',
-                borderRadius: '4px',
-                backgroundColor: '#F8F9FA',
-                fontFamily: 'system-ui, Pretendard, sans-serif',
-                color: '#696969',
-              }}
-            />
-          </div>
-          <div style={{ flex: 1 }}>
-            <label
-              style={{
-                fontSize: '13px',
-                fontWeight: 600,
-                color: '#000000',
-                fontFamily: 'system-ui, Pretendard, sans-serif',
-                display: 'block',
-                marginBottom: '8px',
-              }}
-            >
-              번역 언어
-            </label>
-            <input
-              type="text"
-              value={draft.targetLang || 'ko'}
-              readOnly
-              style={{
-                width: '100%',
-                padding: '10px 12px',
-                fontSize: '13px',
-                border: '1px solid #C0C0C0',
-                borderRadius: '4px',
-                backgroundColor: '#F8F9FA',
-                fontFamily: 'system-ui, Pretendard, sans-serif',
-                color: '#696969',
-              }}
-            />
-          </div>
-        </div>
+			parseAndTranslateTitle();
+		}
+	}, [draft.originalHtml, draft.url, draft.targetLang, draft.sourceLang]);
 
-        {/* 카테고리 */}
-        <div style={{ marginBottom: '24px' }}>
-          <label
-            style={{
-              fontSize: '13px',
-              fontWeight: 600,
-              color: '#000000',
-              fontFamily: 'system-ui, Pretendard, sans-serif',
-              display: 'block',
-              marginBottom: '8px',
-            }}
-          >
-            카테고리 (선택)
-          </label>
-          <select
-            value={categoryId}
-            onChange={(e) => setCategoryId(e.target.value)}
-            style={{
-              width: '100%',
-              padding: '10px 12px',
-              fontSize: '13px',
-              border: '1px solid #C0C0C0',
-              borderRadius: '4px',
-              backgroundColor: '#FFFFFF',
-              fontFamily: 'system-ui, Pretendard, sans-serif',
-              cursor: 'pointer',
-            }}
-            disabled={isCreating || categoriesLoading}
-          >
-            <option value="">카테고리 선택 안 함</option>
-            {categories.map((category) => (
-              <option key={category.id} value={category.id.toString()}>
-                {category.name}
-              </option>
-            ))}
-          </select>
-        </div>
+	// 예상 분량 자동 계산 (Version 1의 body 글자 수)
+	useEffect(() => {
+		if (draft.translatedHtml) {
+			try {
+				const parser = new DOMParser();
+				const doc = parser.parseFromString(draft.translatedHtml, "text/html");
+				const body = doc.body;
 
-        {/* 예상 분량 */}
-        <div style={{ marginBottom: '32px' }}>
-          <label
-            style={{
-              fontSize: '13px',
-              fontWeight: 600,
-              color: '#000000',
-              fontFamily: 'system-ui, Pretendard, sans-serif',
-              display: 'block',
-              marginBottom: '8px',
-            }}
-          >
-            예상 분량 (자동 계산)
-          </label>
-          <input
-            type="number"
-            value={estimatedLength}
-            onChange={(e) => setEstimatedLength(parseInt(e.target.value) || 0)}
-            style={{
-              width: '100%',
-              padding: '10px 12px',
-              fontSize: '13px',
-              border: '1px solid #C0C0C0',
-              borderRadius: '4px',
-              backgroundColor: '#FFFFFF',
-              fontFamily: 'system-ui, Pretendard, sans-serif',
-            }}
-            disabled={isCreating}
-          />
-          <span style={{ fontSize: '12px', color: '#696969', marginTop: '4px', display: 'block' }}>
-            총 글자 수: {estimatedLength.toLocaleString()}자 (공백 제외)
-          </span>
-        </div>
+				// body의 텍스트만 추출 (공백 제거)
+				const textContent = body.textContent || body.innerText || "";
+				const length = textContent.replace(/\s+/g, "").length;
+				setEstimatedLength(length);
+				console.log("✅ 예상 분량 계산 완료:", length, "자");
+			} catch (error) {
+				console.warn("분량 계산 실패:", error);
+				setEstimatedLength(0);
+			}
+		}
+	}, [draft.translatedHtml]);
 
-        {/* 버튼 영역 - 카드 하단 */}
-        <div style={{ 
-          display: 'flex', 
-          justifyContent: 'flex-end', 
-          gap: '12px',
-          marginTop: '32px',
-          paddingTop: '24px',
-          borderTop: '1px solid #E0E0E0',
-        }}>
-          <Button
-            variant="secondary"
-            onClick={() => {
-              if (!title.trim()) {
-                setTitleError('문서 제목을 입력해주세요.');
-                return;
-              }
-              setTitleError('');
-              if (onSaveDraft) {
-                // Step 6에서 임시저장 (버전 생성하지 않음)
-                onSaveDraft({
-                  title: title.trim(),
-                  categoryId: categoryId ? parseInt(categoryId) : undefined,
-                  estimatedLength: estimatedLength > 0 ? estimatedLength : undefined,
-                });
-              } else {
-                // 하위 호환성: 기존 방식
-                onCreateDocument({
-                  title: title.trim(),
-                  categoryId: categoryId ? parseInt(categoryId) : undefined,
-                  estimatedLength: estimatedLength > 0 ? estimatedLength : undefined,
-                  status: 'DRAFT',
-                });
-              }
-            }}
-            disabled={isCreating || !title.trim()}
-            style={{ padding: '10px 20px' }}
-          >
-            {isCreating ? '저장 중...' : '임시 저장 (Draft)'}
-          </Button>
-          <Button
-            variant="primary"
-            onClick={() => {
-              if (!title.trim()) {
-                setTitleError('문서 제목을 입력해주세요.');
-                return;
-              }
-              setTitleError('');
-              onCreateDocument({
-                title: title.trim(),
-                categoryId: categoryId ? parseInt(categoryId) : undefined,
-                estimatedLength: estimatedLength > 0 ? estimatedLength : undefined,
-                status: 'PENDING_TRANSLATION',
-              });
-            }}
-            disabled={isCreating || !title.trim()}
-            style={{ padding: '10px 20px' }}
-          >
-            {isCreating ? '생성 중...' : '문서 생성 및 공개'}
-          </Button>
-        </div>
+	// 카테고리 목록 로드
+	useEffect(() => {
+		const loadCategories = async () => {
+			try {
+				setCategoriesLoading(true);
+				const { categoryApi } = await import("../services/categoryApi");
+				const categoryList = await categoryApi.getAllCategories();
+				setCategories(
+					categoryList.map((cat) => ({ id: cat.id, name: cat.name })),
+				);
+				console.log("✅ 카테고리 목록 로드 완료:", categoryList.length, "개");
+			} catch (error) {
+				console.error("카테고리 목록 로드 실패:", error);
+				setCategories([]);
+			} finally {
+				setCategoriesLoading(false);
+			}
+		};
 
-        {isCreating && (
-          <div
-            style={{
-              marginTop: '16px',
-              padding: '12px',
-              backgroundColor: '#F8F9FA',
-              borderRadius: '4px',
-              fontSize: '12px',
-              color: '#696969',
-              textAlign: 'center',
-            }}
-          >
-            문서를 생성하고 있습니다...
-          </div>
-        )}
-      </div>
-    </div>
-  );
+		loadCategories();
+	}, []);
+
+	// 외부에서 호출 가능한 함수들 (하단 버튼용)
+	React.useImperativeHandle(ref, () => ({
+		handleDraftSave: () => {
+			if (!title.trim()) {
+				setTitleError("문서 제목을 입력해주세요.");
+				return;
+			}
+			setTitleError("");
+			onCreateDocument({
+				title: title.trim(),
+				categoryId: categoryId ? Number.parseInt(categoryId) : undefined,
+				estimatedLength: estimatedLength > 0 ? estimatedLength : undefined,
+				status: "DRAFT",
+			});
+		},
+		handlePublish: () => {
+			if (!title.trim()) {
+				setTitleError("문서 제목을 입력해주세요.");
+				return;
+			}
+			setTitleError("");
+			onCreateDocument({
+				title: title.trim(),
+				categoryId: categoryId ? Number.parseInt(categoryId) : undefined,
+				estimatedLength: estimatedLength > 0 ? estimatedLength : undefined,
+				status: "PENDING_TRANSLATION",
+			});
+		},
+	}));
+
+	return (
+		<div
+			data-step6
+			style={{
+				display: "flex",
+				alignItems: "center",
+				justifyContent: "center",
+				height: "100%",
+				padding: "32px",
+			}}
+		>
+			<div
+				style={{
+					maxWidth: "600px",
+					width: "100%",
+					padding: "32px",
+					border: "1px solid #C0C0C0",
+					borderRadius: "8px",
+					backgroundColor: "#FFFFFF",
+				}}
+			>
+				<h3
+					style={{
+						fontSize: "16px",
+						fontWeight: 600,
+						color: "#000000",
+						fontFamily: "system-ui, Pretendard, sans-serif",
+						marginBottom: "24px",
+					}}
+				>
+					문서 정보 입력
+				</h3>
+
+				{/* 문서 제목 */}
+				<div style={{ marginBottom: "24px" }}>
+					<label
+						style={{
+							fontSize: "13px",
+							fontWeight: 600,
+							color: "#000000",
+							fontFamily: "system-ui, Pretendard, sans-serif",
+							display: "block",
+							marginBottom: "8px",
+						}}
+					>
+						문서 제목 <span style={{ color: "#FF0000" }}>*</span>
+					</label>
+					<input
+						type="text"
+						value={title}
+						onChange={(e) => setTitle(e.target.value)}
+						placeholder="번역 문서의 제목을 입력하세요"
+						style={{
+							width: "100%",
+							padding: "10px 12px",
+							fontSize: "13px",
+							border: "1px solid #C0C0C0",
+							color: "#000000",
+							borderRadius: "4px",
+							backgroundColor: "#FFFFFF",
+							fontFamily: "system-ui, Pretendard, sans-serif",
+						}}
+						disabled={isCreating}
+					/>
+					{titleError && (
+						<span
+							style={{
+								fontSize: "12px",
+								color: "#FF0000",
+								marginTop: "4px",
+								display: "block",
+							}}
+						>
+							{titleError}
+						</span>
+					)}
+				</div>
+
+				{/* 원본 URL */}
+				<div style={{ marginBottom: "24px" }}>
+					<label
+						style={{
+							fontSize: "13px",
+							fontWeight: 600,
+							color: "#000000",
+							fontFamily: "system-ui, Pretendard, sans-serif",
+							display: "block",
+							marginBottom: "8px",
+						}}
+					>
+						원본 URL
+					</label>
+					<input
+						type="text"
+						value={draft.url}
+						readOnly
+						style={{
+							width: "100%",
+							padding: "10px 12px",
+							fontSize: "13px",
+							border: "1px solid #C0C0C0",
+							borderRadius: "4px",
+							backgroundColor: "#F8F9FA",
+							fontFamily: "system-ui, Pretendard, sans-serif",
+							color: "#696969",
+						}}
+					/>
+				</div>
+
+				{/* 언어 정보 */}
+				<div style={{ marginBottom: "24px", display: "flex", gap: "16px" }}>
+					<div style={{ flex: 1 }}>
+						<label
+							style={{
+								fontSize: "13px",
+								fontWeight: 600,
+								color: "#000000",
+								fontFamily: "system-ui, Pretendard, sans-serif",
+								display: "block",
+								marginBottom: "8px",
+							}}
+						>
+							원문 언어
+						</label>
+						<input
+							type="text"
+							value={draft.sourceLang || "auto"}
+							readOnly
+							style={{
+								width: "100%",
+								padding: "10px 12px",
+								fontSize: "13px",
+								border: "1px solid #C0C0C0",
+								borderRadius: "4px",
+								backgroundColor: "#F8F9FA",
+								fontFamily: "system-ui, Pretendard, sans-serif",
+								color: "#696969",
+							}}
+						/>
+					</div>
+					<div style={{ flex: 1 }}>
+						<label
+							style={{
+								fontSize: "13px",
+								fontWeight: 600,
+								color: "#000000",
+								fontFamily: "system-ui, Pretendard, sans-serif",
+								display: "block",
+								marginBottom: "8px",
+							}}
+						>
+							번역 언어
+						</label>
+						<input
+							type="text"
+							value={draft.targetLang || "ko"}
+							readOnly
+							style={{
+								width: "100%",
+								padding: "10px 12px",
+								fontSize: "13px",
+								border: "1px solid #C0C0C0",
+								borderRadius: "4px",
+								backgroundColor: "#F8F9FA",
+								fontFamily: "system-ui, Pretendard, sans-serif",
+								color: "#696969",
+							}}
+						/>
+					</div>
+				</div>
+
+				{/* 카테고리 */}
+				<div style={{ marginBottom: "24px" }}>
+					<label
+						style={{
+							fontSize: "13px",
+							fontWeight: 600,
+							color: "#000000",
+							fontFamily: "system-ui, Pretendard, sans-serif",
+							display: "block",
+							marginBottom: "8px",
+						}}
+					>
+						카테고리 (선택)
+					</label>
+					<select
+						value={categoryId}
+						onChange={(e) => setCategoryId(e.target.value)}
+						style={{
+							width: "100%",
+							padding: "10px 12px",
+							fontSize: "13px",
+							border: "1px solid #C0C0C0",
+							color: "#000000",
+							borderRadius: "4px",
+							backgroundColor: "#FFFFFF",
+							fontFamily: "system-ui, Pretendard, sans-serif",
+							cursor: "pointer",
+						}}
+						disabled={isCreating || categoriesLoading}
+					>
+						<option value="">카테고리 선택 안 함</option>
+						{categories.map((category) => (
+							<option key={category.id} value={category.id.toString()}>
+								{category.name}
+							</option>
+						))}
+					</select>
+				</div>
+
+				{/* 예상 분량 */}
+				<div style={{ marginBottom: "32px" }}>
+					<label
+						style={{
+							fontSize: "13px",
+							fontWeight: 600,
+							color: "#000000",
+							fontFamily: "system-ui, Pretendard, sans-serif",
+							display: "block",
+							marginBottom: "8px",
+						}}
+					>
+						예상 분량 (자동 계산)
+					</label>
+					<input
+						type="number"
+						value={estimatedLength}
+						onChange={(e) =>
+							setEstimatedLength(Number.parseInt(e.target.value) || 0)
+						}
+						style={{
+							width: "100%",
+							padding: "10px 12px",
+							color: "#000000",
+							fontSize: "13px",
+							border: "1px solid #C0C0C0",
+							borderRadius: "4px",
+							backgroundColor: "#FFFFFF",
+							fontFamily: "system-ui, Pretendard, sans-serif",
+						}}
+						disabled={isCreating}
+					/>
+					<span
+						style={{
+							fontSize: "12px",
+							color: "#696969",
+							marginTop: "4px",
+							display: "block",
+						}}
+					>
+						총 글자 수: {estimatedLength.toLocaleString()}자 (공백 제외)
+					</span>
+				</div>
+
+				{/* 버튼 영역 - 카드 하단 */}
+				<div
+					style={{
+						display: "flex",
+						justifyContent: "flex-end",
+						gap: "12px",
+						marginTop: "32px",
+						paddingTop: "24px",
+						borderTop: "1px solid #E0E0E0",
+					}}
+				>
+					<Button
+						variant="secondary"
+						onClick={() => {
+							if (!title.trim()) {
+								setTitleError("문서 제목을 입력해주세요.");
+								return;
+							}
+							setTitleError("");
+							if (onSaveDraft) {
+								// Step 6에서 임시저장 (버전 생성하지 않음)
+								onSaveDraft({
+									title: title.trim(),
+									categoryId: categoryId
+										? Number.parseInt(categoryId)
+										: undefined,
+									estimatedLength:
+										estimatedLength > 0 ? estimatedLength : undefined,
+								});
+							} else {
+								// 하위 호환성: 기존 방식
+								onCreateDocument({
+									title: title.trim(),
+									categoryId: categoryId
+										? Number.parseInt(categoryId)
+										: undefined,
+									estimatedLength:
+										estimatedLength > 0 ? estimatedLength : undefined,
+									status: "DRAFT",
+								});
+							}
+						}}
+						disabled={isCreating || !title.trim()}
+						style={{ padding: "10px 20px" }}
+					>
+						{isCreating ? "저장 중..." : "임시 저장 (Draft)"}
+					</Button>
+					<Button
+						variant="primary"
+						onClick={() => {
+							if (!title.trim()) {
+								setTitleError("문서 제목을 입력해주세요.");
+								return;
+							}
+							setTitleError("");
+							onCreateDocument({
+								title: title.trim(),
+								categoryId: categoryId
+									? Number.parseInt(categoryId)
+									: undefined,
+								estimatedLength:
+									estimatedLength > 0 ? estimatedLength : undefined,
+								status: "PENDING_TRANSLATION",
+							});
+						}}
+						disabled={isCreating || !title.trim()}
+						style={{ padding: "10px 20px" }}
+					>
+						{isCreating ? "생성 중..." : "문서 생성 및 공개"}
+					</Button>
+				</div>
+
+				{isCreating && (
+					<div
+						style={{
+							marginTop: "16px",
+							padding: "12px",
+							backgroundColor: "#F8F9FA",
+							borderRadius: "4px",
+							fontSize: "12px",
+							color: "#696969",
+							textAlign: "center",
+						}}
+					>
+						문서를 생성하고 있습니다...
+					</div>
+				)}
+			</div>
+		</div>
+	);
 });
 
 // STEP 4: 번역 실행
 const Step4Translation: React.FC<{
-  onConfirm: (sourceLang: string, targetLang: string) => void;
-  onCancel: () => void;
-  isTranslating: boolean;
-  translatingProgress?: number;
+	onConfirm: (sourceLang: string, targetLang: string) => void;
+	onCancel: () => void;
+	isTranslating: boolean;
+	translatingProgress?: number;
 }> = ({ onConfirm, onCancel, isTranslating, translatingProgress = 0 }) => {
-  const [sourceLang, setSourceLang] = useState('auto');
-  const [targetLang, setTargetLang] = useState('ko');
+	const [sourceLang, setSourceLang] = useState("auto");
+	const [targetLang, setTargetLang] = useState("ko");
 
-  const languages = [
-    { code: 'auto', name: '자동 감지', deepl: '' },
-    { code: 'ko', name: '한국어', deepl: 'KO' },
-    { code: 'en', name: 'English', deepl: 'EN' },
-    { code: 'ja', name: '日本語', deepl: 'JA' },
-    { code: 'zh', name: '中文', deepl: 'ZH' },
-    { code: 'es', name: 'Español', deepl: 'ES' },
-    { code: 'fr', name: 'Français', deepl: 'FR' },
-    { code: 'de', name: 'Deutsch', deepl: 'DE' },
-    { code: 'it', name: 'Italiano', deepl: 'IT' },
-    { code: 'pt', name: 'Português', deepl: 'PT' },
-  ];
+	const languages = [
+		{ code: "auto", name: "자동 감지", deepl: "" },
+		{ code: "ko", name: "한국어", deepl: "KO" },
+		{ code: "en", name: "English", deepl: "EN" },
+		{ code: "ja", name: "日本語", deepl: "JA" },
+		{ code: "zh", name: "中文", deepl: "ZH" },
+		{ code: "es", name: "Español", deepl: "ES" },
+		{ code: "fr", name: "Français", deepl: "FR" },
+		{ code: "de", name: "Deutsch", deepl: "DE" },
+		{ code: "it", name: "Italiano", deepl: "IT" },
+		{ code: "pt", name: "Português", deepl: "PT" },
+	];
 
-  const getDeepLLangCode = (code: string) => {
-    if (code === 'auto') return '';
-    const lang = languages.find(l => l.code === code);
-    return lang?.deepl || code.toUpperCase();
-  };
+	const getDeepLLangCode = (code: string) => {
+		if (code === "auto") return "";
+		const lang = languages.find((l) => l.code === code);
+		return lang?.deepl || code.toUpperCase();
+	};
 
-  return (
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        height: '100%',
-      }}
-    >
-      <div
-        style={{
-          padding: '32px',
-          border: '1px solid #C0C0C0',
-          borderRadius: '8px',
-          backgroundColor: '#FFFFFF',
-          maxWidth: '500px',
-          width: '100%',
-        }}
-      >
-        <h3
-          style={{
-            fontSize: '14px',
-            fontWeight: 600,
-            color: '#000000',
-            fontFamily: 'system-ui, Pretendard, sans-serif',
-            marginBottom: '24px',
-          }}
-        >
-          번역 실행
-        </h3>
+	return (
+		<div
+			style={{
+				display: "flex",
+				alignItems: "center",
+				justifyContent: "center",
+				height: "100%",
+			}}
+		>
+			<div
+				style={{
+					padding: "32px",
+					border: "1px solid #C0C0C0",
+					borderRadius: "8px",
+					backgroundColor: "#FFFFFF",
+					maxWidth: "500px",
+					width: "100%",
+				}}
+			>
+				<h3
+					style={{
+						fontSize: "14px",
+						fontWeight: 600,
+						color: "#000000",
+						fontFamily: "system-ui, Pretendard, sans-serif",
+						marginBottom: "24px",
+					}}
+				>
+					번역 실행
+				</h3>
 
-        {/* 언어 선택 */}
-        <div style={{ marginBottom: '24px' }}>
-          <label
-            style={{
-              fontSize: '13px',
-              fontWeight: 600,
-              color: '#000000',
-              fontFamily: 'system-ui, Pretendard, sans-serif',
-              display: 'block',
-              marginBottom: '8px',
-            }}
-          >
-            원문 언어
-          </label>
-          <select
-            value={sourceLang}
-            onChange={(e) => setSourceLang(e.target.value)}
-            style={{
-              width: '100%',
-              padding: '8px 12px',
-              fontSize: '13px',
-              border: '1px solid #C0C0C0',
-              borderRadius: '4px',
-              backgroundColor: '#FFFFFF',
-              fontFamily: 'system-ui, Pretendard, sans-serif',
-              cursor: 'pointer',
-            }}
-            disabled={isTranslating}
-          >
-            {languages.map((lang) => (
-              <option key={lang.code} value={lang.code}>
-                {lang.name}
-              </option>
-            ))}
-          </select>
-        </div>
+				{/* 언어 선택 */}
+				<div style={{ marginBottom: "24px" }}>
+					<label
+						style={{
+							fontSize: "13px",
+							fontWeight: 600,
+							color: "#000000",
+							fontFamily: "system-ui, Pretendard, sans-serif",
+							display: "block",
+							marginBottom: "8px",
+						}}
+					>
+						원문 언어
+					</label>
+					<select
+						value={sourceLang}
+						onChange={(e) => setSourceLang(e.target.value)}
+						style={{
+							width: "100%",
+							padding: "8px 12px",
+							fontSize: "13px",
+							border: "1px solid #C0C0C0",
+							color: "#000000",
+							borderRadius: "4px",
+							backgroundColor: "#FFFFFF",
+							fontFamily: "system-ui, Pretendard, sans-serif",
+							cursor: "pointer",
+						}}
+						disabled={isTranslating}
+					>
+						{languages.map((lang) => (
+							<option key={lang.code} value={lang.code}>
+								{lang.name}
+							</option>
+						))}
+					</select>
+				</div>
 
-        <div style={{ marginBottom: '24px' }}>
-          <label
-            style={{
-              fontSize: '13px',
-              fontWeight: 600,
-              color: '#000000',
-              fontFamily: 'system-ui, Pretendard, sans-serif',
-              display: 'block',
-              marginBottom: '8px',
-            }}
-          >
-            번역 언어
-          </label>
-          <select
-            value={targetLang}
-            onChange={(e) => setTargetLang(e.target.value)}
-            style={{
-              width: '100%',
-              padding: '8px 12px',
-              fontSize: '13px',
-              border: '1px solid #C0C0C0',
-              borderRadius: '4px',
-              backgroundColor: '#FFFFFF',
-              fontFamily: 'system-ui, Pretendard, sans-serif',
-              cursor: 'pointer',
-            }}
-            disabled={isTranslating}
-          >
-            {languages.filter(l => l.code !== 'auto').map((lang) => (
-              <option key={lang.code} value={lang.code}>
-                {lang.name}
-              </option>
-            ))}
-          </select>
-        </div>
+				<div style={{ marginBottom: "24px" }}>
+					<label
+						style={{
+							fontSize: "13px",
+							fontWeight: 600,
+							color: "#000000",
+							fontFamily: "system-ui, Pretendard, sans-serif",
+							display: "block",
+							marginBottom: "8px",
+						}}
+					>
+						번역 언어
+					</label>
+					<select
+						value={targetLang}
+						onChange={(e) => setTargetLang(e.target.value)}
+						style={{
+							width: "100%",
+							padding: "8px 12px",
+							fontSize: "13px",
+							border: "1px solid #C0C0C0",
+							borderRadius: "4px",
+							backgroundColor: "#FFFFFF",
+							color: "#000000",
+							fontFamily: "system-ui, Pretendard, sans-serif",
+							cursor: "pointer",
+						}}
+						disabled={isTranslating}
+					>
+						{languages
+							.filter((l) => l.code !== "auto")
+							.map((lang) => (
+								<option key={lang.code} value={lang.code}>
+									{lang.name}
+								</option>
+							))}
+					</select>
+				</div>
 
-        <p
-          style={{
-            fontSize: '13px',
-            color: '#696969',
-            fontFamily: 'system-ui, Pretendard, sans-serif',
-            marginBottom: '24px',
-          }}
-        >
-          선택한 영역을 {languages.find(l => l.code === targetLang)?.name}로 번역하시겠습니까?
-        </p>
+				<p
+					style={{
+						fontSize: "13px",
+						color: "#696969",
+						fontFamily: "system-ui, Pretendard, sans-serif",
+						marginBottom: "24px",
+					}}
+				>
+					선택한 영역을 {languages.find((l) => l.code === targetLang)?.name}로
+					번역하시겠습니까?
+				</p>
 
-        <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
-          <Button variant="secondary" onClick={onCancel} disabled={isTranslating}>
-            취소
-          </Button>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
-            <Button
-              variant="primary"
-              onClick={() => onConfirm(
-                sourceLang === 'auto' ? '' : getDeepLLangCode(sourceLang), 
-                getDeepLLangCode(targetLang)
-              )} 
-              disabled={isTranslating}
-            >
-              {isTranslating ? '번역 중...' : '번역 실행'}
-            </Button>
-            {isTranslating && translatingProgress > 0 && (
-              <span style={{ fontSize: '13px', color: '#696969', fontWeight: 600 }}>
-                {Math.round(translatingProgress)}%
-              </span>
-            )}
-          </div>
-        </div>
-      </div>
-    </div>
-  );
+				<div
+					style={{ display: "flex", gap: "8px", justifyContent: "flex-end" }}
+				>
+					<Button
+						variant="secondary"
+						onClick={onCancel}
+						disabled={isTranslating}
+					>
+						취소
+					</Button>
+					<div style={{ display: "flex", alignItems: "center", gap: "12px" }}>
+						<Button
+							variant="primary"
+							onClick={() =>
+								onConfirm(
+									sourceLang === "auto" ? "" : getDeepLLangCode(sourceLang),
+									getDeepLLangCode(targetLang),
+								)
+							}
+							disabled={isTranslating}
+						>
+							{isTranslating ? "번역 중..." : "번역 실행"}
+						</Button>
+						{isTranslating && translatingProgress > 0 && (
+							<span
+								style={{ fontSize: "13px", color: "#696969", fontWeight: 600 }}
+							>
+								{Math.round(translatingProgress)}%
+							</span>
+						)}
+					</div>
+				</div>
+			</div>
+		</div>
+	);
 };
 
 // STEP 5: 원문/편집본 병렬 편집 (NewTranslation 전용)
 const Step5ParallelEdit: React.FC<{
-  crawledHtml: string; // STEP 1에서 크롤링한 전체 원문
-  selectedHtml: string; // STEP 2/3에서 선택한 영역
-  translatedHtml: string;
-  onTranslatedChange: (html: string) => void;
-  collapsedPanels: Set<string>;
-  onTogglePanel: (panelId: string) => void;
-  showVersion0Glossary: boolean;
-  glossaryTerms: GlossaryTermPair[];
+	crawledHtml: string; // STEP 1에서 크롤링한 전체 원문
+	selectedHtml: string; // STEP 2/3에서 선택한 영역
+	translatedHtml: string;
+	onTranslatedChange: (html: string) => void;
+	collapsedPanels: Set<string>;
+	onTogglePanel: (panelId: string) => void;
+	showVersion0Glossary: boolean;
+	glossaryTerms: GlossaryTermPair[];
 }> = ({
-  crawledHtml,
-  selectedHtml,
-  translatedHtml,
-  onTranslatedChange,
-  collapsedPanels,
-  onTogglePanel,
-  showVersion0Glossary,
-  glossaryTerms,
+	crawledHtml,
+	selectedHtml,
+	translatedHtml,
+	onTranslatedChange,
+	collapsedPanels,
+	onTogglePanel,
+	showVersion0Glossary,
+	glossaryTerms,
 }) => {
-  const [mode, setMode] = useState<EditorMode>('text');
-  const [fullscreenPanel, setFullscreenPanel] = useState<string | null>(null);
-  const [selectedElements, setSelectedElements] = useState<HTMLElement[]>([]);
-  
-  // 링크 편집 모달 상태
-  const [showLinkModal, setShowLinkModal] = useState(false);
-  const [editingLink, setEditingLink] = useState<HTMLAnchorElement | null>(null);
-  const [linkUrl, setLinkUrl] = useState('');
-  
-  // 더보기 메뉴 상태
-  const [showMoreMenu, setShowMoreMenu] = useState(false);
-  
-  const crawledIframeRef = React.useRef<HTMLIFrameElement>(null);
-  const selectedIframeRef = React.useRef<HTMLIFrameElement>(null);
-  const translatedIframeRef = React.useRef<HTMLIFrameElement>(null);
-  const [isTranslatedInitialized, setIsTranslatedInitialized] = useState(false);
-  const crawledLoadedRef = React.useRef(false);
-  const selectedLoadedRef = React.useRef(false);
-  
-  // 컴포넌트 편집용 Undo/Redo Stack (STEP 5)
-  const undoStackRef = React.useRef<string[]>([]);
-  const redoStackRef = React.useRef<string[]>([]);
-  const currentHtmlRef = React.useRef<string>('');
-  // 컴포넌트 클릭 핸들러 저장 (제거를 위해)
-  const componentClickHandlersRef = React.useRef<Map<HTMLElement, (e: Event) => void>>(new Map());
-  // 링크 클릭 방지 핸들러 저장 (제거를 위해)
-  const linkClickHandlersRef = React.useRef<Map<HTMLElement, (e: Event) => void>>(new Map());
-  // window 키보드 이벤트 리스너 저장 (cleanup에서 제거하기 위해)
-  const windowKeydownHandlerRef = React.useRef<((e: KeyboardEvent) => void) | null>(null);
-  const iframeKeydownHandlerRef = React.useRef<((e: KeyboardEvent) => void) | null>(null);
+	const [mode, setMode] = useState<EditorMode>("text");
+	const [fullscreenPanel, setFullscreenPanel] = useState<string | null>(null);
+	const [selectedElements, setSelectedElements] = useState<HTMLElement[]>([]);
 
-  // 패널 접기/펼치기 (props로 받은 함수 사용)
-  const togglePanel = onTogglePanel;
+	// 링크 편집 모달 상태
+	const [showLinkModal, setShowLinkModal] = useState(false);
+	const [editingLink, setEditingLink] = useState<HTMLAnchorElement | null>(
+		null,
+	);
+	const [linkUrl, setLinkUrl] = useState("");
 
-  // 전체화면 토글
-  const toggleFullscreen = (panelId: string) => {
-    setFullscreenPanel(prev => prev === panelId ? null : panelId);
-  };
+	// 더보기 메뉴 상태
+	const [showMoreMenu, setShowMoreMenu] = useState(false);
 
-  // 크롤링된 원문 iframe 렌더링 (읽기 전용)
-  useEffect(() => {
-    const iframe = crawledIframeRef.current;
-    if (!iframe || !crawledHtml) return;
-    
-    console.log('🌐 크롤링 원본 iframe 렌더링 시작');
-    const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-    if (iframeDoc) {
-      try {
-        iframeDoc.open();
-        iframeDoc.write(crawledHtml);
-        iframeDoc.close();
-        crawledLoadedRef.current = true;
-        console.log('✅ 크롤링 원본 iframe 렌더링 완료');
-      } catch (error) {
-        console.warn('crawled iframe write error (ignored):', error);
-      }
-    }
-  }, [crawledHtml, collapsedPanels, fullscreenPanel]);
+	const crawledIframeRef = React.useRef<HTMLIFrameElement>(null);
+	const selectedIframeRef = React.useRef<HTMLIFrameElement>(null);
+	const translatedIframeRef = React.useRef<HTMLIFrameElement>(null);
+	const [isTranslatedInitialized, setIsTranslatedInitialized] = useState(false);
+	const crawledLoadedRef = React.useRef(false);
+	const selectedLoadedRef = React.useRef(false);
 
-  // 선택한 영역 iframe 렌더링 (읽기 전용)
-  useEffect(() => {
-    const iframe = selectedIframeRef.current;
-    if (!iframe || !selectedHtml) return;
-    
-    console.log('📦 선택한 영역 iframe 렌더링 시작');
-    const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-    if (iframeDoc) {
-      try {
-        iframeDoc.open();
-        iframeDoc.write(selectedHtml);
-        iframeDoc.close();
+	// 컴포넌트 편집용 Undo/Redo Stack (STEP 5)
+	const undoStackRef = React.useRef<string[]>([]);
+	const redoStackRef = React.useRef<string[]>([]);
+	const currentHtmlRef = React.useRef<string>("");
+	// 컴포넌트 클릭 핸들러 저장 (제거를 위해)
+	const componentClickHandlersRef = React.useRef<
+		Map<HTMLElement, (e: Event) => void>
+	>(new Map());
+	// 링크 클릭 방지 핸들러 저장 (제거를 위해)
+	const linkClickHandlersRef = React.useRef<
+		Map<HTMLElement, (e: Event) => void>
+	>(new Map());
+	// window 키보드 이벤트 리스너 저장 (cleanup에서 제거하기 위해)
+	const windowKeydownHandlerRef = React.useRef<
+		((e: KeyboardEvent) => void) | null
+	>(null);
+	const iframeKeydownHandlerRef = React.useRef<
+		((e: KeyboardEvent) => void) | null
+	>(null);
 
-        // Version 0 용어집 표시 스타일
-        const style = iframeDoc.createElement('style');
-        style.textContent = `
+	// 패널 접기/펼치기 (props로 받은 함수 사용)
+	const togglePanel = onTogglePanel;
+
+	// 전체화면 토글
+	const toggleFullscreen = (panelId: string) => {
+		setFullscreenPanel((prev) => (prev === panelId ? null : panelId));
+	};
+
+	// 크롤링된 원문 iframe 렌더링 (읽기 전용)
+	useEffect(() => {
+		const iframe = crawledIframeRef.current;
+		if (!iframe || !crawledHtml) return;
+
+		console.log("🌐 크롤링 원본 iframe 렌더링 시작");
+		const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
+		if (iframeDoc) {
+			try {
+				iframeDoc.open();
+				iframeDoc.write(crawledHtml);
+				iframeDoc.close();
+				crawledLoadedRef.current = true;
+				console.log("✅ 크롤링 원본 iframe 렌더링 완료");
+			} catch (error) {
+				console.warn("crawled iframe write error (ignored):", error);
+			}
+		}
+	}, [crawledHtml, collapsedPanels, fullscreenPanel]);
+
+	// 선택한 영역 iframe 렌더링 (읽기 전용)
+	useEffect(() => {
+		const iframe = selectedIframeRef.current;
+		if (!iframe || !selectedHtml) return;
+
+		console.log("📦 선택한 영역 iframe 렌더링 시작");
+		const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
+		if (iframeDoc) {
+			try {
+				iframeDoc.open();
+				iframeDoc.write(selectedHtml);
+				iframeDoc.close();
+
+				// Version 0 용어집 표시 스타일
+				const style = iframeDoc.createElement("style");
+				style.textContent = `
           .original-glossary-term {
             background-color: #fff4c2;
             color: #7a4b00;
@@ -4801,122 +6046,135 @@ const Step5ParallelEdit: React.FC<{
             padding: 0 2px;
           }
         `;
-        iframeDoc.head.appendChild(style);
+				iframeDoc.head.appendChild(style);
 
-        if (showVersion0Glossary) {
-          highlightGlossaryInOriginalIframe(iframeDoc, glossaryTerms);
-        }
+				if (showVersion0Glossary) {
+					highlightGlossaryInOriginalIframe(iframeDoc, glossaryTerms);
+				}
 
-        selectedLoadedRef.current = true;
-        console.log('✅ 선택한 영역 iframe 렌더링 완료');
-      } catch (error) {
-        console.warn('selected iframe write error (ignored):', error);
-      }
-    }
-  }, [selectedHtml, collapsedPanels, fullscreenPanel, showVersion0Glossary, glossaryTerms]);
+				selectedLoadedRef.current = true;
+				console.log("✅ 선택한 영역 iframe 렌더링 완료");
+			} catch (error) {
+				console.warn("selected iframe write error (ignored):", error);
+			}
+		}
+	}, [
+		selectedHtml,
+		collapsedPanels,
+		fullscreenPanel,
+		showVersion0Glossary,
+		glossaryTerms,
+	]);
 
-  // 편집본 iframe 초기 렌더링 (NewTranslation 전용) - 한 번만 실행
-  useEffect(() => {
-    if (isTranslatedInitialized) return; // 이미 초기화되었으면 스킵
-    
-    const iframe = translatedIframeRef.current;
-    if (!iframe || !translatedHtml) return;
+	// 편집본 iframe 초기 렌더링 (NewTranslation 전용) - 한 번만 실행
+	useEffect(() => {
+		if (isTranslatedInitialized) return; // 이미 초기화되었으면 스킵
 
-    console.log('📝 [NewTranslation Step5] 편집본 iframe 초기 렌더링 시작');
-    const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
+		const iframe = translatedIframeRef.current;
+		if (!iframe || !translatedHtml) return;
 
-    if (iframeDoc) {
-      try {
-        iframeDoc.open();
-        iframeDoc.write(translatedHtml);
-        iframeDoc.close();
-        console.log('✅ [NewTranslation Step5] 편집본 iframe 초기 렌더링 완료');
-      } catch (error) {
-        console.warn('translated iframe write error (ignored):', error);
-      }
+		console.log("📝 [NewTranslation Step5] 편집본 iframe 초기 렌더링 시작");
+		const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
 
-      // 에러 전파 방지
-      if (iframe.contentWindow) {
-        iframe.contentWindow.addEventListener('error', (e) => {
-          e.stopPropagation();
-          e.preventDefault();
-        }, true);
-      }
+		if (iframeDoc) {
+			try {
+				iframeDoc.open();
+				iframeDoc.write(translatedHtml);
+				iframeDoc.close();
+				console.log("✅ [NewTranslation Step5] 편집본 iframe 초기 렌더링 완료");
+			} catch (error) {
+				console.warn("translated iframe write error (ignored):", error);
+			}
 
-        // 초기 HTML을 currentHtmlRef에 저장
-        currentHtmlRef.current = translatedHtml;
-        undoStackRef.current = [];
-        redoStackRef.current = [];
-        setIsTranslatedInitialized(true);
-      }
-  }); // ⭐ Step 3 방식: 의존성 배열 제거하여 translatedHtml 변경 시 트리거되지 않도록 함
+			// 에러 전파 방지
+			if (iframe.contentWindow) {
+				iframe.contentWindow.addEventListener(
+					"error",
+					(e) => {
+						e.stopPropagation();
+						e.preventDefault();
+					},
+					true,
+				);
+			}
 
-  // 편집본 편집 모드 처리 (NewTranslation 전용)
-  useEffect(() => {
-    if (!isTranslatedInitialized || !translatedIframeRef.current) return;
+			// 초기 HTML을 currentHtmlRef에 저장
+			currentHtmlRef.current = translatedHtml;
+			undoStackRef.current = [];
+			redoStackRef.current = [];
+			setIsTranslatedInitialized(true);
+		}
+	}); // ⭐ Step 3 방식: 의존성 배열 제거하여 translatedHtml 변경 시 트리거되지 않도록 함
 
-    const iframe = translatedIframeRef.current;
-    const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-    if (!iframeDoc) return;
+	// 편집본 편집 모드 처리 (NewTranslation 전용)
+	useEffect(() => {
+		if (!isTranslatedInitialized || !translatedIframeRef.current) return;
 
-    console.log('🎨 [NewTranslation Step5] 편집본 편집 모드:', mode);
+		const iframe = translatedIframeRef.current;
+		const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
+		if (!iframeDoc) return;
 
-    // 기존 스타일 제거
-    const existingStyle = iframeDoc.querySelector('#editor-styles');
-    if (existingStyle) existingStyle.remove();
+		console.log("🎨 [NewTranslation Step5] 편집본 편집 모드:", mode);
 
-    // ⚠️ DOM 노드 복제-교체는 하지 않음 (포커스/입력 흐름 유지)
-    // Step 3처럼 스타일과 contentEditable만 변경
+		// 기존 스타일 제거
+		const existingStyle = iframeDoc.querySelector("#editor-styles");
+		if (existingStyle) existingStyle.remove();
 
-    if (mode === 'text') {
-      // 텍스트 편집 모드
-      console.log('📝 [NewTranslation Step5] 텍스트 편집 모드 활성화');
+		// ⚠️ DOM 노드 복제-교체는 하지 않음 (포커스/입력 흐름 유지)
+		// Step 3처럼 스타일과 contentEditable만 변경
 
-      // ⭐ 컴포넌트 클릭 핸들러 제거
-      componentClickHandlersRef.current.forEach((handler, el) => {
-        el.removeEventListener('click', handler, true);
-      });
-      componentClickHandlersRef.current.clear();
+		if (mode === "text") {
+			// 텍스트 편집 모드
+			console.log("📝 [NewTranslation Step5] 텍스트 편집 모드 활성화");
 
-      // ⭐ 모든 요소의 검은색 테두리 제거 (computed style 기반)
-      const allElements = iframeDoc.querySelectorAll('*');
-      allElements.forEach(el => {
-        const htmlEl = el as HTMLElement;
-        const computedStyle = iframeDoc.defaultView?.getComputedStyle(htmlEl);
-        if (computedStyle) {
-          const outline = computedStyle.outline;
-          const outlineColor = computedStyle.outlineColor;
-          if (outline && outline !== 'none' && (
-            outlineColor === 'rgb(0, 0, 0)' || 
-            outlineColor === '#000000' || 
-            outlineColor === 'black' ||
-            outline.includes('3px solid') ||
-            outline.includes('black')
-          )) {
-            htmlEl.style.outline = '';
-            htmlEl.style.outlineOffset = '';
-          }
-        }
-        if (htmlEl.style.outline && (
-          htmlEl.style.outline.includes('3px solid') ||
-          htmlEl.style.outline.includes('black') ||
-          htmlEl.style.outline.includes('#000')
-        )) {
-          htmlEl.style.outline = '';
-          htmlEl.style.outlineOffset = '';
-        }
-      });
+			// ⭐ 컴포넌트 클릭 핸들러 제거
+			componentClickHandlersRef.current.forEach((handler, el) => {
+				el.removeEventListener("click", handler, true);
+			});
+			componentClickHandlersRef.current.clear();
 
-      // ⭐ 컴포넌트 편집 모드 CSS 규칙 제거 또는 오버라이드
-      const editorStyles = iframeDoc.getElementById('editor-styles');
-      if (editorStyles) {
-        editorStyles.remove();
-      }
+			// ⭐ 모든 요소의 검은색 테두리 제거 (computed style 기반)
+			const allElements = iframeDoc.querySelectorAll("*");
+			allElements.forEach((el) => {
+				const htmlEl = el as HTMLElement;
+				const computedStyle = iframeDoc.defaultView?.getComputedStyle(htmlEl);
+				if (computedStyle) {
+					const outline = computedStyle.outline;
+					const outlineColor = computedStyle.outlineColor;
+					if (
+						outline &&
+						outline !== "none" &&
+						(outlineColor === "rgb(0, 0, 0)" ||
+							outlineColor === "#000000" ||
+							outlineColor === "black" ||
+							outline.includes("3px solid") ||
+							outline.includes("black"))
+					) {
+						htmlEl.style.outline = "";
+						htmlEl.style.outlineOffset = "";
+					}
+				}
+				if (
+					htmlEl.style.outline &&
+					(htmlEl.style.outline.includes("3px solid") ||
+						htmlEl.style.outline.includes("black") ||
+						htmlEl.style.outline.includes("#000"))
+				) {
+					htmlEl.style.outline = "";
+					htmlEl.style.outlineOffset = "";
+				}
+			});
 
-      // ⭐ 컴포넌트 선택 스타일을 완전히 무효화하는 CSS 추가
-      const textEditOverrideStyle = iframeDoc.createElement('style');
-      textEditOverrideStyle.id = 'text-edit-override-styles';
-      textEditOverrideStyle.textContent = `
+			// ⭐ 컴포넌트 편집 모드 CSS 규칙 제거 또는 오버라이드
+			const editorStyles = iframeDoc.getElementById("editor-styles");
+			if (editorStyles) {
+				editorStyles.remove();
+			}
+
+			// ⭐ 컴포넌트 선택 스타일을 완전히 무효화하는 CSS 추가
+			const textEditOverrideStyle = iframeDoc.createElement("style");
+			textEditOverrideStyle.id = "text-edit-override-styles";
+			textEditOverrideStyle.textContent = `
         .component-selected,
         [data-component-editable] {
           outline: none !important;
@@ -4931,17 +6189,19 @@ const Step5ParallelEdit: React.FC<{
           outline: none !important;
         }
       `;
-      const existingOverride = iframeDoc.getElementById('text-edit-override-styles');
-      if (existingOverride) {
-        existingOverride.remove();
-      }
-      iframeDoc.head.appendChild(textEditOverrideStyle);
+			const existingOverride = iframeDoc.getElementById(
+				"text-edit-override-styles",
+			);
+			if (existingOverride) {
+				existingOverride.remove();
+			}
+			iframeDoc.head.appendChild(textEditOverrideStyle);
 
-      // ⭐ contentEditable 설정 (cross-element selection을 위해)
-      if (iframeDoc.body) {
-        const style = iframeDoc.createElement('style');
-        style.id = 'text-edit-styles';
-        style.textContent = `
+			// ⭐ contentEditable 설정 (cross-element selection을 위해)
+			if (iframeDoc.body) {
+				const style = iframeDoc.createElement("style");
+				style.id = "text-edit-styles";
+				style.textContent = `
           body, body * {
             -webkit-user-select: text !important;
             -moz-user-select: text !important;
@@ -4950,60 +6210,62 @@ const Step5ParallelEdit: React.FC<{
             cursor: text !important;
           }
         `;
-        const existingStyle = iframeDoc.getElementById('text-edit-styles');
-        if (existingStyle) {
-          existingStyle.remove();
-        }
-        iframeDoc.head.appendChild(style);
-        
-        iframeDoc.body.contentEditable = 'true';
-        iframeDoc.body.style.cursor = 'text';
-        
-        const textElements = iframeDoc.querySelectorAll('p, h1, h2, h3, h4, h5, h6, span, a, li, td, th, label, button, div, section, article');
-      textElements.forEach(el => {
-          const htmlEl = el as HTMLElement;
-          if (!['SCRIPT', 'STYLE', 'NOSCRIPT'].includes(htmlEl.tagName)) {
-            htmlEl.contentEditable = 'true';
-            htmlEl.style.cursor = 'text';
-            htmlEl.style.outline = 'none';
-          }
-        });
-        
-        // ⭐ currentHtmlRef 초기화 (텍스트 편집 모드)
-        const initialHtml = iframeDoc.documentElement.outerHTML;
-        currentHtmlRef.current = initialHtml;
-        console.log('💾 Step 5 텍스트 편집 모드 currentHtmlRef 초기화 완료');
-      }
+				const existingStyle = iframeDoc.getElementById("text-edit-styles");
+				if (existingStyle) {
+					existingStyle.remove();
+				}
+				iframeDoc.head.appendChild(style);
 
-      // ⭐ 링크 클릭 방지 (다른 사이트로 이동 방지)
-      // 기존 링크 클릭 핸들러 제거
-      linkClickHandlersRef.current.forEach((handler, link) => {
-        link.removeEventListener('click', handler, true);
-      });
-      linkClickHandlersRef.current.clear();
-      
-      // 모든 링크에 클릭 방지 핸들러 추가
-      const allLinks = iframeDoc.querySelectorAll('a');
-      const preventLinkNavigation = (e: Event) => {
-        e.preventDefault();
-        e.stopPropagation();
-        e.stopImmediatePropagation();
-        return false;
-      };
-      
-      allLinks.forEach(link => {
-        const htmlLink = link as HTMLElement;
-        htmlLink.addEventListener('click', preventLinkNavigation, true);
-        linkClickHandlersRef.current.set(htmlLink, preventLinkNavigation);
-        // 링크 스타일 변경 (편집 모드임을 표시)
-        htmlLink.style.cursor = 'text';
-        htmlLink.style.textDecoration = 'none';
-      });
-      
-      // 링크 스타일 CSS 추가
-      const linkStyle = iframeDoc.createElement('style');
-      linkStyle.id = 'text-edit-link-style';
-      linkStyle.textContent = `
+				iframeDoc.body.contentEditable = "true";
+				iframeDoc.body.style.cursor = "text";
+
+				const textElements = iframeDoc.querySelectorAll(
+					"p, h1, h2, h3, h4, h5, h6, span, a, li, td, th, label, button, div, section, article",
+				);
+				textElements.forEach((el) => {
+					const htmlEl = el as HTMLElement;
+					if (!["SCRIPT", "STYLE", "NOSCRIPT"].includes(htmlEl.tagName)) {
+						htmlEl.contentEditable = "true";
+						htmlEl.style.cursor = "text";
+						htmlEl.style.outline = "none";
+					}
+				});
+
+				// ⭐ currentHtmlRef 초기화 (텍스트 편집 모드)
+				const initialHtml = iframeDoc.documentElement.outerHTML;
+				currentHtmlRef.current = initialHtml;
+				console.log("💾 Step 5 텍스트 편집 모드 currentHtmlRef 초기화 완료");
+			}
+
+			// ⭐ 링크 클릭 방지 (다른 사이트로 이동 방지)
+			// 기존 링크 클릭 핸들러 제거
+			linkClickHandlersRef.current.forEach((handler, link) => {
+				link.removeEventListener("click", handler, true);
+			});
+			linkClickHandlersRef.current.clear();
+
+			// 모든 링크에 클릭 방지 핸들러 추가
+			const allLinks = iframeDoc.querySelectorAll("a");
+			const preventLinkNavigation = (e: Event) => {
+				e.preventDefault();
+				e.stopPropagation();
+				e.stopImmediatePropagation();
+				return false;
+			};
+
+			allLinks.forEach((link) => {
+				const htmlLink = link as HTMLElement;
+				htmlLink.addEventListener("click", preventLinkNavigation, true);
+				linkClickHandlersRef.current.set(htmlLink, preventLinkNavigation);
+				// 링크 스타일 변경 (편집 모드임을 표시)
+				htmlLink.style.cursor = "text";
+				htmlLink.style.textDecoration = "none";
+			});
+
+			// 링크 스타일 CSS 추가
+			const linkStyle = iframeDoc.createElement("style");
+			linkStyle.id = "text-edit-link-style";
+			linkStyle.textContent = `
         a {
           cursor: text !important;
           pointer-events: auto !important;
@@ -5012,137 +6274,150 @@ const Step5ParallelEdit: React.FC<{
           text-decoration: underline !important;
         }
       `;
-      const existingLinkStyle = iframeDoc.getElementById('text-edit-link-style');
-      if (existingLinkStyle) {
-        existingLinkStyle.remove();
-      }
-      iframeDoc.head.appendChild(linkStyle);
+			const existingLinkStyle = iframeDoc.getElementById(
+				"text-edit-link-style",
+			);
+			if (existingLinkStyle) {
+				existingLinkStyle.remove();
+			}
+			iframeDoc.head.appendChild(linkStyle);
 
-      // ⭐ Step 3와 동일한 방식으로 키보드 이벤트 처리
-      const handleKeyDown = (e: KeyboardEvent) => {
-        // Cmd+Z (Mac) 또는 Ctrl+Z (Windows) - Undo
-        if ((e.ctrlKey || e.metaKey) && e.key === 'z' && !e.shiftKey) {
-          e.preventDefault();
-          e.stopImmediatePropagation();
-          iframeDoc.execCommand('undo', false);
-          const updatedHtml = iframeDoc.documentElement.outerHTML;
-          currentHtmlRef.current = updatedHtml;
-          onTranslatedChange(updatedHtml);
-          console.log('↩️ Undo (STEP 5 텍스트 편집)');
-        }
-        // Cmd+Shift+Z (Mac) 또는 Ctrl+Y (Windows) - Redo
-        else if ((e.ctrlKey || e.metaKey) && (e.key === 'y' || (e.key === 'z' && e.shiftKey))) {
-          e.preventDefault();
-          e.stopImmediatePropagation();
-          iframeDoc.execCommand('redo', false);
-          const updatedHtml = iframeDoc.documentElement.outerHTML;
-          currentHtmlRef.current = updatedHtml;
-          onTranslatedChange(updatedHtml);
-          console.log('↪️ Redo (STEP 5 텍스트 편집)');
-        }
-        
-        // ⭐ 백스페이스 키 처리 (브라우저 기본 동작 허용) - Step 3와 동일
-        if (e.key === 'Backspace' && !e.ctrlKey && !e.metaKey && !e.altKey) {
-          // 브라우저가 알아서 처리하게 놔둠
-          console.log('⌫ 백스페이스 (STEP 5 텍스트 편집)');
-        }
-      };
-      
-      // 기존 리스너 제거
-      if (iframeKeydownHandlerRef.current && iframeDoc) {
-        iframeDoc.removeEventListener('keydown', iframeKeydownHandlerRef.current, true);
-      }
-      // 새 리스너 등록 및 저장
-      iframeKeydownHandlerRef.current = handleKeyDown;
-      iframeDoc.addEventListener('keydown', handleKeyDown, true);
-      console.log('✅ Step 5 텍스트 모드 키보드 단축키 등록 완료');
-      
-      // ⚡ 최적화: input 이벤트 디바운스 (메모리 사용 감소)
-      let inputTimeoutId: NodeJS.Timeout | null = null;
-      const handleInput = () => {
-        // 기존 타이머 취소
-        if (inputTimeoutId) {
-          clearTimeout(inputTimeoutId);
-        }
-        
-        // 500ms 후에 HTML 추출 (디바운스)
-        inputTimeoutId = setTimeout(() => {
-          const updatedHtml = iframeDoc.documentElement.outerHTML;
-          onTranslatedChange(updatedHtml);
-          inputTimeoutId = null;
-        }, 500);
-      };
-      iframeDoc.body.addEventListener('input', handleInput);
+			// ⭐ Step 3와 동일한 방식으로 키보드 이벤트 처리
+			const handleKeyDown = (e: KeyboardEvent) => {
+				// Cmd+Z (Mac) 또는 Ctrl+Z (Windows) - Undo
+				if ((e.ctrlKey || e.metaKey) && e.key === "z" && !e.shiftKey) {
+					e.preventDefault();
+					e.stopImmediatePropagation();
+					iframeDoc.execCommand("undo", false);
+					const updatedHtml = iframeDoc.documentElement.outerHTML;
+					currentHtmlRef.current = updatedHtml;
+					onTranslatedChange(updatedHtml);
+					console.log("↩️ Undo (STEP 5 텍스트 편집)");
+				}
+				// Cmd+Shift+Z (Mac) 또는 Ctrl+Y (Windows) - Redo
+				else if (
+					(e.ctrlKey || e.metaKey) &&
+					(e.key === "y" || (e.key === "z" && e.shiftKey))
+				) {
+					e.preventDefault();
+					e.stopImmediatePropagation();
+					iframeDoc.execCommand("redo", false);
+					const updatedHtml = iframeDoc.documentElement.outerHTML;
+					currentHtmlRef.current = updatedHtml;
+					onTranslatedChange(updatedHtml);
+					console.log("↪️ Redo (STEP 5 텍스트 편집)");
+				}
 
-    } else if (mode === 'component') {
-      // 컴포넌트 편집 모드
-      console.log('🧩 [NewTranslation Step5] 컴포넌트 편집 모드 활성화');
+				// ⭐ 백스페이스 키 처리 (브라우저 기본 동작 허용) - Step 3와 동일
+				if (e.key === "Backspace" && !e.ctrlKey && !e.metaKey && !e.altKey) {
+					// 브라우저가 알아서 처리하게 놔둠
+					console.log("⌫ 백스페이스 (STEP 5 텍스트 편집)");
+				}
+			};
 
-      // ⭐ 1. 브라우저의 텍스트 selection clear
-      const selection = iframeDoc.defaultView?.getSelection();
-      if (selection) {
-        selection.removeAllRanges();
-      }
-      
-      // ⭐ 2. selectedElements state 초기화
-      setSelectedElements([]);
-      
-      // ⭐ 3. 모든 .component-selected 클래스 제거 및 기존 핸들러 제거
-      const existingSelected = iframeDoc.querySelectorAll('.component-selected');
-      existingSelected.forEach(el => {
-        const htmlEl = el as HTMLElement;
-        htmlEl.classList.remove('component-selected');
-        htmlEl.style.outline = '';
-        htmlEl.style.boxShadow = '';
-        htmlEl.style.backgroundColor = '';
-        htmlEl.style.outlineOffset = '';
-        
-        // 기존 핸들러 제거
-        const handler = componentClickHandlersRef.current.get(htmlEl);
-        if (handler) {
-          htmlEl.removeEventListener('click', handler, true);
-          componentClickHandlersRef.current.delete(htmlEl);
-        }
-      });
-      
-      // 모든 컴포넌트 클릭 핸들러 제거
-      componentClickHandlersRef.current.forEach((handler, el) => {
-        el.removeEventListener('click', handler, true);
-      });
-      componentClickHandlersRef.current.clear();
+			// 기존 리스너 제거
+			if (iframeKeydownHandlerRef.current && iframeDoc) {
+				iframeDoc.removeEventListener(
+					"keydown",
+					iframeKeydownHandlerRef.current,
+					true,
+				);
+			}
+			// 새 리스너 등록 및 저장
+			iframeKeydownHandlerRef.current = handleKeyDown;
+			iframeDoc.addEventListener("keydown", handleKeyDown, true);
+			console.log("✅ Step 5 텍스트 모드 키보드 단축키 등록 완료");
 
-      // ⭐ 4. 텍스트 편집 모드 스타일 태그 제거
-      const textEditOverrideStyle = iframeDoc.getElementById('text-edit-override-styles');
-      if (textEditOverrideStyle) {
-        textEditOverrideStyle.remove();
-      }
-      const textEditStyle = iframeDoc.getElementById('text-edit-styles');
-      if (textEditStyle) {
-        textEditStyle.remove();
-      }
-      
-      // ⭐ 5. 링크 클릭 핸들러 제거
-      linkClickHandlersRef.current.forEach((handler, link) => {
-        link.removeEventListener('click', handler, true);
-      });
-      linkClickHandlersRef.current.clear();
-      
-      // 링크 스타일 태그 제거
-      const linkStyle = iframeDoc.getElementById('text-edit-link-style');
-      if (linkStyle) {
-        linkStyle.remove();
-      }
+			// ⚡ 최적화: input 이벤트 디바운스 (메모리 사용 감소)
+			let inputTimeoutId: NodeJS.Timeout | null = null;
+			const handleInput = () => {
+				// 기존 타이머 취소
+				if (inputTimeoutId) {
+					clearTimeout(inputTimeoutId);
+				}
 
-      // contentEditable 비활성화
-      const allEditableElements = iframeDoc.querySelectorAll('[contenteditable]');
-      allEditableElements.forEach(el => {
-        (el as HTMLElement).contentEditable = 'false';
-      });
+				// 500ms 후에 HTML 추출 (디바운스)
+				inputTimeoutId = setTimeout(() => {
+					const updatedHtml = iframeDoc.documentElement.outerHTML;
+					onTranslatedChange(updatedHtml);
+					inputTimeoutId = null;
+				}, 500);
+			};
+			iframeDoc.body.addEventListener("input", handleInput);
+		} else if (mode === "component") {
+			// 컴포넌트 편집 모드
+			console.log("🧩 [NewTranslation Step5] 컴포넌트 편집 모드 활성화");
 
-      // 스타일 추가
-      const style = iframeDoc.createElement('style');
-      style.id = 'editor-styles';
-      style.textContent = `
+			// ⭐ 1. 브라우저의 텍스트 selection clear
+			const selection = iframeDoc.defaultView?.getSelection();
+			if (selection) {
+				selection.removeAllRanges();
+			}
+
+			// ⭐ 2. selectedElements state 초기화
+			setSelectedElements([]);
+
+			// ⭐ 3. 모든 .component-selected 클래스 제거 및 기존 핸들러 제거
+			const existingSelected = iframeDoc.querySelectorAll(
+				".component-selected",
+			);
+			existingSelected.forEach((el) => {
+				const htmlEl = el as HTMLElement;
+				htmlEl.classList.remove("component-selected");
+				htmlEl.style.outline = "";
+				htmlEl.style.boxShadow = "";
+				htmlEl.style.backgroundColor = "";
+				htmlEl.style.outlineOffset = "";
+
+				// 기존 핸들러 제거
+				const handler = componentClickHandlersRef.current.get(htmlEl);
+				if (handler) {
+					htmlEl.removeEventListener("click", handler, true);
+					componentClickHandlersRef.current.delete(htmlEl);
+				}
+			});
+
+			// 모든 컴포넌트 클릭 핸들러 제거
+			componentClickHandlersRef.current.forEach((handler, el) => {
+				el.removeEventListener("click", handler, true);
+			});
+			componentClickHandlersRef.current.clear();
+
+			// ⭐ 4. 텍스트 편집 모드 스타일 태그 제거
+			const textEditOverrideStyle = iframeDoc.getElementById(
+				"text-edit-override-styles",
+			);
+			if (textEditOverrideStyle) {
+				textEditOverrideStyle.remove();
+			}
+			const textEditStyle = iframeDoc.getElementById("text-edit-styles");
+			if (textEditStyle) {
+				textEditStyle.remove();
+			}
+
+			// ⭐ 5. 링크 클릭 핸들러 제거
+			linkClickHandlersRef.current.forEach((handler, link) => {
+				link.removeEventListener("click", handler, true);
+			});
+			linkClickHandlersRef.current.clear();
+
+			// 링크 스타일 태그 제거
+			const linkStyle = iframeDoc.getElementById("text-edit-link-style");
+			if (linkStyle) {
+				linkStyle.remove();
+			}
+
+			// contentEditable 비활성화
+			const allEditableElements =
+				iframeDoc.querySelectorAll("[contenteditable]");
+			allEditableElements.forEach((el) => {
+				(el as HTMLElement).contentEditable = "false";
+			});
+
+			// 스타일 추가
+			const style = iframeDoc.createElement("style");
+			style.id = "editor-styles";
+			style.textContent = `
         div[data-component-editable],
         section[data-component-editable],
         article[data-component-editable],
@@ -5200,2530 +6475,3176 @@ const Step5ParallelEdit: React.FC<{
           to { opacity: 1; transform: translateY(0); }
         }
       `;
-      iframeDoc.head.appendChild(style);
+			iframeDoc.head.appendChild(style);
 
-      // 클릭 가능한 컴포넌트 표시 (a 태그도 포함)
-      const componentElements = iframeDoc.querySelectorAll('div, section, article, header, footer, main, aside, nav, p, h1, h2, h3, h4, h5, h6, a');
+			// 클릭 가능한 컴포넌트 표시 (a 태그도 포함)
+			const componentElements = iframeDoc.querySelectorAll(
+				"div, section, article, header, footer, main, aside, nav, p, h1, h2, h3, h4, h5, h6, a",
+			);
 
-      // Cmd+Z / Cmd+Y 지원 (컴포넌트 편집 모드) - 커스텀 Undo Stack 사용
-      const handleKeydown = (e: KeyboardEvent) => {
-        console.log('🔑 Step 5 iframe 키 감지:', e.key, 'ctrl:', e.ctrlKey, 'meta:', e.metaKey, 'shift:', e.shiftKey);
-        // Cmd+Z (Mac) 또는 Ctrl+Z (Windows) - Undo
-        if ((e.ctrlKey || e.metaKey) && e.key === 'z' && !e.shiftKey) {
-          e.preventDefault(); // ⭐ 항상 preventDefault 호출 (undo stack이 비어있어도 시스템 단축키 방지)
-          e.stopImmediatePropagation();
-          
-          if (undoStackRef.current.length > 0) {
-            console.log('↩️ Undo (컴포넌트 편집) - stack:', undoStackRef.current.length);
-            
-            // 현재 상태를 redo stack에 저장
-            redoStackRef.current.push(currentHtmlRef.current);
-            
-            // undo stack에서 이전 상태 복원
-            const previousHtml = undoStackRef.current.pop()!;
-            currentHtmlRef.current = previousHtml;
-            
-            // iframe에 HTML 복원
-            iframeDoc.open();
-            iframeDoc.write(previousHtml);
-            iframeDoc.close();
-            
-            onTranslatedChange(previousHtml);
-            setSelectedElements([]);
-            
-            // ⭐ translatedHtml 의존성 배열에 추가되어 useEffect가 자동으로 재실행됨
-            // iframe에 포커스를 주어 키보드 이벤트가 계속 작동하도록 함
-            setTimeout(() => {
-              const newIframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-              if (newIframeDoc?.body) {
-                newIframeDoc.body.setAttribute('tabindex', '-1');
-                newIframeDoc.body.focus();
-              }
-            }, 50);
-          } else {
-            console.log('⚠️ Undo stack이 비어있습니다 (STEP 5)');
-            // ⭐ undo stack이 비어있어도 preventDefault는 이미 호출됨 (시스템 단축키 방지)
-          }
-        }
-        // Cmd+Shift+Z (Mac) 또는 Ctrl+Y (Windows) - Redo
-        else if ((e.ctrlKey || e.metaKey) && (e.key === 'y' || (e.key === 'z' && e.shiftKey))) {
-          e.preventDefault(); // ⭐ 항상 preventDefault 호출 (redo stack이 비어있어도 시스템 단축키 방지)
-          e.stopImmediatePropagation();
-          
-          if (redoStackRef.current.length > 0) {
-            console.log('↪️ Redo (컴포넌트 편집 STEP 5) - stack:', redoStackRef.current.length);
-            
-            // 현재 상태를 undo stack에 저장
-            undoStackRef.current.push(currentHtmlRef.current);
-            
-            // redo stack에서 다음 상태 복원
-            const nextHtml = redoStackRef.current.pop()!;
-            currentHtmlRef.current = nextHtml;
-            
-            // iframe에 HTML 복원
-            iframeDoc.open();
-            iframeDoc.write(nextHtml);
-            iframeDoc.close();
-            
-            onTranslatedChange(nextHtml);
-            setSelectedElements([]);
-            
-            // ⭐ translatedHtml 의존성 배열에 추가되어 useEffect가 자동으로 재실행됨
-            // iframe에 포커스를 주어 키보드 이벤트가 계속 작동하도록 함
-            setTimeout(() => {
-              const newIframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-              if (newIframeDoc?.body) {
-                newIframeDoc.body.setAttribute('tabindex', '-1');
-                newIframeDoc.body.focus();
-              }
-            }, 50);
-          } else {
-            console.log('⚠️ Redo stack이 비어있습니다');
-            // ⭐ redo stack이 비어있어도 preventDefault는 이미 호출됨 (시스템 단축키 방지)
-          }
-        }
-      };
-      
-      // 기존 iframe 리스너 제거
-      if (iframeKeydownHandlerRef.current && iframeDoc) {
-        iframeDoc.removeEventListener('keydown', iframeKeydownHandlerRef.current, true);
-      }
-      // 새 iframe 리스너 등록 및 저장
-      iframeKeydownHandlerRef.current = handleKeydown;
-      iframeDoc.addEventListener('keydown', handleKeydown, true);
-      console.log('✅ Step 5 컴포넌트 모드 키보드 단축키 등록 완료 (iframe)');
-      
-      // 부모 window에서도 이벤트 잡기 (iframe 포커스가 없을 때 대비)
-      const handleWindowKeydown = (e: KeyboardEvent) => {
-        console.log('🔑 Step 5 window 키 감지:', e.key, 'ctrl:', e.ctrlKey, 'meta:', e.metaKey, 'shift:', e.shiftKey);
-        
-        // Ctrl+Z (되돌리기)
-        if ((e.ctrlKey || e.metaKey) && e.key === 'z' && !e.shiftKey) {
-          e.preventDefault();
-          e.stopImmediatePropagation();
-          
-          if (undoStackRef.current.length > 0 && iframeDoc) {
-            console.log('↩️ Undo (Step 5 컴포넌트 편집 - window)');
-            
-            redoStackRef.current.push(currentHtmlRef.current);
-            const previousHtml = undoStackRef.current.pop()!;
-            currentHtmlRef.current = previousHtml;
-            
-            iframeDoc.open();
-            iframeDoc.write(previousHtml);
-            iframeDoc.close();
-            
-            onTranslatedChange(previousHtml);
-            setSelectedElements([]);
-            
-            // ⭐ translatedHtml 의존성 배열에 추가되어 useEffect가 자동으로 재실행됨
-            // iframe에 포커스를 주어 키보드 이벤트가 계속 작동하도록 함
-            setTimeout(() => {
-              const newIframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-              if (newIframeDoc?.body) {
-                newIframeDoc.body.setAttribute('tabindex', '-1');
-                newIframeDoc.body.focus();
-              }
-            }, 50);
-          }
-        }
-        // Ctrl+Shift+Z 또는 Ctrl+Y (다시 실행)
-        else if ((e.ctrlKey || e.metaKey) && (e.key === 'y' || (e.key === 'z' && e.shiftKey))) {
-          e.preventDefault();
-          e.stopImmediatePropagation();
-          
-          if (redoStackRef.current.length > 0 && iframeDoc) {
-            console.log('↪️ Redo (Step 5 컴포넌트 편집 - window)');
-            
-            undoStackRef.current.push(currentHtmlRef.current);
-            const nextHtml = redoStackRef.current.pop()!;
-            currentHtmlRef.current = nextHtml;
-            
-            iframeDoc.open();
-            iframeDoc.write(nextHtml);
-            iframeDoc.close();
-            
-            onTranslatedChange(nextHtml);
-            setSelectedElements([]);
-            
-            // ⭐ translatedHtml 의존성 배열에 추가되어 useEffect가 자동으로 재실행됨
-            // iframe에 포커스를 주어 키보드 이벤트가 계속 작동하도록 함
-            setTimeout(() => {
-              const newIframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-              if (newIframeDoc?.body) {
-                newIframeDoc.body.setAttribute('tabindex', '-1');
-                newIframeDoc.body.focus();
-              }
-            }, 50);
-          }
-        }
-      };
-      
-      // 기존 window 리스너 제거
-      if (windowKeydownHandlerRef.current) {
-        window.removeEventListener('keydown', windowKeydownHandlerRef.current, true);
-      }
-      // 새 window 리스너 등록 및 저장
-      windowKeydownHandlerRef.current = handleWindowKeydown;
-      window.addEventListener('keydown', handleWindowKeydown, true);
-      console.log('✅ Step 5 window 키보드 이벤트 리스너 등록 완료');
+			// Cmd+Z / Cmd+Y 지원 (컴포넌트 편집 모드) - 커스텀 Undo Stack 사용
+			const handleKeydown = (e: KeyboardEvent) => {
+				console.log(
+					"🔑 Step 5 iframe 키 감지:",
+					e.key,
+					"ctrl:",
+					e.ctrlKey,
+					"meta:",
+					e.metaKey,
+					"shift:",
+					e.shiftKey,
+				);
+				// Cmd+Z (Mac) 또는 Ctrl+Z (Windows) - Undo
+				if ((e.ctrlKey || e.metaKey) && e.key === "z" && !e.shiftKey) {
+					e.preventDefault(); // ⭐ 항상 preventDefault 호출 (undo stack이 비어있어도 시스템 단축키 방지)
+					e.stopImmediatePropagation();
 
-      // 컴포넌트 클릭 핸들러 (다중 선택 + 토글)
-      const handleComponentClick = (e: Event) => {
-        e.stopPropagation();
-        e.preventDefault();
+					if (undoStackRef.current.length > 0) {
+						console.log(
+							"↩️ Undo (컴포넌트 편집) - stack:",
+							undoStackRef.current.length,
+						);
 
-        const target = e.target as HTMLElement;
-        if (!target || ['SCRIPT', 'STYLE', 'NOSCRIPT', 'HTML', 'HEAD', 'BODY'].includes(target.tagName)) return;
+						// 현재 상태를 redo stack에 저장
+						redoStackRef.current.push(currentHtmlRef.current);
 
-        // ⭐ 링크 내부 요소를 클릭한 경우 가장 가까운 편집 가능한 요소 찾기
-        const editableElement = target.closest('[data-component-editable]') as HTMLElement;
-        if (!editableElement) {
-          console.log('⚠️ 편집 가능한 요소를 찾을 수 없습니다:', target.tagName);
-          return;
-        }
+						// undo stack에서 이전 상태 복원
+						const previousHtml = undoStackRef.current.pop()!;
+						currentHtmlRef.current = previousHtml;
 
-        const isSelected = editableElement.classList.contains('component-selected');
+						// iframe에 HTML 복원
+						iframeDoc.open();
+						iframeDoc.write(previousHtml);
+						iframeDoc.close();
 
-        if (isSelected) {
-          editableElement.classList.remove('component-selected');
-          editableElement.style.outline = '1px dashed #C0C0C0';
-          editableElement.style.boxShadow = 'none';
-          setSelectedElements(prev => prev.filter(el => el !== editableElement));
-        } else {
-          editableElement.classList.add('component-selected');
-          editableElement.style.outline = '3px solid #000000';
-          editableElement.style.boxShadow = 'none';
-          setSelectedElements(prev => [...prev, editableElement]);
-        }
-      };
+						onTranslatedChange(previousHtml);
+						setSelectedElements([]);
 
-      // ⭐ Step 3와 동일한 방식으로 이벤트 리스너 등록 (capture phase)
-      componentElements.forEach((el) => {
-        if (el.tagName && !['SCRIPT', 'STYLE', 'NOSCRIPT', 'HTML', 'HEAD', 'BODY'].includes(el.tagName)) {
-          const htmlEl = el as HTMLElement;
-          htmlEl.setAttribute('data-component-editable', 'true');
-          htmlEl.style.cursor = 'pointer';
-          htmlEl.style.outline = '1px dashed #C0C0C0';
-          
-          // 기존 핸들러가 있으면 제거
-          const existingHandler = componentClickHandlersRef.current.get(htmlEl);
-          if (existingHandler) {
-            htmlEl.removeEventListener('click', existingHandler, true);
-          }
-          
-          // 클릭 이벤트 리스너 추가 및 저장 (capture phase)
-          htmlEl.addEventListener('click', handleComponentClick, true);
-          componentClickHandlersRef.current.set(htmlEl, handleComponentClick);
-        }
-      });
-      
-      // ⭐ 링크 클릭 방지 (다른 사이트로 이동 방지)
-      const allLinks = iframeDoc.querySelectorAll('a');
-      const preventLinkNavigation = (e: Event) => {
-        e.preventDefault();
-        e.stopPropagation();
-        e.stopImmediatePropagation();
-        return false;
-      };
-      
-      allLinks.forEach(link => {
-        const htmlLink = link as HTMLElement;
-        // 기존 핸들러가 있으면 제거
-        const existingLinkHandler = linkClickHandlersRef.current.get(htmlLink);
-        if (existingLinkHandler) {
-          htmlLink.removeEventListener('click', existingLinkHandler, true);
-        }
-        htmlLink.addEventListener('click', preventLinkNavigation, true);
-        linkClickHandlersRef.current.set(htmlLink, preventLinkNavigation);
-        htmlLink.style.cursor = 'pointer';
-      });
-      
-      console.log('✅ Step 5 컴포넌트 클릭 리스너 추가 완료:', componentElements.length, '개');
-      console.log('✅ Step 5 링크 클릭 방지 핸들러 추가 완료:', allLinks.length, '개');
-      
-      console.log('✅ Step 5 컴포넌트 편집 모드 링크 클릭 방지 핸들러 추가 완료:', allLinks.length, '개');
-    }
+						// ⭐ translatedHtml 의존성 배열에 추가되어 useEffect가 자동으로 재실행됨
+						// iframe에 포커스를 주어 키보드 이벤트가 계속 작동하도록 함
+						setTimeout(() => {
+							const newIframeDoc =
+								iframe.contentDocument || iframe.contentWindow?.document;
+							if (newIframeDoc?.body) {
+								newIframeDoc.body.setAttribute("tabindex", "-1");
+								newIframeDoc.body.focus();
+							}
+						}, 50);
+					} else {
+						console.log("⚠️ Undo stack이 비어있습니다 (STEP 5)");
+						// ⭐ undo stack이 비어있어도 preventDefault는 이미 호출됨 (시스템 단축키 방지)
+					}
+				}
+				// Cmd+Shift+Z (Mac) 또는 Ctrl+Y (Windows) - Redo
+				else if (
+					(e.ctrlKey || e.metaKey) &&
+					(e.key === "y" || (e.key === "z" && e.shiftKey))
+				) {
+					e.preventDefault(); // ⭐ 항상 preventDefault 호출 (redo stack이 비어있어도 시스템 단축키 방지)
+					e.stopImmediatePropagation();
 
-    return () => {
-      console.log('🧹 Step 5 cleanup: 이벤트 리스너 제거');
-      // window 리스너 제거
-      if (windowKeydownHandlerRef.current) {
-        window.removeEventListener('keydown', windowKeydownHandlerRef.current, true);
-        console.log('✅ Step 5 window 키보드 리스너 제거');
-      }
-      // iframe 리스너는 모드 전환 시 자동으로 제거됨 (DOM이 재설정되므로)
-    };
-  }, [mode, isTranslatedInitialized, translatedHtml]); // ⭐ translatedHtml 추가하여 undo/redo 후 자동 재활성화
+					if (redoStackRef.current.length > 0) {
+						console.log(
+							"↪️ Redo (컴포넌트 편집 STEP 5) - stack:",
+							redoStackRef.current.length,
+						);
 
-  // 컴포넌트 삭제
-  const handleDelete = () => {
-    if (!translatedIframeRef.current) return;
+						// 현재 상태를 undo stack에 저장
+						undoStackRef.current.push(currentHtmlRef.current);
 
-    const iframe = translatedIframeRef.current;
-    const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-    if (!iframeDoc) return;
+						// redo stack에서 다음 상태 복원
+						const nextHtml = redoStackRef.current.pop()!;
+						currentHtmlRef.current = nextHtml;
 
-    console.log('🗑️ 선택된 요소 삭제 중:', selectedElements.length, '개');
+						// iframe에 HTML 복원
+						iframeDoc.open();
+						iframeDoc.write(nextHtml);
+						iframeDoc.close();
 
-    // 삭제 전 현재 상태를 undo stack에 저장
-    const currentHtml = iframeDoc.documentElement.outerHTML;
-    if (currentHtmlRef.current && currentHtmlRef.current !== currentHtml) {
-      undoStackRef.current.push(currentHtmlRef.current);
-      redoStackRef.current = []; // 새 작업 시 redo stack 초기화
-      console.log('💾 Undo stack에 저장 (STEP 5 삭제 전):', undoStackRef.current.length);
-    }
+						onTranslatedChange(nextHtml);
+						setSelectedElements([]);
 
-    selectedElements.forEach(el => {
-      if (el.parentNode) {
-        el.parentNode.removeChild(el);
-      }
-    });
+						// ⭐ translatedHtml 의존성 배열에 추가되어 useEffect가 자동으로 재실행됨
+						// iframe에 포커스를 주어 키보드 이벤트가 계속 작동하도록 함
+						setTimeout(() => {
+							const newIframeDoc =
+								iframe.contentDocument || iframe.contentWindow?.document;
+							if (newIframeDoc?.body) {
+								newIframeDoc.body.setAttribute("tabindex", "-1");
+								newIframeDoc.body.focus();
+							}
+						}, 50);
+					} else {
+						console.log("⚠️ Redo stack이 비어있습니다");
+						// ⭐ redo stack이 비어있어도 preventDefault는 이미 호출됨 (시스템 단축키 방지)
+					}
+				}
+			};
 
-    const newHtml = iframeDoc.documentElement.outerHTML;
-    currentHtmlRef.current = newHtml;
-    onTranslatedChange(newHtml);
-    setSelectedElements([]);
+			// 기존 iframe 리스너 제거
+			if (iframeKeydownHandlerRef.current && iframeDoc) {
+				iframeDoc.removeEventListener(
+					"keydown",
+					iframeKeydownHandlerRef.current,
+					true,
+				);
+			}
+			// 새 iframe 리스너 등록 및 저장
+			iframeKeydownHandlerRef.current = handleKeydown;
+			iframeDoc.addEventListener("keydown", handleKeydown, true);
+			console.log("✅ Step 5 컴포넌트 모드 키보드 단축키 등록 완료 (iframe)");
 
-    console.log('✅ 삭제 완료 (STEP 5)');
-    
-    // ⭐ 삭제 후 iframe에 포커스를 주어 키보드 단축키가 바로 작동하도록 함
-    setTimeout(() => {
-      // body에 tabIndex 설정하여 포커스 가능하게 만들기
-      if (iframeDoc.body) {
-        iframeDoc.body.setAttribute('tabindex', '-1');
-        iframeDoc.body.focus();
-      }
-      if (iframe.contentWindow) {
-        iframe.contentWindow.focus();
-      }
-      iframe.focus();
-      console.log('🎯 Step 5 iframe에 포커스 설정');
-    }, 100);
-  };
+			// 부모 window에서도 이벤트 잡기 (iframe 포커스가 없을 때 대비)
+			const handleWindowKeydown = (e: KeyboardEvent) => {
+				console.log(
+					"🔑 Step 5 window 키 감지:",
+					e.key,
+					"ctrl:",
+					e.ctrlKey,
+					"meta:",
+					e.metaKey,
+					"shift:",
+					e.shiftKey,
+				);
 
-  // 패널 정의
-  const panels = [
-    { id: 'crawled', title: '원본 웹사이트', ref: crawledIframeRef, editable: false },
-    { id: 'selected', title: 'Version 0', ref: selectedIframeRef, editable: false },
-    { id: 'translated', title: 'Version 1 (AI 초벌 번역)', ref: translatedIframeRef, editable: true },
-  ];
+				// Ctrl+Z (되돌리기)
+				if ((e.ctrlKey || e.metaKey) && e.key === "z" && !e.shiftKey) {
+					e.preventDefault();
+					e.stopImmediatePropagation();
 
-  return (
-    <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
-      {/* 3개 패널 */}
-      <div style={{ display: 'flex', height: '100%', gap: '4px', padding: '4px' }}>
-        {panels.map(panel => {
-          const isCollapsed = collapsedPanels.has(panel.id);
-          const isFullscreen = fullscreenPanel === panel.id;
-          const visiblePanels = panels.filter(p => !collapsedPanels.has(p.id));
-          const hasFullscreen = fullscreenPanel !== null;
-          const isHidden = hasFullscreen && !isFullscreen;
+					if (undoStackRef.current.length > 0 && iframeDoc) {
+						console.log("↩️ Undo (Step 5 컴포넌트 편집 - window)");
 
-          if (isHidden) return null; // 전체화면 모드에서 다른 패널 숨김
+						redoStackRef.current.push(currentHtmlRef.current);
+						const previousHtml = undoStackRef.current.pop()!;
+						currentHtmlRef.current = previousHtml;
 
-          return (
-            <div
-              key={panel.id}
-              style={{
-                flex: isCollapsed ? '0 0 0' : isFullscreen ? '1' : `1 1 ${100 / visiblePanels.length}%`,
-                display: isCollapsed ? 'none' : 'flex',
-                flexDirection: 'column',
-                transition: 'flex 0.2s ease',
-                minWidth: isCollapsed ? '0' : '200px',
-              }}
-            >
-              {/* 패널 헤더 */}
-              <div
-                style={{
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  alignItems: 'center',
-                  padding: '8px 12px',
-                  backgroundColor: '#D3D3D3',
-                  borderRadius: '4px 4px 0 0',
-                  cursor: 'default',
-                  height: '36px',
-                }}
-              >
-                <span style={{ fontSize: '12px', fontWeight: 600, color: '#000000' }}>
-                  {panel.title}
-                </span>
-                <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                  <button
-                    onClick={() => toggleFullscreen(panel.id)}
-                    style={{
-                      padding: '4px 8px',
-                      fontSize: '11px',
-                      border: '1px solid #A9A9A9',
-                      borderRadius: '3px',
-                      backgroundColor: '#FFFFFF',
-                      color: '#000000',
-                      cursor: 'pointer',
-                      fontWeight: 500,
-                    }}
-                    title={isFullscreen ? '확대 해제' : '전체화면 확대'}
-                  >
-                    {isFullscreen ? '축소' : '확대'}
-                  </button>
-                </div>
-              </div>
+						iframeDoc.open();
+						iframeDoc.write(previousHtml);
+						iframeDoc.close();
 
-              {/* 패널 내용 */}
-              <div
-                style={{
-                  flex: 1,
-                  border: '1px solid #C0C0C0',
-                  borderTop: 'none',
-                  borderRadius: '0 0 4px 4px',
-                  overflow: 'hidden',
-                  backgroundColor: '#FFFFFF',
-                  display: 'flex',
-                  flexDirection: 'column',
-                  position: 'relative', // 오버레이를 위한 relative positioning
-                }}
-              >
-                  {/* 편집본 패널에만 편집 툴바 추가 */}
-                  {panel.id === 'translated' && (
-                    <>
-                      <div
-                        style={{
-                          padding: '8px 12px',
-                          borderBottom: '1px solid #C0C0C0',
-                          backgroundColor: '#F8F9FA',
-                          display: 'flex',
-                          justifyContent: 'flex-start',
-                          alignItems: 'center',
-                          flexWrap: 'wrap',
-                          gap: '8px',
-                        }}
-                      >
-                        <div style={{ display: 'flex', gap: '4px', alignItems: 'center', flexWrap: 'wrap' }}>
-                          <Button
-                            variant={mode === 'text' ? 'primary' : 'secondary'}
-                            onClick={() => setMode('text')}
-                            style={{ fontSize: '11px', padding: '4px 8px' }}
-                          >
-                            텍스트 편집
-                          </Button>
-                          <Button
-                            variant={mode === 'component' ? 'primary' : 'secondary'}
-                            onClick={() => setMode('component')}
-                            style={{ fontSize: '11px', padding: '4px 8px' }}
-                          >
-                            컴포넌트 편집
-                          </Button>
-                          
-                          {/* Rich Text 기능 (텍스트 모드일 때만) */}
-                          {mode === 'text' && (
-                            <>
-                              <div style={{ width: '1px', height: '20px', backgroundColor: '#C0C0C0', margin: '0 4px' }} />
-                              <button
-                            onClick={() => {
-                                  const iframeDoc = translatedIframeRef.current?.contentDocument || translatedIframeRef.current?.contentWindow?.document;
-                                  if (iframeDoc) iframeDoc.execCommand('bold', false);
-                                }}
-                                style={{
-                                  padding: '4px 8px',
-                                  fontSize: '11px',
-                                  fontWeight: 'bold',
-                                  border: '1px solid #A9A9A9',
-                                  borderRadius: '3px',
-                                  backgroundColor: '#FFFFFF',
-                                  color: '#000000',
-                                  cursor: 'pointer',
-                                }}
-                                title="굵게 (Ctrl+B)"
-                              >
-                                B
-                              </button>
-                              <button
-                                onClick={() => {
-                                  const iframeDoc = translatedIframeRef.current?.contentDocument || translatedIframeRef.current?.contentWindow?.document;
-                                  if (iframeDoc) iframeDoc.execCommand('italic', false);
-                                }}
-                                style={{
-                                  padding: '4px 8px',
-                                  fontSize: '11px',
-                                  fontStyle: 'italic',
-                                  border: '1px solid #A9A9A9',
-                                  borderRadius: '3px',
-                                  backgroundColor: '#FFFFFF',
-                                  color: '#000000',
-                                  cursor: 'pointer',
-                                }}
-                                title="기울임 (Ctrl+I)"
-                              >
-                                I
-                              </button>
-                              <button
-                                onClick={() => {
-                                  const iframeDoc = translatedIframeRef.current?.contentDocument || translatedIframeRef.current?.contentWindow?.document;
-                                  if (iframeDoc) iframeDoc.execCommand('underline', false);
-                                }}
-                                style={{
-                                  padding: '4px 8px',
-                                  fontSize: '11px',
-                                  textDecoration: 'underline',
-                                  border: '1px solid #A9A9A9',
-                                  borderRadius: '3px',
-                                  backgroundColor: '#FFFFFF',
-                                  color: '#000000',
-                                  cursor: 'pointer',
-                                }}
-                                title="밑줄 (Ctrl+U)"
-                              >
-                                U
-                              </button>
-                              <button
-                                onClick={() => {
-                                  const iframeDoc = translatedIframeRef.current?.contentDocument || translatedIframeRef.current?.contentWindow?.document;
-                                  if (iframeDoc) iframeDoc.execCommand('strikeThrough', false);
-                                }}
-                                style={{
-                                  padding: '4px 8px',
-                                  fontSize: '11px',
-                                  textDecoration: 'line-through',
-                                  border: '1px solid #A9A9A9',
-                                  borderRadius: '3px',
-                                  backgroundColor: '#FFFFFF',
-                                  color: '#000000',
-                                  cursor: 'pointer',
-                                }}
-                                title="취소선"
-                              >
-                                S
-                              </button>
+						onTranslatedChange(previousHtml);
+						setSelectedElements([]);
 
-                              <button
-                                onClick={() => {
-                                  const iframeDoc = translatedIframeRef.current?.contentDocument || translatedIframeRef.current?.contentWindow?.document;
-                                  if (!iframeDoc) return;
-                                  iframeDoc.execCommand('removeFormat', false);
-                                  // removeFormat이 border-style:solid 만 남기는 문제 수정
-                                  setTimeout(() => {
-                                    iframeDoc.querySelectorAll('*').forEach((el) => {
-                                      const htmlEl = el as HTMLElement;
-                                      if (htmlEl.style && htmlEl.style.borderStyle === 'solid' && !htmlEl.style.borderWidth) {
-                                        htmlEl.style.borderWidth = '0';
-                                      }
-                                    });
-                                  }, 0);
-                                }}
-                                style={{
-                                  padding: '4px 8px',
-                                  fontSize: '11px',
-                                  fontWeight: 600,
-                                  border: '1px solid #A9A9A9',
-                                  borderRadius: '3px',
-                                  backgroundColor: '#FFFFFF',
-                                  color: '#000000',
-                                  cursor: 'pointer',
-                                }}
-                                title="서식 지우기 (선택 영역)"
-                              >
-                                서식 지우기
-                              </button>
+						// ⭐ translatedHtml 의존성 배열에 추가되어 useEffect가 자동으로 재실행됨
+						// iframe에 포커스를 주어 키보드 이벤트가 계속 작동하도록 함
+						setTimeout(() => {
+							const newIframeDoc =
+								iframe.contentDocument || iframe.contentWindow?.document;
+							if (newIframeDoc?.body) {
+								newIframeDoc.body.setAttribute("tabindex", "-1");
+								newIframeDoc.body.focus();
+							}
+						}, 50);
+					}
+				}
+				// Ctrl+Shift+Z 또는 Ctrl+Y (다시 실행)
+				else if (
+					(e.ctrlKey || e.metaKey) &&
+					(e.key === "y" || (e.key === "z" && e.shiftKey))
+				) {
+					e.preventDefault();
+					e.stopImmediatePropagation();
 
-                              <div style={{ width: '1px', height: '20px', backgroundColor: '#C0C0C0', margin: '0 4px' }} />
-                              <select
-                                onChange={(e) => {
-                                  const iframeDoc = translatedIframeRef.current?.contentDocument || translatedIframeRef.current?.contentWindow?.document;
-                                  if (iframeDoc && e.target.value) {
-                                    const fontSize = e.target.value;
-                                    const selection = iframeDoc.getSelection();
-                                    
-                                    if (selection && selection.rangeCount > 0 && !selection.getRangeAt(0).collapsed) {
-                                      const range = selection.getRangeAt(0);
-                                      const selectedText = range.toString();
-                                      
-                                      const spanHtml = `<span style="font-size: ${fontSize}pt;">${selectedText}</span>`;
-                                      
-                                      try {
-                                        iframeDoc.execCommand('insertHTML', false, spanHtml);
-                                      } catch (err) {
-                                        range.deleteContents();
-                                        const tempDiv = iframeDoc.createElement('div');
-                                        tempDiv.innerHTML = spanHtml;
-                                        const fragment = iframeDoc.createDocumentFragment();
-                                        while (tempDiv.firstChild) {
-                                          fragment.appendChild(tempDiv.firstChild);
-                                        }
-                                        range.insertNode(fragment);
-                                        
-                                        range.setStartAfter(fragment.lastChild || range.startContainer);
-                                        range.collapse(false);
-                                        selection.removeAllRanges();
-                                        selection.addRange(range);
-                                      }
-                                    } else {
-                                      iframeDoc.execCommand('fontSize', false, '3');
-                                  setTimeout(() => {
-                                        const fontSizeElements = iframeDoc.querySelectorAll('font[size="3"]');
-                                        if (fontSizeElements.length > 0) {
-                                          const lastElement = fontSizeElements[fontSizeElements.length - 1] as HTMLElement;
-                                          lastElement.style.fontSize = `${fontSize}pt`;
-                                          lastElement.removeAttribute('size');
-                                          
-                                          const span = iframeDoc.createElement('span');
-                                          span.style.fontSize = `${fontSize}pt`;
-                                          span.innerHTML = lastElement.innerHTML;
-                                          
-                                          if (lastElement.parentNode) {
-                                            lastElement.parentNode.replaceChild(span, lastElement);
-                                          }
-                                        }
-                                      }, 0);
-                                    }
-                                    
-                                    e.target.value = '';
-                                  }
-                                }}
-                                style={{
-                                  fontSize: '11px',
-                                  padding: '4px 8px',
-                                  border: '1px solid #A9A9A9',
-                                  borderRadius: '3px',
-                                  backgroundColor: '#FFFFFF',
-                                  color: '#000000',
-                                  cursor: 'pointer',
-                                }}
-                                title="글자 크기 (pt)"
-                              >
-                                <option value="">크기</option>
-                                <option value="8">8pt</option>
-                                <option value="9">9pt</option>
-                                <option value="10">10pt</option>
-                                <option value="11">11pt</option>
-                                <option value="12">12pt</option>
-                                <option value="14">14pt</option>
-                                <option value="16">16pt</option>
-                                <option value="18">18pt</option>
-                                <option value="20">20pt</option>
-                                <option value="24">24pt</option>
-                                <option value="28">28pt</option>
-                                <option value="32">32pt</option>
-                                <option value="36">36pt</option>
-                                <option value="48">48pt</option>
-                                <option value="72">72pt</option>
-                              </select>
-                              <select
-                                onChange={(e) => {
-                                  const iframeDoc = translatedIframeRef.current?.contentDocument || translatedIframeRef.current?.contentWindow?.document;
-                                  if (iframeDoc && e.target.value) {
-                                    const lineHeight = e.target.value;
-                                    const selection = iframeDoc.getSelection();
-                                    
-                                    if (selection && selection.rangeCount > 0) {
-                                      const range = selection.getRangeAt(0);
-                                      
-                                      let blockElement: HTMLElement | null = null;
-                                      
-                                      if (range.commonAncestorContainer.nodeType === 1) {
-                                        blockElement = (range.commonAncestorContainer as HTMLElement).closest('p, div, h1, h2, h3, h4, h5, h6, li, blockquote, pre');
-                                      } else {
-                                        blockElement = range.commonAncestorContainer.parentElement?.closest('p, div, h1, h2, h3, h4, h5, h6, li, blockquote, pre') || null;
-                                      }
-                                      
-                                      if (blockElement) {
-                                        try {
-                                          const blockRange = iframeDoc.createRange();
-                                          blockRange.selectNodeContents(blockElement);
-                                          selection.removeAllRanges();
-                                          selection.addRange(blockRange);
-                                          
-                                          const originalHtml = blockElement.innerHTML;
-                                          const tagName = blockElement.tagName.toLowerCase();
-                                          const newHtml = `<${tagName} style="line-height: ${lineHeight};">${originalHtml}</${tagName}>`;
-                                          
-                                          iframeDoc.execCommand('insertHTML', false, newHtml);
-                                        } catch (err) {
-                                          blockElement.style.lineHeight = lineHeight;
-                                        }
-                                      } else {
-                                        const div = iframeDoc.createElement('div');
-                                        div.style.lineHeight = lineHeight;
-                                        div.innerHTML = '&nbsp;';
-                                        
-                                        try {
-                                          iframeDoc.execCommand('insertHTML', false, div.outerHTML);
-                                        } catch (err) {
-                                          range.insertNode(div);
-                                        }
-                                      }
-                                    }
-                                    
-                                    e.target.value = '';
-                                  }
-                                }}
-                                style={{
-                                  fontSize: '11px',
-                                  padding: '4px 8px',
-                                  border: '1px solid #A9A9A9',
-                                  borderRadius: '3px',
-                                  backgroundColor: '#FFFFFF',
-                                  color: '#000000',
-                                  cursor: 'pointer',
-                                  marginLeft: '4px',
-                                }}
-                                title="줄간격"
-                              >
-                                <option value="">줄간격</option>
-                                <option value="1.0">1.0 (단일)</option>
-                                <option value="1.15">1.15</option>
-                                <option value="1.5">1.5 (기본)</option>
-                                <option value="1.75">1.75</option>
-                                <option value="2.0">2.0 (2배)</option>
-                                <option value="2.5">2.5</option>
-                                <option value="3.0">3.0</option>
-                              </select>
-                              <div style={{ position: 'relative', display: 'inline-block', width: '30px', height: '26px' }}>
-                                <input
-                                  type="color"
-                                  onChange={(e) => {
-                                    const iframeDoc = translatedIframeRef.current?.contentDocument || translatedIframeRef.current?.contentWindow?.document;
-                                    if (iframeDoc) iframeDoc.execCommand('foreColor', false, e.target.value);
-                                  }}
-                                  style={{
-                                    position: 'absolute',
-                                    width: '100%',
-                                    height: '100%',
-                                    opacity: 0,
-                                    cursor: 'pointer',
-                                    zIndex: 2,
-                                  }}
-                                  title="글자 색상"
-                                />
-                                <button
-                                  style={{
-                                    position: 'absolute',
-                                    width: '100%',
-                                    height: '100%',
-                                    border: '1px solid #A9A9A9',
-                                    borderRadius: '3px',
-                                    backgroundColor: '#FFFFFF',
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    justifyContent: 'center',
-                                    cursor: 'pointer',
-                                    padding: 0,
-                                    pointerEvents: 'none',
-                                  }}
-                                  title="글자 색상"
-                                  disabled
-                                >
-                                  <Palette size={16} color="#000000" />
-                                </button>
-                              </div>
-                              <div style={{ position: 'relative', display: 'inline-block', width: '30px', height: '26px', marginLeft: '4px' }}>
-                                <input
-                                  type="color"
-                                  onChange={(e) => {
-                                    const iframeDoc = translatedIframeRef.current?.contentDocument || translatedIframeRef.current?.contentWindow?.document;
-                                    if (iframeDoc) iframeDoc.execCommand('backColor', false, e.target.value);
-                                  }}
-                                  style={{
-                                    position: 'absolute',
-                                    width: '100%',
-                                    height: '100%',
-                                    opacity: 0,
-                                    cursor: 'pointer',
-                                    zIndex: 2,
-                                  }}
-                                  title="배경 색상"
-                                />
-                                <button
-                                  style={{
-                                    position: 'absolute',
-                                    width: '100%',
-                                    height: '100%',
-                                    border: '1px solid #A9A9A9',
-                                    borderRadius: '3px',
-                                    backgroundColor: '#FFFFFF',
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    justifyContent: 'center',
-                                    cursor: 'pointer',
-                                    padding: 0,
-                                    pointerEvents: 'none',
-                                  }}
-                                  title="배경 색상"
-                                  disabled
-                                >
-                                  <Highlighter size={16} color="#000000" />
-                                </button>
-                              </div>
-                              <div style={{ width: '1px', height: '20px', backgroundColor: '#C0C0C0', margin: '0 4px' }} />
-                              <button
-                                onClick={() => {
-                                  const iframeDoc = translatedIframeRef.current?.contentDocument || translatedIframeRef.current?.contentWindow?.document;
-                                  if (iframeDoc) iframeDoc.execCommand('justifyLeft', false);
-                                }}
-                                style={{
-                                  padding: '4px 8px',
-                                  fontSize: '11px',
-                                  border: '1px solid #A9A9A9',
-                                  borderRadius: '3px',
-                                  backgroundColor: '#FFFFFF',
-                                  color: '#000000',
-                                  cursor: 'pointer',
-                                  display: 'flex',
-                                  alignItems: 'center',
-                                  justifyContent: 'center',
-                                }}
-                                title="왼쪽 정렬"
-                              >
-                                <AlignLeft size={16} />
-                              </button>
-                              <button
-                                onClick={() => {
-                                  const iframeDoc = translatedIframeRef.current?.contentDocument || translatedIframeRef.current?.contentWindow?.document;
-                                  if (iframeDoc) iframeDoc.execCommand('justifyCenter', false);
-                                }}
-                                style={{
-                                  padding: '4px 8px',
-                                  fontSize: '11px',
-                                  border: '1px solid #A9A9A9',
-                                  borderRadius: '3px',
-                                  backgroundColor: '#FFFFFF',
-                                  color: '#000000',
-                                  cursor: 'pointer',
-                                  display: 'flex',
-                                  alignItems: 'center',
-                                  justifyContent: 'center',
-                                }}
-                                title="가운데 정렬"
-                              >
-                                <AlignCenter size={16} />
-                              </button>
-                              <button
-                                onClick={() => {
-                                  const iframeDoc = translatedIframeRef.current?.contentDocument || translatedIframeRef.current?.contentWindow?.document;
-                                  if (iframeDoc) iframeDoc.execCommand('justifyRight', false);
-                                }}
-                                style={{
-                                  padding: '4px 8px',
-                                  fontSize: '11px',
-                                  border: '1px solid #A9A9A9',
-                                  borderRadius: '3px',
-                                  backgroundColor: '#FFFFFF',
-                                  color: '#000000',
-                                  cursor: 'pointer',
-                                  display: 'flex',
-                                  alignItems: 'center',
-                                  justifyContent: 'center',
-                                }}
-                                title="오른쪽 정렬"
-                              >
-                                <AlignRight size={16} />
-                              </button>
+					if (redoStackRef.current.length > 0 && iframeDoc) {
+						console.log("↪️ Redo (Step 5 컴포넌트 편집 - window)");
 
-                              <button
-                                onClick={() => {
-                                  const iframeDoc = translatedIframeRef.current?.contentDocument || translatedIframeRef.current?.contentWindow?.document;
-                                  if (iframeDoc) iframeDoc.execCommand('justifyFull', false);
-                                }}
-                                style={{
-                                  padding: '4px 8px',
-                                  fontSize: '11px',
-                                  border: '1px solid #A9A9A9',
-                                  borderRadius: '3px',
-                                  backgroundColor: '#FFFFFF',
-                                  color: '#000000',
-                                  cursor: 'pointer',
-                                  display: 'flex',
-                                  alignItems: 'center',
-                                  justifyContent: 'center',
-                                }}
-                                title="양쪽 정렬"
-                              >
-                                <AlignJustify size={16} />
-                              </button>
+						undoStackRef.current.push(currentHtmlRef.current);
+						const nextHtml = redoStackRef.current.pop()!;
+						currentHtmlRef.current = nextHtml;
 
-                              <div style={{ width: '1px', height: '20px', backgroundColor: '#C0C0C0', margin: '0 4px' }} />
-                              <button
-                                onClick={() => {
-                                  const iframeDoc = translatedIframeRef.current?.contentDocument || translatedIframeRef.current?.contentWindow?.document;
-                                  if (iframeDoc) iframeDoc.execCommand('insertUnorderedList', false);
-                                }}
-                                style={{
-                                  padding: '4px 8px',
-                                  fontSize: '11px',
-                                  border: '1px solid #A9A9A9',
-                                  borderRadius: '3px',
-                                  backgroundColor: '#FFFFFF',
-                                  color: '#000000',
-                                  cursor: 'pointer',
-                                  display: 'flex',
-                                  alignItems: 'center',
-                                  justifyContent: 'center',
-                                }}
-                                title="글머리 기호 목록"
-                              >
-                                <List size={16} />
-                              </button>
-                              <button
-                                onClick={() => {
-                                  const iframeDoc = translatedIframeRef.current?.contentDocument || translatedIframeRef.current?.contentWindow?.document;
-                                  if (iframeDoc) iframeDoc.execCommand('insertOrderedList', false);
-                                }}
-                                style={{
-                                  padding: '4px 8px',
-                                  fontSize: '11px',
-                                  border: '1px solid #A9A9A9',
-                                  borderRadius: '3px',
-                                  backgroundColor: '#FFFFFF',
-                                  color: '#000000',
-                                  cursor: 'pointer',
-                                  display: 'flex',
-                                  alignItems: 'center',
-                                  justifyContent: 'center',
-                                }}
-                                title="번호 매기기 목록"
-                              >
-                                <ListOrdered size={16} />
-                              </button>
-                              <button
-                                onClick={() => {
-                                  const iframeDoc = translatedIframeRef.current?.contentDocument || translatedIframeRef.current?.contentWindow?.document;
-                                  if (iframeDoc) {
-                                    const url = prompt('링크 URL을 입력하세요:');
-                                    if (url) iframeDoc.execCommand('createLink', false, url);
-                                  }
-                                }}
-                                style={{
-                                  padding: '4px 8px',
-                                  fontSize: '11px',
-                                  border: '1px solid #A9A9A9',
-                                  borderRadius: '3px',
-                                  backgroundColor: '#FFFFFF',
-                                  color: '#000000',
-                                  cursor: 'pointer',
-                                  display: 'flex',
-                                  alignItems: 'center',
-                                  justifyContent: 'center',
-                                }}
-                                title="링크 삽입"
-                              >
-                                <Link2 size={16} />
-                              </button>
-                              <div style={{ width: '1px', height: '20px', backgroundColor: '#C0C0C0', margin: '0 4px' }} />
-                              <div style={{ position: 'relative', display: 'inline-block' }}>
-                                <input
-                                  type="file"
-                                  accept="image/*"
-                                  onChange={(e) => {
-                                    const file = e.target.files?.[0];
-                                    if (file) {
-                                      const reader = new FileReader();
-                                      reader.onload = (event) => {
-                                        const imageUrl = event.target?.result as string;
-                                        const iframeDoc = translatedIframeRef.current?.contentDocument || translatedIframeRef.current?.contentWindow?.document;
-                                        if (iframeDoc && imageUrl) {
-                                          try {
-                                            iframeDoc.execCommand('insertHTML', false, `<img src="${imageUrl}" alt="" style="max-width: 100%; height: auto;" />`);
-                                          } catch (err) {
-                                            const selection = iframeDoc.getSelection();
-                                            if (selection && selection.rangeCount > 0) {
-                                              const range = selection.getRangeAt(0);
-                                              const img = iframeDoc.createElement('img');
-                                              img.src = imageUrl;
-                                              img.alt = '';
-                                              img.style.maxWidth = '100%';
-                                              img.style.height = 'auto';
-                                              range.insertNode(img);
-                                            }
-                                          }
-                                        }
-                                      };
-                                      reader.readAsDataURL(file);
-                                    }
-                                    e.target.value = '';
-                                  }}
-                                  style={{
-                                    position: 'absolute',
-                                    width: '100%',
-                                    height: '100%',
-                                    opacity: 0,
-                                    cursor: 'pointer',
-                                    zIndex: 2,
-                                  }}
-                                  title="이미지 삽입"
-                                />
-                                <button
-                                  style={{
-                                    padding: '4px 8px',
-                                    fontSize: '11px',
-                                    border: '1px solid #A9A9A9',
-                                    borderRadius: '3px',
-                                    backgroundColor: '#FFFFFF',
-                                    color: '#000000',
-                                    cursor: 'pointer',
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    justifyContent: 'center',
-                                    pointerEvents: 'none',
-                                  }}
-                                  title="이미지 삽입"
-                                  disabled
-                                >
-                                  <Image size={16} />
-                                </button>
-                              </div>
-                              <button
-                                onClick={() => {
-                                  const iframeDoc = translatedIframeRef.current?.contentDocument || translatedIframeRef.current?.contentWindow?.document;
-                                  if (iframeDoc) {
-                                    try {
-                                      iframeDoc.execCommand('insertHTML', false, '<pre style="background-color: #f4f4f4; padding: 10px; border-radius: 4px; overflow-x: auto;"><code></code></pre>');
-                                    } catch (err) {
-                                      iframeDoc.execCommand('formatBlock', false, 'pre');
-                                      const selection = iframeDoc.getSelection();
-                                      if (selection && selection.rangeCount > 0) {
-                                        const range = selection.getRangeAt(0);
-                                        const preElement = range.commonAncestorContainer.nodeType === 1 
-                                          ? range.commonAncestorContainer as HTMLElement
-                                          : (range.commonAncestorContainer.parentElement as HTMLElement);
-                                        if (preElement && preElement.tagName === 'PRE') {
-                                          preElement.style.backgroundColor = '#f4f4f4';
-                                          preElement.style.padding = '10px';
-                                          preElement.style.borderRadius = '4px';
-                                          preElement.style.overflowX = 'auto';
-                                        }
-                                      }
-                                    }
-                                  }
-                                }}
-                                style={{
-                                  padding: '4px 8px',
-                                  fontSize: '11px',
-                                  border: '1px solid #A9A9A9',
-                                  borderRadius: '3px',
-                                  backgroundColor: '#FFFFFF',
-                                  color: '#000000',
-                                  cursor: 'pointer',
-                                  display: 'flex',
-                                  alignItems: 'center',
-                                  justifyContent: 'center',
-                                }}
-                                title="코드 블록"
-                              >
-                                <Code size={16} />
-                              </button>
-                              <div style={{ position: 'relative', display: 'inline-block' }} data-more-menu>
-                                <button
-                                  onClick={() => setShowMoreMenu(!showMoreMenu)}
-                                  style={{
-                                    padding: '4px 8px',
-                                    fontSize: '11px',
-                                    border: '1px solid #A9A9A9',
-                                    borderRadius: '3px',
-                                    backgroundColor: showMoreMenu ? '#E0E0E0' : '#FFFFFF',
-                                    color: '#000000',
-                                    cursor: 'pointer',
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    justifyContent: 'center',
-                                  }}
-                                  title="더보기"
-                                >
-                                  <MoreVertical size={16} />
-                                </button>
-                                {showMoreMenu && (
-                                  <div
-                                    style={{
-                                      position: 'absolute',
-                                      top: '100%',
-                                      right: 0,
-                                      marginTop: '4px',
-                                      backgroundColor: '#FFFFFF',
-                                      border: '1px solid #A9A9A9',
-                                      borderRadius: '4px',
-                                      boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
-                                      zIndex: 1000,
-                                      display: 'flex',
-                                      flexDirection: 'row',
-                                      gap: '4px',
-                                      padding: '4px',
-                                    }}
-                                    onClick={(e) => e.stopPropagation()}
-                                    data-more-menu
-                                  >
-                                    <button
-                                      onClick={() => {
-                                        const iframeDoc = translatedIframeRef.current?.contentDocument || translatedIframeRef.current?.contentWindow?.document;
-                                        if (iframeDoc) {
-                                          iframeDoc.execCommand('formatBlock', false, 'blockquote');
-                                        }
-                                        setShowMoreMenu(false);
-                                      }}
-                                      style={{
-                                        padding: '4px 8px',
-                                        fontSize: '11px',
-                                        border: '1px solid #A9A9A9',
-                                        borderRadius: '3px',
-                                        backgroundColor: '#FFFFFF',
-                                        color: '#000000',
-                                        cursor: 'pointer',
-                                        display: 'flex',
-                                        alignItems: 'center',
-                                        justifyContent: 'center',
-                                      }}
-                                      title="인용문"
-                                    >
-                                      <Quote size={16} />
-                                    </button>
-                                    <button
-                                      onClick={() => {
-                                        const iframeDoc = translatedIframeRef.current?.contentDocument || translatedIframeRef.current?.contentWindow?.document;
-                                        if (iframeDoc) {
-                                          iframeDoc.execCommand('insertHorizontalRule', false);
-                                        }
-                                        setShowMoreMenu(false);
-                                      }}
-                                      style={{
-                                        padding: '4px 8px',
-                                        fontSize: '11px',
-                                        border: '1px solid #A9A9A9',
-                                        borderRadius: '3px',
-                                        backgroundColor: '#FFFFFF',
-                                        color: '#000000',
-                                        cursor: 'pointer',
-                                        display: 'flex',
-                                        alignItems: 'center',
-                                        justifyContent: 'center',
-                                      }}
-                                      title="구분선"
-                                    >
-                                      <Minus size={16} />
-                                    </button>
-                                    <button
-                                      onClick={() => {
-                                        const iframeDoc = translatedIframeRef.current?.contentDocument || translatedIframeRef.current?.contentWindow?.document;
-                                        if (iframeDoc) {
-                                          const rows = prompt('행 수를 입력하세요 (기본값: 3):', '3');
-                                          const cols = prompt('열 수를 입력하세요 (기본값: 3):', '3');
-                                          const rowCount = parseInt(rows || '3', 10);
-                                          const colCount = parseInt(cols || '3', 10);
-                                          
-                                          if (rowCount > 0 && colCount > 0) {
-                                            let tableHtml = '<table border="1" style="border-collapse: collapse; width: 100%;">';
-                                            for (let i = 0; i < rowCount; i++) {
-                                              tableHtml += '<tr>';
-                                              for (let j = 0; j < colCount; j++) {
-                                                tableHtml += '<td style="padding: 8px; border: 1px solid #000;">&nbsp;</td>';
-                                              }
-                                              tableHtml += '</tr>';
-                                            }
-                                            tableHtml += '</table>';
-                                            
-                                            try {
-                                              iframeDoc.execCommand('insertHTML', false, tableHtml);
-                                            } catch (err) {
-                                              const selection = iframeDoc.getSelection();
-                                              if (selection && selection.rangeCount > 0) {
-                                                const range = selection.getRangeAt(0);
-                                                const tempDiv = iframeDoc.createElement('div');
-                                                tempDiv.innerHTML = tableHtml;
-                                                const fragment = iframeDoc.createDocumentFragment();
-                                                while (tempDiv.firstChild) {
-                                                  fragment.appendChild(tempDiv.firstChild);
-                                                }
-                                                range.insertNode(fragment);
-                                              }
-                                            }
-                                          }
-                                        }
-                                        setShowMoreMenu(false);
-                                      }}
-                                      style={{
-                                        padding: '4px 8px',
-                                        fontSize: '11px',
-                                        border: '1px solid #A9A9A9',
-                                        borderRadius: '3px',
-                                        backgroundColor: '#FFFFFF',
-                                        color: '#000000',
-                                        cursor: 'pointer',
-                                        display: 'flex',
-                                        alignItems: 'center',
-                                        justifyContent: 'center',
-                                      }}
-                                      title="표"
-                                    >
-                                      <Table size={16} />
-                                    </button>
-                                    <button
-                                      onClick={() => {
-                                        const iframeDoc = translatedIframeRef.current?.contentDocument || translatedIframeRef.current?.contentWindow?.document;
-                                        if (iframeDoc) {
-                                          const selection = iframeDoc.getSelection();
-                                          if (selection && selection.rangeCount > 0 && !selection.getRangeAt(0).collapsed) {
-                                            const range = selection.getRangeAt(0);
-                                            const selectedText = range.toString();
-                                            
-                                            try {
-                                              iframeDoc.execCommand('insertHTML', false, `<sup>${selectedText}</sup>`);
-                                            } catch (err) {
-                                              const sup = iframeDoc.createElement('sup');
-                                              sup.textContent = selectedText;
-                                              range.deleteContents();
-                                              range.insertNode(sup);
-                                            }
-                                          } else {
-                                            try {
-                                              iframeDoc.execCommand('insertHTML', false, '<sup></sup>');
-                                            } catch (err) {
-                                              const selection = iframeDoc.getSelection();
-                                              if (selection && selection.rangeCount > 0) {
-                                                const range = selection.getRangeAt(0);
-                                                const sup = iframeDoc.createElement('sup');
-                                                sup.innerHTML = '&nbsp;';
-                                                range.insertNode(sup);
-                                              }
-                                            }
-                                          }
-                                        }
-                                        setShowMoreMenu(false);
-                                      }}
-                                      style={{
-                                        padding: '4px 8px',
-                                        fontSize: '11px',
-                                        border: '1px solid #A9A9A9',
-                                        borderRadius: '3px',
-                                        backgroundColor: '#FFFFFF',
-                                        color: '#000000',
-                                        cursor: 'pointer',
-                                        display: 'flex',
-                                        alignItems: 'center',
-                                        justifyContent: 'center',
-                                      }}
-                                      title="위 첨자"
-                                    >
-                                      <Superscript size={16} />
-                                    </button>
-                                    <button
-                                      onClick={() => {
-                                        const iframeDoc = translatedIframeRef.current?.contentDocument || translatedIframeRef.current?.contentWindow?.document;
-                                        if (iframeDoc) {
-                                          const selection = iframeDoc.getSelection();
-                                          if (selection && selection.rangeCount > 0 && !selection.getRangeAt(0).collapsed) {
-                                            const range = selection.getRangeAt(0);
-                                            const selectedText = range.toString();
-                                            
-                                            try {
-                                              iframeDoc.execCommand('insertHTML', false, `<sub>${selectedText}</sub>`);
-                                            } catch (err) {
-                                              const sub = iframeDoc.createElement('sub');
-                                              sub.textContent = selectedText;
-                                              range.deleteContents();
-                                              range.insertNode(sub);
-                                            }
-                                } else {
-                                            try {
-                                              iframeDoc.execCommand('insertHTML', false, '<sub></sub>');
-                                            } catch (err) {
-                                              const selection = iframeDoc.getSelection();
-                                              if (selection && selection.rangeCount > 0) {
-                                                const range = selection.getRangeAt(0);
-                                                const sub = iframeDoc.createElement('sub');
-                                                sub.innerHTML = '&nbsp;';
-                                                range.insertNode(sub);
-                                              }
-                                            }
-                                          }
-                                        }
-                                        setShowMoreMenu(false);
-                                      }}
-                                      style={{
-                                        padding: '4px 8px',
-                                        fontSize: '11px',
-                                        border: '1px solid #A9A9A9',
-                                        borderRadius: '3px',
-                                        backgroundColor: '#FFFFFF',
-                                        color: '#000000',
-                                        cursor: 'pointer',
-                                        display: 'flex',
-                                        alignItems: 'center',
-                                        justifyContent: 'center',
-                                      }}
-                                      title="아래 첨자"
-                                    >
-                                      <Subscript size={16} />
-                                    </button>
-                                  </div>
-                                )}
-                              </div>
-                              <div style={{ width: '1px', height: '20px', backgroundColor: '#C0C0C0', margin: '0 4px' }} />
-                              <button
-                                onClick={() => {
-                                  const iframe = translatedIframeRef.current;
-                                  const iframeDoc = iframe?.contentDocument || iframe?.contentWindow?.document;
-                                  if (!iframeDoc) return;
-                                  
-                                  if (mode === 'text') {
-                                    iframeDoc.body.setAttribute('tabindex', '-1');
-                                    iframeDoc.body.focus();
-                                iframeDoc.execCommand('undo', false);
-                                const updatedHtml = iframeDoc.documentElement.outerHTML;
-                                currentHtmlRef.current = updatedHtml;
-                                onTranslatedChange(updatedHtml);
-                                  } else {
-                                    if (undoStackRef.current.length > 0) {
-                                      const currentHtml = iframeDoc.documentElement.outerHTML;
-                                      redoStackRef.current.push(currentHtml);
-                                      const previousHtml = undoStackRef.current.pop() || '';
-                                      iframeDoc.open();
-                                      iframeDoc.write(previousHtml);
-                                      iframeDoc.close();
-                                      currentHtmlRef.current = previousHtml;
-                                      onTranslatedChange(previousHtml);
-                                      setSelectedElements([]);
-                                    }
-                                  }
-                                }}
-                                style={{
-                                  padding: '4px 8px',
-                                  fontSize: '11px',
-                                  border: '1px solid #A9A9A9',
-                                  borderRadius: '3px',
-                                  backgroundColor: '#FFFFFF',
-                                  color: '#000000',
-                                  cursor: 'pointer',
-                                  display: 'flex',
-                                  alignItems: 'center',
-                                  justifyContent: 'center',
-                                }}
-                                title="실행 취소 (Ctrl/Cmd+Z)"
-                              >
-                                <Undo2 size={16} color="#000000" />
-                              </button>
-                              <button
-                            onClick={() => {
-                              const iframe = translatedIframeRef.current;
-                              const iframeDoc = iframe?.contentDocument || iframe?.contentWindow?.document;
-                              if (!iframeDoc) return;
+						iframeDoc.open();
+						iframeDoc.write(nextHtml);
+						iframeDoc.close();
 
-                                  if (mode === 'text') {
-                                    iframeDoc.body.setAttribute('tabindex', '-1');
-                                    iframeDoc.body.focus();
-                                    iframeDoc.execCommand('redo', false);
-                                    const updatedHtml = iframeDoc.documentElement.outerHTML;
-                                    currentHtmlRef.current = updatedHtml;
-                                    onTranslatedChange(updatedHtml);
-                                  } else {
-                                if (redoStackRef.current.length > 0) {
-                                  const currentHtml = iframeDoc.documentElement.outerHTML;
-                                  undoStackRef.current.push(currentHtml);
-                                  const nextHtml = redoStackRef.current.pop() || '';
-                                  iframeDoc.open();
-                                  iframeDoc.write(nextHtml);
-                                  iframeDoc.close();
-                                  currentHtmlRef.current = nextHtml;
-                                  onTranslatedChange(nextHtml);
-                                  setSelectedElements([]);
-                                    }
-                                  }
-                                }}
-                                style={{
-                                  padding: '4px 8px',
-                                  fontSize: '11px',
-                                  border: '1px solid #A9A9A9',
-                                  borderRadius: '3px',
-                                  backgroundColor: '#FFFFFF',
-                                  color: '#000000',
-                                  cursor: 'pointer',
-                                  display: 'flex',
-                                  alignItems: 'center',
-                                  justifyContent: 'center',
-                                }}
-                                title="다시 실행 (Ctrl/Cmd+Y)"
-                              >
-                                <Redo2 size={16} color="#000000" />
-                              </button>
-                            </>
-                          )}
-                        </div>
-                        {mode === 'component' && (
-                          <div style={{ display: 'flex', gap: '4px', alignItems: 'center' }}>
-                            <span style={{ fontSize: '11px', color: '#696969' }}>
-                              {selectedElements.length}개 선택됨
-                            </span>
-                            <Button
-                              variant="secondary"
-                              onClick={() => {
-                                if (!translatedIframeRef.current) return;
-                                const iframeDoc = translatedIframeRef.current.contentDocument || translatedIframeRef.current.contentWindow?.document;
-                                if (iframeDoc) {
-                                  selectedElements.forEach(el => {
-                                    el.classList.remove('component-selected');
-                                    el.style.outline = '';
-                                    el.style.boxShadow = '';
-                                    el.style.backgroundColor = '';
-                                    el.style.outlineOffset = '';
-                                  });
-                                }
-                                setSelectedElements([]);
-                              }}
-                              disabled={selectedElements.length === 0}
-                              style={{ fontSize: '11px', padding: '4px 8px' }}
-                              title="전체 선택 취소"
-                            >
-                              선택 취소
-                            </Button>
-                            <Button
-                              variant="primary"
-                              onClick={handleDelete}
-                              disabled={selectedElements.length === 0}
-                              style={{ fontSize: '11px', padding: '4px 8px' }}
-                            >
-                              삭제
-                            </Button>
-                          </div>
-                        )}
-                      </div>
-                    </>
-                  )}
-                  
-                  <div style={{ flex: 1, overflow: 'hidden' }}>
-                    <iframe
-                      ref={panel.ref}
-                      style={{ 
-                        width: '100%', 
-                        height: '100%', 
-                        border: 'none',
-                        display: 'block',
-                      }}
-                      title={panel.title}
-                    />
-                  </div>
-                </div>
-            </div>
-          );
-        })}
-      </div>
-    </div>
-  );
+						onTranslatedChange(nextHtml);
+						setSelectedElements([]);
+
+						// ⭐ translatedHtml 의존성 배열에 추가되어 useEffect가 자동으로 재실행됨
+						// iframe에 포커스를 주어 키보드 이벤트가 계속 작동하도록 함
+						setTimeout(() => {
+							const newIframeDoc =
+								iframe.contentDocument || iframe.contentWindow?.document;
+							if (newIframeDoc?.body) {
+								newIframeDoc.body.setAttribute("tabindex", "-1");
+								newIframeDoc.body.focus();
+							}
+						}, 50);
+					}
+				}
+			};
+
+			// 기존 window 리스너 제거
+			if (windowKeydownHandlerRef.current) {
+				window.removeEventListener(
+					"keydown",
+					windowKeydownHandlerRef.current,
+					true,
+				);
+			}
+			// 새 window 리스너 등록 및 저장
+			windowKeydownHandlerRef.current = handleWindowKeydown;
+			window.addEventListener("keydown", handleWindowKeydown, true);
+			console.log("✅ Step 5 window 키보드 이벤트 리스너 등록 완료");
+
+			// 컴포넌트 클릭 핸들러 (다중 선택 + 토글)
+			const handleComponentClick = (e: Event) => {
+				e.stopPropagation();
+				e.preventDefault();
+
+				const target = e.target as HTMLElement;
+				if (
+					!target ||
+					["SCRIPT", "STYLE", "NOSCRIPT", "HTML", "HEAD", "BODY"].includes(
+						target.tagName,
+					)
+				)
+					return;
+
+				// ⭐ 링크 내부 요소를 클릭한 경우 가장 가까운 편집 가능한 요소 찾기
+				const editableElement = target.closest(
+					"[data-component-editable]",
+				) as HTMLElement;
+				if (!editableElement) {
+					console.log("⚠️ 편집 가능한 요소를 찾을 수 없습니다:", target.tagName);
+					return;
+				}
+
+				const isSelected =
+					editableElement.classList.contains("component-selected");
+
+				if (isSelected) {
+					editableElement.classList.remove("component-selected");
+					editableElement.style.outline = "1px dashed #C0C0C0";
+					editableElement.style.boxShadow = "none";
+					setSelectedElements((prev) =>
+						prev.filter((el) => el !== editableElement),
+					);
+				} else {
+					editableElement.classList.add("component-selected");
+					editableElement.style.outline = "3px solid #000000";
+					editableElement.style.boxShadow = "none";
+					setSelectedElements((prev) => [...prev, editableElement]);
+				}
+			};
+
+			// ⭐ Step 3와 동일한 방식으로 이벤트 리스너 등록 (capture phase)
+			componentElements.forEach((el) => {
+				if (
+					el.tagName &&
+					!["SCRIPT", "STYLE", "NOSCRIPT", "HTML", "HEAD", "BODY"].includes(
+						el.tagName,
+					)
+				) {
+					const htmlEl = el as HTMLElement;
+					htmlEl.setAttribute("data-component-editable", "true");
+					htmlEl.style.cursor = "pointer";
+					htmlEl.style.outline = "1px dashed #C0C0C0";
+
+					// 기존 핸들러가 있으면 제거
+					const existingHandler = componentClickHandlersRef.current.get(htmlEl);
+					if (existingHandler) {
+						htmlEl.removeEventListener("click", existingHandler, true);
+					}
+
+					// 클릭 이벤트 리스너 추가 및 저장 (capture phase)
+					htmlEl.addEventListener("click", handleComponentClick, true);
+					componentClickHandlersRef.current.set(htmlEl, handleComponentClick);
+				}
+			});
+
+			// ⭐ 링크 클릭 방지 (다른 사이트로 이동 방지)
+			const allLinks = iframeDoc.querySelectorAll("a");
+			const preventLinkNavigation = (e: Event) => {
+				e.preventDefault();
+				e.stopPropagation();
+				e.stopImmediatePropagation();
+				return false;
+			};
+
+			allLinks.forEach((link) => {
+				const htmlLink = link as HTMLElement;
+				// 기존 핸들러가 있으면 제거
+				const existingLinkHandler = linkClickHandlersRef.current.get(htmlLink);
+				if (existingLinkHandler) {
+					htmlLink.removeEventListener("click", existingLinkHandler, true);
+				}
+				htmlLink.addEventListener("click", preventLinkNavigation, true);
+				linkClickHandlersRef.current.set(htmlLink, preventLinkNavigation);
+				htmlLink.style.cursor = "pointer";
+			});
+
+			console.log(
+				"✅ Step 5 컴포넌트 클릭 리스너 추가 완료:",
+				componentElements.length,
+				"개",
+			);
+			console.log(
+				"✅ Step 5 링크 클릭 방지 핸들러 추가 완료:",
+				allLinks.length,
+				"개",
+			);
+
+			console.log(
+				"✅ Step 5 컴포넌트 편집 모드 링크 클릭 방지 핸들러 추가 완료:",
+				allLinks.length,
+				"개",
+			);
+		}
+
+		return () => {
+			console.log("🧹 Step 5 cleanup: 이벤트 리스너 제거");
+			// window 리스너 제거
+			if (windowKeydownHandlerRef.current) {
+				window.removeEventListener(
+					"keydown",
+					windowKeydownHandlerRef.current,
+					true,
+				);
+				console.log("✅ Step 5 window 키보드 리스너 제거");
+			}
+			// iframe 리스너는 모드 전환 시 자동으로 제거됨 (DOM이 재설정되므로)
+		};
+	}, [mode, isTranslatedInitialized, translatedHtml]); // ⭐ translatedHtml 추가하여 undo/redo 후 자동 재활성화
+
+	// 컴포넌트 삭제
+	const handleDelete = () => {
+		if (!translatedIframeRef.current) return;
+
+		const iframe = translatedIframeRef.current;
+		const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
+		if (!iframeDoc) return;
+
+		console.log("🗑️ 선택된 요소 삭제 중:", selectedElements.length, "개");
+
+		// 삭제 전 현재 상태를 undo stack에 저장
+		const currentHtml = iframeDoc.documentElement.outerHTML;
+		if (currentHtmlRef.current && currentHtmlRef.current !== currentHtml) {
+			undoStackRef.current.push(currentHtmlRef.current);
+			redoStackRef.current = []; // 새 작업 시 redo stack 초기화
+			console.log(
+				"💾 Undo stack에 저장 (STEP 5 삭제 전):",
+				undoStackRef.current.length,
+			);
+		}
+
+		selectedElements.forEach((el) => {
+			if (el.parentNode) {
+				el.parentNode.removeChild(el);
+			}
+		});
+
+		const newHtml = iframeDoc.documentElement.outerHTML;
+		currentHtmlRef.current = newHtml;
+		onTranslatedChange(newHtml);
+		setSelectedElements([]);
+
+		console.log("✅ 삭제 완료 (STEP 5)");
+
+		// ⭐ 삭제 후 iframe에 포커스를 주어 키보드 단축키가 바로 작동하도록 함
+		setTimeout(() => {
+			// body에 tabIndex 설정하여 포커스 가능하게 만들기
+			if (iframeDoc.body) {
+				iframeDoc.body.setAttribute("tabindex", "-1");
+				iframeDoc.body.focus();
+			}
+			if (iframe.contentWindow) {
+				iframe.contentWindow.focus();
+			}
+			iframe.focus();
+			console.log("🎯 Step 5 iframe에 포커스 설정");
+		}, 100);
+	};
+
+	// 패널 정의
+	const panels = [
+		{
+			id: "crawled",
+			title: "원본 웹사이트",
+			ref: crawledIframeRef,
+			editable: false,
+		},
+		{
+			id: "selected",
+			title: "Version 0",
+			ref: selectedIframeRef,
+			editable: false,
+		},
+		{
+			id: "translated",
+			title: "Version 1 (AI 초벌 번역)",
+			ref: translatedIframeRef,
+			editable: true,
+		},
+	];
+
+	return (
+		<div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
+			{/* 3개 패널 */}
+			<div
+				style={{ display: "flex", height: "100%", gap: "4px", padding: "4px" }}
+			>
+				{panels.map((panel) => {
+					const isCollapsed = collapsedPanels.has(panel.id);
+					const isFullscreen = fullscreenPanel === panel.id;
+					const visiblePanels = panels.filter(
+						(p) => !collapsedPanels.has(p.id),
+					);
+					const hasFullscreen = fullscreenPanel !== null;
+					const isHidden = hasFullscreen && !isFullscreen;
+
+					if (isHidden) return null; // 전체화면 모드에서 다른 패널 숨김
+
+					return (
+						<div
+							key={panel.id}
+							style={{
+								flex: isCollapsed
+									? "0 0 0"
+									: isFullscreen
+										? "1"
+										: `1 1 ${100 / visiblePanels.length}%`,
+								display: isCollapsed ? "none" : "flex",
+								flexDirection: "column",
+								transition: "flex 0.2s ease",
+								minWidth: isCollapsed ? "0" : "200px",
+							}}
+						>
+							{/* 패널 헤더 */}
+							<div
+								style={{
+									display: "flex",
+									justifyContent: "space-between",
+									alignItems: "center",
+									padding: "8px 12px",
+									backgroundColor: "#D3D3D3",
+									borderRadius: "4px 4px 0 0",
+									cursor: "default",
+									height: "36px",
+								}}
+							>
+								<span
+									style={{
+										fontSize: "12px",
+										fontWeight: 600,
+										color: "#000000",
+									}}
+								>
+									{panel.title}
+								</span>
+								<div
+									style={{ display: "flex", alignItems: "center", gap: "8px" }}
+								>
+									<button
+										onClick={() => toggleFullscreen(panel.id)}
+										style={{
+											padding: "4px 8px",
+											fontSize: "11px",
+											border: "1px solid #A9A9A9",
+											borderRadius: "3px",
+											backgroundColor: "#FFFFFF",
+											color: "#000000",
+											cursor: "pointer",
+											fontWeight: 500,
+										}}
+										title={isFullscreen ? "확대 해제" : "전체화면 확대"}
+									>
+										{isFullscreen ? "축소" : "확대"}
+									</button>
+								</div>
+							</div>
+
+							{/* 패널 내용 */}
+							<div
+								style={{
+									flex: 1,
+									border: "1px solid #C0C0C0",
+									borderTop: "none",
+									borderRadius: "0 0 4px 4px",
+									overflow: "hidden",
+									backgroundColor: "#FFFFFF",
+									display: "flex",
+									flexDirection: "column",
+									position: "relative", // 오버레이를 위한 relative positioning
+								}}
+							>
+								{/* 편집본 패널에만 편집 툴바 추가 */}
+								{panel.id === "translated" && (
+									<>
+										<div
+											style={{
+												padding: "8px 12px",
+												borderBottom: "1px solid #C0C0C0",
+												backgroundColor: "#F8F9FA",
+												display: "flex",
+												justifyContent: "flex-start",
+												alignItems: "center",
+												flexWrap: "wrap",
+												gap: "8px",
+											}}
+										>
+											<div
+												style={{
+													display: "flex",
+													gap: "4px",
+													alignItems: "center",
+													flexWrap: "wrap",
+												}}
+											>
+												<Button
+													variant={mode === "text" ? "primary" : "secondary"}
+													onClick={() => setMode("text")}
+													style={{ fontSize: "11px", padding: "4px 8px" }}
+												>
+													텍스트 편집
+												</Button>
+												<Button
+													variant={
+														mode === "component" ? "primary" : "secondary"
+													}
+													onClick={() => setMode("component")}
+													style={{ fontSize: "11px", padding: "4px 8px" }}
+												>
+													컴포넌트 편집
+												</Button>
+
+												{/* Rich Text 기능 (텍스트 모드일 때만) */}
+												{mode === "text" && (
+													<>
+														<div
+															style={{
+																width: "1px",
+																height: "20px",
+																backgroundColor: "#C0C0C0",
+																margin: "0 4px",
+															}}
+														/>
+														<button
+															onClick={() => {
+																const iframeDoc =
+																	translatedIframeRef.current
+																		?.contentDocument ||
+																	translatedIframeRef.current?.contentWindow
+																		?.document;
+																if (iframeDoc)
+																	iframeDoc.execCommand("bold", false);
+															}}
+															style={{
+																padding: "4px 8px",
+																fontSize: "11px",
+																fontWeight: "bold",
+																border: "1px solid #A9A9A9",
+																borderRadius: "3px",
+																backgroundColor: "#FFFFFF",
+																color: "#000000",
+																cursor: "pointer",
+															}}
+															title="굵게 (Ctrl+B)"
+														>
+															B
+														</button>
+														<button
+															onClick={() => {
+																const iframeDoc =
+																	translatedIframeRef.current
+																		?.contentDocument ||
+																	translatedIframeRef.current?.contentWindow
+																		?.document;
+																if (iframeDoc)
+																	iframeDoc.execCommand("italic", false);
+															}}
+															style={{
+																padding: "4px 8px",
+																fontSize: "11px",
+																fontStyle: "italic",
+																border: "1px solid #A9A9A9",
+																borderRadius: "3px",
+																backgroundColor: "#FFFFFF",
+																color: "#000000",
+																cursor: "pointer",
+															}}
+															title="기울임 (Ctrl+I)"
+														>
+															I
+														</button>
+														<button
+															onClick={() => {
+																const iframeDoc =
+																	translatedIframeRef.current
+																		?.contentDocument ||
+																	translatedIframeRef.current?.contentWindow
+																		?.document;
+																if (iframeDoc)
+																	iframeDoc.execCommand("underline", false);
+															}}
+															style={{
+																padding: "4px 8px",
+																fontSize: "11px",
+																textDecoration: "underline",
+																border: "1px solid #A9A9A9",
+																borderRadius: "3px",
+																backgroundColor: "#FFFFFF",
+																color: "#000000",
+																cursor: "pointer",
+															}}
+															title="밑줄 (Ctrl+U)"
+														>
+															U
+														</button>
+														<button
+															onClick={() => {
+																const iframeDoc =
+																	translatedIframeRef.current
+																		?.contentDocument ||
+																	translatedIframeRef.current?.contentWindow
+																		?.document;
+																if (iframeDoc)
+																	iframeDoc.execCommand("strikeThrough", false);
+															}}
+															style={{
+																padding: "4px 8px",
+																fontSize: "11px",
+																textDecoration: "line-through",
+																border: "1px solid #A9A9A9",
+																borderRadius: "3px",
+																backgroundColor: "#FFFFFF",
+																color: "#000000",
+																cursor: "pointer",
+															}}
+															title="취소선"
+														>
+															S
+														</button>
+
+														<button
+															onClick={() => {
+																const iframeDoc =
+																	translatedIframeRef.current
+																		?.contentDocument ||
+																	translatedIframeRef.current?.contentWindow
+																		?.document;
+																if (!iframeDoc) return;
+																iframeDoc.execCommand("removeFormat", false);
+																// removeFormat이 border-style:solid 만 남기는 문제 수정
+																setTimeout(() => {
+																	iframeDoc
+																		.querySelectorAll("*")
+																		.forEach((el) => {
+																			const htmlEl = el as HTMLElement;
+																			if (
+																				htmlEl.style &&
+																				htmlEl.style.borderStyle === "solid" &&
+																				!htmlEl.style.borderWidth
+																			) {
+																				htmlEl.style.borderWidth = "0";
+																			}
+																		});
+																}, 0);
+															}}
+															style={{
+																padding: "4px 8px",
+																fontSize: "11px",
+																fontWeight: 600,
+																border: "1px solid #A9A9A9",
+																borderRadius: "3px",
+																backgroundColor: "#FFFFFF",
+																color: "#000000",
+																cursor: "pointer",
+															}}
+															title="서식 지우기 (선택 영역)"
+														>
+															서식 지우기
+														</button>
+
+														<div
+															style={{
+																width: "1px",
+																height: "20px",
+																backgroundColor: "#C0C0C0",
+																margin: "0 4px",
+															}}
+														/>
+														<select
+															onChange={(e) => {
+																const iframeDoc =
+																	translatedIframeRef.current
+																		?.contentDocument ||
+																	translatedIframeRef.current?.contentWindow
+																		?.document;
+																if (iframeDoc && e.target.value) {
+																	const fontSize = e.target.value;
+																	const selection = iframeDoc.getSelection();
+
+																	if (
+																		selection &&
+																		selection.rangeCount > 0 &&
+																		!selection.getRangeAt(0).collapsed
+																	) {
+																		const range = selection.getRangeAt(0);
+																		const selectedText = range.toString();
+
+																		const spanHtml = `<span style="font-size: ${fontSize}pt;">${selectedText}</span>`;
+
+																		try {
+																			iframeDoc.execCommand(
+																				"insertHTML",
+																				false,
+																				spanHtml,
+																			);
+																		} catch (err) {
+																			range.deleteContents();
+																			const tempDiv =
+																				iframeDoc.createElement("div");
+																			tempDiv.innerHTML = spanHtml;
+																			const fragment =
+																				iframeDoc.createDocumentFragment();
+																			while (tempDiv.firstChild) {
+																				fragment.appendChild(
+																					tempDiv.firstChild,
+																				);
+																			}
+																			range.insertNode(fragment);
+
+																			range.setStartAfter(
+																				fragment.lastChild ||
+																					range.startContainer,
+																			);
+																			range.collapse(false);
+																			selection.removeAllRanges();
+																			selection.addRange(range);
+																		}
+																	} else {
+																		iframeDoc.execCommand(
+																			"fontSize",
+																			false,
+																			"3",
+																		);
+																		setTimeout(() => {
+																			const fontSizeElements =
+																				iframeDoc.querySelectorAll(
+																					'font[size="3"]',
+																				);
+																			if (fontSizeElements.length > 0) {
+																				const lastElement = fontSizeElements[
+																					fontSizeElements.length - 1
+																				] as HTMLElement;
+																				lastElement.style.fontSize = `${fontSize}pt`;
+																				lastElement.removeAttribute("size");
+
+																				const span =
+																					iframeDoc.createElement("span");
+																				span.style.fontSize = `${fontSize}pt`;
+																				span.innerHTML = lastElement.innerHTML;
+
+																				if (lastElement.parentNode) {
+																					lastElement.parentNode.replaceChild(
+																						span,
+																						lastElement,
+																					);
+																				}
+																			}
+																		}, 0);
+																	}
+
+																	e.target.value = "";
+																}
+															}}
+															style={{
+																fontSize: "11px",
+																padding: "4px 8px",
+																border: "1px solid #A9A9A9",
+																borderRadius: "3px",
+																backgroundColor: "#FFFFFF",
+																color: "#000000",
+																cursor: "pointer",
+															}}
+															title="글자 크기 (pt)"
+														>
+															<option value="">크기</option>
+															<option value="8">8pt</option>
+															<option value="9">9pt</option>
+															<option value="10">10pt</option>
+															<option value="11">11pt</option>
+															<option value="12">12pt</option>
+															<option value="14">14pt</option>
+															<option value="16">16pt</option>
+															<option value="18">18pt</option>
+															<option value="20">20pt</option>
+															<option value="24">24pt</option>
+															<option value="28">28pt</option>
+															<option value="32">32pt</option>
+															<option value="36">36pt</option>
+															<option value="48">48pt</option>
+															<option value="72">72pt</option>
+														</select>
+														<select
+															onChange={(e) => {
+																const iframeDoc =
+																	translatedIframeRef.current
+																		?.contentDocument ||
+																	translatedIframeRef.current?.contentWindow
+																		?.document;
+																if (iframeDoc && e.target.value) {
+																	const lineHeight = e.target.value;
+																	const selection = iframeDoc.getSelection();
+
+																	if (selection && selection.rangeCount > 0) {
+																		const range = selection.getRangeAt(0);
+
+																		let blockElement: HTMLElement | null = null;
+
+																		if (
+																			range.commonAncestorContainer.nodeType ===
+																			1
+																		) {
+																			blockElement = (
+																				range.commonAncestorContainer as HTMLElement
+																			).closest(
+																				"p, div, h1, h2, h3, h4, h5, h6, li, blockquote, pre",
+																			);
+																		} else {
+																			blockElement =
+																				range.commonAncestorContainer.parentElement?.closest(
+																					"p, div, h1, h2, h3, h4, h5, h6, li, blockquote, pre",
+																				) || null;
+																		}
+
+																		if (blockElement) {
+																			try {
+																				const blockRange =
+																					iframeDoc.createRange();
+																				blockRange.selectNodeContents(
+																					blockElement,
+																				);
+																				selection.removeAllRanges();
+																				selection.addRange(blockRange);
+
+																				const originalHtml =
+																					blockElement.innerHTML;
+																				const tagName =
+																					blockElement.tagName.toLowerCase();
+																				const newHtml = `<${tagName} style="line-height: ${lineHeight};">${originalHtml}</${tagName}>`;
+
+																				iframeDoc.execCommand(
+																					"insertHTML",
+																					false,
+																					newHtml,
+																				);
+																			} catch (err) {
+																				blockElement.style.lineHeight =
+																					lineHeight;
+																			}
+																		} else {
+																			const div =
+																				iframeDoc.createElement("div");
+																			div.style.lineHeight = lineHeight;
+																			div.innerHTML = "&nbsp;";
+
+																			try {
+																				iframeDoc.execCommand(
+																					"insertHTML",
+																					false,
+																					div.outerHTML,
+																				);
+																			} catch (err) {
+																				range.insertNode(div);
+																			}
+																		}
+																	}
+
+																	e.target.value = "";
+																}
+															}}
+															style={{
+																fontSize: "11px",
+																padding: "4px 8px",
+																border: "1px solid #A9A9A9",
+																borderRadius: "3px",
+																backgroundColor: "#FFFFFF",
+																color: "#000000",
+																cursor: "pointer",
+																marginLeft: "4px",
+															}}
+															title="줄간격"
+														>
+															<option value="">줄간격</option>
+															<option value="1.0">1.0 (단일)</option>
+															<option value="1.15">1.15</option>
+															<option value="1.5">1.5 (기본)</option>
+															<option value="1.75">1.75</option>
+															<option value="2.0">2.0 (2배)</option>
+															<option value="2.5">2.5</option>
+															<option value="3.0">3.0</option>
+														</select>
+														<div
+															style={{
+																position: "relative",
+																display: "inline-block",
+																width: "30px",
+																height: "26px",
+															}}
+														>
+															<input
+																type="color"
+																onChange={(e) => {
+																	const iframeDoc =
+																		translatedIframeRef.current
+																			?.contentDocument ||
+																		translatedIframeRef.current?.contentWindow
+																			?.document;
+																	if (iframeDoc)
+																		iframeDoc.execCommand(
+																			"foreColor",
+																			false,
+																			e.target.value,
+																		);
+																}}
+																style={{
+																	position: "absolute",
+																	width: "100%",
+																	height: "100%",
+																	opacity: 0,
+																	cursor: "pointer",
+																	zIndex: 2,
+																}}
+																title="글자 색상"
+															/>
+															<button
+																style={{
+																	position: "absolute",
+																	width: "100%",
+																	height: "100%",
+																	border: "1px solid #A9A9A9",
+																	borderRadius: "3px",
+																	backgroundColor: "#FFFFFF",
+																	display: "flex",
+																	alignItems: "center",
+																	justifyContent: "center",
+																	cursor: "pointer",
+																	padding: 0,
+																	pointerEvents: "none",
+																}}
+																title="글자 색상"
+																disabled
+															>
+																<Palette size={16} color="#000000" />
+															</button>
+														</div>
+														<div
+															style={{
+																position: "relative",
+																display: "inline-block",
+																width: "30px",
+																height: "26px",
+																marginLeft: "4px",
+															}}
+														>
+															<input
+																type="color"
+																onChange={(e) => {
+																	const iframeDoc =
+																		translatedIframeRef.current
+																			?.contentDocument ||
+																		translatedIframeRef.current?.contentWindow
+																			?.document;
+																	if (iframeDoc)
+																		iframeDoc.execCommand(
+																			"backColor",
+																			false,
+																			e.target.value,
+																		);
+																}}
+																style={{
+																	position: "absolute",
+																	width: "100%",
+																	height: "100%",
+																	opacity: 0,
+																	cursor: "pointer",
+																	zIndex: 2,
+																}}
+																title="배경 색상"
+															/>
+															<button
+																style={{
+																	position: "absolute",
+																	width: "100%",
+																	height: "100%",
+																	border: "1px solid #A9A9A9",
+																	borderRadius: "3px",
+																	backgroundColor: "#FFFFFF",
+																	display: "flex",
+																	alignItems: "center",
+																	justifyContent: "center",
+																	cursor: "pointer",
+																	padding: 0,
+																	pointerEvents: "none",
+																}}
+																title="배경 색상"
+																disabled
+															>
+																<Highlighter size={16} color="#000000" />
+															</button>
+														</div>
+														<div
+															style={{
+																width: "1px",
+																height: "20px",
+																backgroundColor: "#C0C0C0",
+																margin: "0 4px",
+															}}
+														/>
+														<button
+															onClick={() => {
+																const iframeDoc =
+																	translatedIframeRef.current
+																		?.contentDocument ||
+																	translatedIframeRef.current?.contentWindow
+																		?.document;
+																if (iframeDoc)
+																	iframeDoc.execCommand("justifyLeft", false);
+															}}
+															style={{
+																padding: "4px 8px",
+																fontSize: "11px",
+																border: "1px solid #A9A9A9",
+																borderRadius: "3px",
+																backgroundColor: "#FFFFFF",
+																color: "#000000",
+																cursor: "pointer",
+																display: "flex",
+																alignItems: "center",
+																justifyContent: "center",
+															}}
+															title="왼쪽 정렬"
+														>
+															<AlignLeft size={16} />
+														</button>
+														<button
+															onClick={() => {
+																const iframeDoc =
+																	translatedIframeRef.current
+																		?.contentDocument ||
+																	translatedIframeRef.current?.contentWindow
+																		?.document;
+																if (iframeDoc)
+																	iframeDoc.execCommand("justifyCenter", false);
+															}}
+															style={{
+																padding: "4px 8px",
+																fontSize: "11px",
+																border: "1px solid #A9A9A9",
+																borderRadius: "3px",
+																backgroundColor: "#FFFFFF",
+																color: "#000000",
+																cursor: "pointer",
+																display: "flex",
+																alignItems: "center",
+																justifyContent: "center",
+															}}
+															title="가운데 정렬"
+														>
+															<AlignCenter size={16} />
+														</button>
+														<button
+															onClick={() => {
+																const iframeDoc =
+																	translatedIframeRef.current
+																		?.contentDocument ||
+																	translatedIframeRef.current?.contentWindow
+																		?.document;
+																if (iframeDoc)
+																	iframeDoc.execCommand("justifyRight", false);
+															}}
+															style={{
+																padding: "4px 8px",
+																fontSize: "11px",
+																border: "1px solid #A9A9A9",
+																borderRadius: "3px",
+																backgroundColor: "#FFFFFF",
+																color: "#000000",
+																cursor: "pointer",
+																display: "flex",
+																alignItems: "center",
+																justifyContent: "center",
+															}}
+															title="오른쪽 정렬"
+														>
+															<AlignRight size={16} />
+														</button>
+
+														<button
+															onClick={() => {
+																const iframeDoc =
+																	translatedIframeRef.current
+																		?.contentDocument ||
+																	translatedIframeRef.current?.contentWindow
+																		?.document;
+																if (iframeDoc)
+																	iframeDoc.execCommand("justifyFull", false);
+															}}
+															style={{
+																padding: "4px 8px",
+																fontSize: "11px",
+																border: "1px solid #A9A9A9",
+																borderRadius: "3px",
+																backgroundColor: "#FFFFFF",
+																color: "#000000",
+																cursor: "pointer",
+																display: "flex",
+																alignItems: "center",
+																justifyContent: "center",
+															}}
+															title="양쪽 정렬"
+														>
+															<AlignJustify size={16} />
+														</button>
+
+														<div
+															style={{
+																width: "1px",
+																height: "20px",
+																backgroundColor: "#C0C0C0",
+																margin: "0 4px",
+															}}
+														/>
+														<button
+															onClick={() => {
+																const iframeDoc =
+																	translatedIframeRef.current
+																		?.contentDocument ||
+																	translatedIframeRef.current?.contentWindow
+																		?.document;
+																if (iframeDoc)
+																	iframeDoc.execCommand(
+																		"insertUnorderedList",
+																		false,
+																	);
+															}}
+															style={{
+																padding: "4px 8px",
+																fontSize: "11px",
+																border: "1px solid #A9A9A9",
+																borderRadius: "3px",
+																backgroundColor: "#FFFFFF",
+																color: "#000000",
+																cursor: "pointer",
+																display: "flex",
+																alignItems: "center",
+																justifyContent: "center",
+															}}
+															title="글머리 기호 목록"
+														>
+															<List size={16} />
+														</button>
+														<button
+															onClick={() => {
+																const iframeDoc =
+																	translatedIframeRef.current
+																		?.contentDocument ||
+																	translatedIframeRef.current?.contentWindow
+																		?.document;
+																if (iframeDoc)
+																	iframeDoc.execCommand(
+																		"insertOrderedList",
+																		false,
+																	);
+															}}
+															style={{
+																padding: "4px 8px",
+																fontSize: "11px",
+																border: "1px solid #A9A9A9",
+																borderRadius: "3px",
+																backgroundColor: "#FFFFFF",
+																color: "#000000",
+																cursor: "pointer",
+																display: "flex",
+																alignItems: "center",
+																justifyContent: "center",
+															}}
+															title="번호 매기기 목록"
+														>
+															<ListOrdered size={16} />
+														</button>
+														<button
+															onClick={() => {
+																const iframeDoc =
+																	translatedIframeRef.current
+																		?.contentDocument ||
+																	translatedIframeRef.current?.contentWindow
+																		?.document;
+																if (iframeDoc) {
+																	const url = prompt("링크 URL을 입력하세요:");
+																	if (url)
+																		iframeDoc.execCommand(
+																			"createLink",
+																			false,
+																			url,
+																		);
+																}
+															}}
+															style={{
+																padding: "4px 8px",
+																fontSize: "11px",
+																border: "1px solid #A9A9A9",
+																borderRadius: "3px",
+																backgroundColor: "#FFFFFF",
+																color: "#000000",
+																cursor: "pointer",
+																display: "flex",
+																alignItems: "center",
+																justifyContent: "center",
+															}}
+															title="링크 삽입"
+														>
+															<Link2 size={16} />
+														</button>
+														<div
+															style={{
+																width: "1px",
+																height: "20px",
+																backgroundColor: "#C0C0C0",
+																margin: "0 4px",
+															}}
+														/>
+														<div
+															style={{
+																position: "relative",
+																display: "inline-block",
+															}}
+														>
+															<input
+																type="file"
+																accept="image/*"
+																onChange={(e) => {
+																	const file = e.target.files?.[0];
+																	if (file) {
+																		const reader = new FileReader();
+																		reader.onload = (event) => {
+																			const imageUrl = event.target
+																				?.result as string;
+																			const iframeDoc =
+																				translatedIframeRef.current
+																					?.contentDocument ||
+																				translatedIframeRef.current
+																					?.contentWindow?.document;
+																			if (iframeDoc && imageUrl) {
+																				try {
+																					iframeDoc.execCommand(
+																						"insertHTML",
+																						false,
+																						`<img src="${imageUrl}" alt="" style="max-width: 100%; height: auto;" />`,
+																					);
+																				} catch (err) {
+																					const selection =
+																						iframeDoc.getSelection();
+																					if (
+																						selection &&
+																						selection.rangeCount > 0
+																					) {
+																						const range =
+																							selection.getRangeAt(0);
+																						const img =
+																							iframeDoc.createElement("img");
+																						img.src = imageUrl;
+																						img.alt = "";
+																						img.style.maxWidth = "100%";
+																						img.style.height = "auto";
+																						range.insertNode(img);
+																					}
+																				}
+																			}
+																		};
+																		reader.readAsDataURL(file);
+																	}
+																	e.target.value = "";
+																}}
+																style={{
+																	position: "absolute",
+																	width: "100%",
+																	height: "100%",
+																	opacity: 0,
+																	cursor: "pointer",
+																	zIndex: 2,
+																}}
+																title="이미지 삽입"
+															/>
+															<button
+																style={{
+																	padding: "4px 8px",
+																	fontSize: "11px",
+																	border: "1px solid #A9A9A9",
+																	borderRadius: "3px",
+																	backgroundColor: "#FFFFFF",
+																	color: "#000000",
+																	cursor: "pointer",
+																	display: "flex",
+																	alignItems: "center",
+																	justifyContent: "center",
+																	pointerEvents: "none",
+																}}
+																title="이미지 삽입"
+																disabled
+															>
+																<Image size={16} />
+															</button>
+														</div>
+														<button
+															onClick={() => {
+																const iframeDoc =
+																	translatedIframeRef.current
+																		?.contentDocument ||
+																	translatedIframeRef.current?.contentWindow
+																		?.document;
+																if (iframeDoc) {
+																	try {
+																		iframeDoc.execCommand(
+																			"insertHTML",
+																			false,
+																			'<pre style="background-color: #f4f4f4; padding: 10px; border-radius: 4px; overflow-x: auto;"><code></code></pre>',
+																		);
+																	} catch (err) {
+																		iframeDoc.execCommand(
+																			"formatBlock",
+																			false,
+																			"pre",
+																		);
+																		const selection = iframeDoc.getSelection();
+																		if (selection && selection.rangeCount > 0) {
+																			const range = selection.getRangeAt(0);
+																			const preElement =
+																				range.commonAncestorContainer
+																					.nodeType === 1
+																					? (range.commonAncestorContainer as HTMLElement)
+																					: (range.commonAncestorContainer
+																							.parentElement as HTMLElement);
+																			if (
+																				preElement &&
+																				preElement.tagName === "PRE"
+																			) {
+																				preElement.style.backgroundColor =
+																					"#f4f4f4";
+																				preElement.style.padding = "10px";
+																				preElement.style.borderRadius = "4px";
+																				preElement.style.overflowX = "auto";
+																			}
+																		}
+																	}
+																}
+															}}
+															style={{
+																padding: "4px 8px",
+																fontSize: "11px",
+																border: "1px solid #A9A9A9",
+																borderRadius: "3px",
+																backgroundColor: "#FFFFFF",
+																color: "#000000",
+																cursor: "pointer",
+																display: "flex",
+																alignItems: "center",
+																justifyContent: "center",
+															}}
+															title="코드 블록"
+														>
+															<Code size={16} />
+														</button>
+														<div
+															style={{
+																position: "relative",
+																display: "inline-block",
+															}}
+															data-more-menu
+														>
+															<button
+																onClick={() => setShowMoreMenu(!showMoreMenu)}
+																style={{
+																	padding: "4px 8px",
+																	fontSize: "11px",
+																	border: "1px solid #A9A9A9",
+																	borderRadius: "3px",
+																	backgroundColor: showMoreMenu
+																		? "#E0E0E0"
+																		: "#FFFFFF",
+																	color: "#000000",
+																	cursor: "pointer",
+																	display: "flex",
+																	alignItems: "center",
+																	justifyContent: "center",
+																}}
+																title="더보기"
+															>
+																<MoreVertical size={16} />
+															</button>
+															{showMoreMenu && (
+																<div
+																	style={{
+																		position: "absolute",
+																		top: "100%",
+																		right: 0,
+																		marginTop: "4px",
+																		backgroundColor: "#FFFFFF",
+																		border: "1px solid #A9A9A9",
+																		borderRadius: "4px",
+																		boxShadow: "0 2px 8px rgba(0,0,0,0.15)",
+																		zIndex: 1000,
+																		display: "flex",
+																		flexDirection: "row",
+																		gap: "4px",
+																		padding: "4px",
+																	}}
+																	onClick={(e) => e.stopPropagation()}
+																	data-more-menu
+																>
+																	<button
+																		onClick={() => {
+																			const iframeDoc =
+																				translatedIframeRef.current
+																					?.contentDocument ||
+																				translatedIframeRef.current
+																					?.contentWindow?.document;
+																			if (iframeDoc) {
+																				iframeDoc.execCommand(
+																					"formatBlock",
+																					false,
+																					"blockquote",
+																				);
+																			}
+																			setShowMoreMenu(false);
+																		}}
+																		style={{
+																			padding: "4px 8px",
+																			fontSize: "11px",
+																			border: "1px solid #A9A9A9",
+																			borderRadius: "3px",
+																			backgroundColor: "#FFFFFF",
+																			color: "#000000",
+																			cursor: "pointer",
+																			display: "flex",
+																			alignItems: "center",
+																			justifyContent: "center",
+																		}}
+																		title="인용문"
+																	>
+																		<Quote size={16} />
+																	</button>
+																	<button
+																		onClick={() => {
+																			const iframeDoc =
+																				translatedIframeRef.current
+																					?.contentDocument ||
+																				translatedIframeRef.current
+																					?.contentWindow?.document;
+																			if (iframeDoc) {
+																				iframeDoc.execCommand(
+																					"insertHorizontalRule",
+																					false,
+																				);
+																			}
+																			setShowMoreMenu(false);
+																		}}
+																		style={{
+																			padding: "4px 8px",
+																			fontSize: "11px",
+																			border: "1px solid #A9A9A9",
+																			borderRadius: "3px",
+																			backgroundColor: "#FFFFFF",
+																			color: "#000000",
+																			cursor: "pointer",
+																			display: "flex",
+																			alignItems: "center",
+																			justifyContent: "center",
+																		}}
+																		title="구분선"
+																	>
+																		<Minus size={16} />
+																	</button>
+																	<button
+																		onClick={() => {
+																			const iframeDoc =
+																				translatedIframeRef.current
+																					?.contentDocument ||
+																				translatedIframeRef.current
+																					?.contentWindow?.document;
+																			if (iframeDoc) {
+																				const rows = prompt(
+																					"행 수를 입력하세요 (기본값: 3):",
+																					"3",
+																				);
+																				const cols = prompt(
+																					"열 수를 입력하세요 (기본값: 3):",
+																					"3",
+																				);
+																				const rowCount = Number.parseInt(
+																					rows || "3",
+																					10,
+																				);
+																				const colCount = Number.parseInt(
+																					cols || "3",
+																					10,
+																				);
+
+																				if (rowCount > 0 && colCount > 0) {
+																					let tableHtml =
+																						'<table border="1" style="border-collapse: collapse; width: 100%;">';
+																					for (let i = 0; i < rowCount; i++) {
+																						tableHtml += "<tr>";
+																						for (let j = 0; j < colCount; j++) {
+																							tableHtml +=
+																								'<td style="padding: 8px; border: 1px solid #000;">&nbsp;</td>';
+																						}
+																						tableHtml += "</tr>";
+																					}
+																					tableHtml += "</table>";
+
+																					try {
+																						iframeDoc.execCommand(
+																							"insertHTML",
+																							false,
+																							tableHtml,
+																						);
+																					} catch (err) {
+																						const selection =
+																							iframeDoc.getSelection();
+																						if (
+																							selection &&
+																							selection.rangeCount > 0
+																						) {
+																							const range =
+																								selection.getRangeAt(0);
+																							const tempDiv =
+																								iframeDoc.createElement("div");
+																							tempDiv.innerHTML = tableHtml;
+																							const fragment =
+																								iframeDoc.createDocumentFragment();
+																							while (tempDiv.firstChild) {
+																								fragment.appendChild(
+																									tempDiv.firstChild,
+																								);
+																							}
+																							range.insertNode(fragment);
+																						}
+																					}
+																				}
+																			}
+																			setShowMoreMenu(false);
+																		}}
+																		style={{
+																			padding: "4px 8px",
+																			fontSize: "11px",
+																			border: "1px solid #A9A9A9",
+																			borderRadius: "3px",
+																			backgroundColor: "#FFFFFF",
+																			color: "#000000",
+																			cursor: "pointer",
+																			display: "flex",
+																			alignItems: "center",
+																			justifyContent: "center",
+																		}}
+																		title="표"
+																	>
+																		<Table size={16} />
+																	</button>
+																	<button
+																		onClick={() => {
+																			const iframeDoc =
+																				translatedIframeRef.current
+																					?.contentDocument ||
+																				translatedIframeRef.current
+																					?.contentWindow?.document;
+																			if (iframeDoc) {
+																				const selection =
+																					iframeDoc.getSelection();
+																				if (
+																					selection &&
+																					selection.rangeCount > 0 &&
+																					!selection.getRangeAt(0).collapsed
+																				) {
+																					const range = selection.getRangeAt(0);
+																					const selectedText = range.toString();
+
+																					try {
+																						iframeDoc.execCommand(
+																							"insertHTML",
+																							false,
+																							`<sup>${selectedText}</sup>`,
+																						);
+																					} catch (err) {
+																						const sup =
+																							iframeDoc.createElement("sup");
+																						sup.textContent = selectedText;
+																						range.deleteContents();
+																						range.insertNode(sup);
+																					}
+																				} else {
+																					try {
+																						iframeDoc.execCommand(
+																							"insertHTML",
+																							false,
+																							"<sup></sup>",
+																						);
+																					} catch (err) {
+																						const selection =
+																							iframeDoc.getSelection();
+																						if (
+																							selection &&
+																							selection.rangeCount > 0
+																						) {
+																							const range =
+																								selection.getRangeAt(0);
+																							const sup =
+																								iframeDoc.createElement("sup");
+																							sup.innerHTML = "&nbsp;";
+																							range.insertNode(sup);
+																						}
+																					}
+																				}
+																			}
+																			setShowMoreMenu(false);
+																		}}
+																		style={{
+																			padding: "4px 8px",
+																			fontSize: "11px",
+																			border: "1px solid #A9A9A9",
+																			borderRadius: "3px",
+																			backgroundColor: "#FFFFFF",
+																			color: "#000000",
+																			cursor: "pointer",
+																			display: "flex",
+																			alignItems: "center",
+																			justifyContent: "center",
+																		}}
+																		title="위 첨자"
+																	>
+																		<Superscript size={16} />
+																	</button>
+																	<button
+																		onClick={() => {
+																			const iframeDoc =
+																				translatedIframeRef.current
+																					?.contentDocument ||
+																				translatedIframeRef.current
+																					?.contentWindow?.document;
+																			if (iframeDoc) {
+																				const selection =
+																					iframeDoc.getSelection();
+																				if (
+																					selection &&
+																					selection.rangeCount > 0 &&
+																					!selection.getRangeAt(0).collapsed
+																				) {
+																					const range = selection.getRangeAt(0);
+																					const selectedText = range.toString();
+
+																					try {
+																						iframeDoc.execCommand(
+																							"insertHTML",
+																							false,
+																							`<sub>${selectedText}</sub>`,
+																						);
+																					} catch (err) {
+																						const sub =
+																							iframeDoc.createElement("sub");
+																						sub.textContent = selectedText;
+																						range.deleteContents();
+																						range.insertNode(sub);
+																					}
+																				} else {
+																					try {
+																						iframeDoc.execCommand(
+																							"insertHTML",
+																							false,
+																							"<sub></sub>",
+																						);
+																					} catch (err) {
+																						const selection =
+																							iframeDoc.getSelection();
+																						if (
+																							selection &&
+																							selection.rangeCount > 0
+																						) {
+																							const range =
+																								selection.getRangeAt(0);
+																							const sub =
+																								iframeDoc.createElement("sub");
+																							sub.innerHTML = "&nbsp;";
+																							range.insertNode(sub);
+																						}
+																					}
+																				}
+																			}
+																			setShowMoreMenu(false);
+																		}}
+																		style={{
+																			padding: "4px 8px",
+																			fontSize: "11px",
+																			border: "1px solid #A9A9A9",
+																			borderRadius: "3px",
+																			backgroundColor: "#FFFFFF",
+																			color: "#000000",
+																			cursor: "pointer",
+																			display: "flex",
+																			alignItems: "center",
+																			justifyContent: "center",
+																		}}
+																		title="아래 첨자"
+																	>
+																		<Subscript size={16} />
+																	</button>
+																</div>
+															)}
+														</div>
+														<div
+															style={{
+																width: "1px",
+																height: "20px",
+																backgroundColor: "#C0C0C0",
+																margin: "0 4px",
+															}}
+														/>
+														<button
+															onClick={() => {
+																const iframe = translatedIframeRef.current;
+																const iframeDoc =
+																	iframe?.contentDocument ||
+																	iframe?.contentWindow?.document;
+																if (!iframeDoc) return;
+
+																if (mode === "text") {
+																	iframeDoc.body.setAttribute("tabindex", "-1");
+																	iframeDoc.body.focus();
+																	iframeDoc.execCommand("undo", false);
+																	const updatedHtml =
+																		iframeDoc.documentElement.outerHTML;
+																	currentHtmlRef.current = updatedHtml;
+																	onTranslatedChange(updatedHtml);
+																} else {
+																	if (undoStackRef.current.length > 0) {
+																		const currentHtml =
+																			iframeDoc.documentElement.outerHTML;
+																		redoStackRef.current.push(currentHtml);
+																		const previousHtml =
+																			undoStackRef.current.pop() || "";
+																		iframeDoc.open();
+																		iframeDoc.write(previousHtml);
+																		iframeDoc.close();
+																		currentHtmlRef.current = previousHtml;
+																		onTranslatedChange(previousHtml);
+																		setSelectedElements([]);
+																	}
+																}
+															}}
+															style={{
+																padding: "4px 8px",
+																fontSize: "11px",
+																border: "1px solid #A9A9A9",
+																borderRadius: "3px",
+																backgroundColor: "#FFFFFF",
+																color: "#000000",
+																cursor: "pointer",
+																display: "flex",
+																alignItems: "center",
+																justifyContent: "center",
+															}}
+															title="실행 취소 (Ctrl/Cmd+Z)"
+														>
+															<Undo2 size={16} color="#000000" />
+														</button>
+														<button
+															onClick={() => {
+																const iframe = translatedIframeRef.current;
+																const iframeDoc =
+																	iframe?.contentDocument ||
+																	iframe?.contentWindow?.document;
+																if (!iframeDoc) return;
+
+																if (mode === "text") {
+																	iframeDoc.body.setAttribute("tabindex", "-1");
+																	iframeDoc.body.focus();
+																	iframeDoc.execCommand("redo", false);
+																	const updatedHtml =
+																		iframeDoc.documentElement.outerHTML;
+																	currentHtmlRef.current = updatedHtml;
+																	onTranslatedChange(updatedHtml);
+																} else {
+																	if (redoStackRef.current.length > 0) {
+																		const currentHtml =
+																			iframeDoc.documentElement.outerHTML;
+																		undoStackRef.current.push(currentHtml);
+																		const nextHtml =
+																			redoStackRef.current.pop() || "";
+																		iframeDoc.open();
+																		iframeDoc.write(nextHtml);
+																		iframeDoc.close();
+																		currentHtmlRef.current = nextHtml;
+																		onTranslatedChange(nextHtml);
+																		setSelectedElements([]);
+																	}
+																}
+															}}
+															style={{
+																padding: "4px 8px",
+																fontSize: "11px",
+																border: "1px solid #A9A9A9",
+																borderRadius: "3px",
+																backgroundColor: "#FFFFFF",
+																color: "#000000",
+																cursor: "pointer",
+																display: "flex",
+																alignItems: "center",
+																justifyContent: "center",
+															}}
+															title="다시 실행 (Ctrl/Cmd+Y)"
+														>
+															<Redo2 size={16} color="#000000" />
+														</button>
+													</>
+												)}
+											</div>
+											{mode === "component" && (
+												<div
+													style={{
+														display: "flex",
+														gap: "4px",
+														alignItems: "center",
+													}}
+												>
+													<span style={{ fontSize: "11px", color: "#696969" }}>
+														{selectedElements.length}개 선택됨
+													</span>
+													<Button
+														variant="secondary"
+														onClick={() => {
+															if (!translatedIframeRef.current) return;
+															const iframeDoc =
+																translatedIframeRef.current.contentDocument ||
+																translatedIframeRef.current.contentWindow
+																	?.document;
+															if (iframeDoc) {
+																selectedElements.forEach((el) => {
+																	el.classList.remove("component-selected");
+																	el.style.outline = "";
+																	el.style.boxShadow = "";
+																	el.style.backgroundColor = "";
+																	el.style.outlineOffset = "";
+																});
+															}
+															setSelectedElements([]);
+														}}
+														disabled={selectedElements.length === 0}
+														style={{ fontSize: "11px", padding: "4px 8px" }}
+														title="전체 선택 취소"
+													>
+														선택 취소
+													</Button>
+													<Button
+														variant="primary"
+														onClick={handleDelete}
+														disabled={selectedElements.length === 0}
+														style={{ fontSize: "11px", padding: "4px 8px" }}
+													>
+														삭제
+													</Button>
+												</div>
+											)}
+										</div>
+									</>
+								)}
+
+								<div style={{ flex: 1, overflow: "hidden" }}>
+									<iframe
+										ref={panel.ref}
+										style={{
+											width: "100%",
+											height: "100%",
+											border: "none",
+											display: "block",
+										}}
+										title={panel.title}
+									/>
+								</div>
+							</div>
+						</div>
+					);
+				})}
+			</div>
+		</div>
+	);
 };
 
 const NewTranslation: React.FC = () => {
-  const navigate = useNavigate();
-  const { user } = useUser();
-  const { setIsCollapsed } = useSidebar();
-  const [currentStep, setCurrentStep] = useState(1);
-  const [isManualPasteMode, setIsManualPasteMode] = useState(false);
-  
-  // ⭐ localStorage에서 draft 복원 (뒤로가기 대응)
-  const loadDraftFromStorage = (): TranslationDraft | null => {
-    try {
-      const saved = localStorage.getItem('transflow-draft');
-      if (saved) {
-        const parsed = JSON.parse(saved);
-        console.log('📦 localStorage에서 draft 복원:', parsed);
-        return parsed;
-      }
-    } catch (e) {
-      console.warn('⚠️ localStorage에서 draft 복원 실패:', e);
-    }
-    return null;
-  };
+	const navigate = useNavigate();
+	const { user } = useUser();
+	const { setIsCollapsed } = useSidebar();
+	const [currentStep, setCurrentStep] = useState(1);
+	const [isManualPasteMode, setIsManualPasteMode] = useState(false);
 
-  // ⭐ localStorage에 draft 저장
-  const saveDraftToStorage = (draftToSave: TranslationDraft) => {
-    try {
-      localStorage.setItem('transflow-draft', JSON.stringify(draftToSave));
-      console.log('💾 localStorage에 draft 저장 완료');
-    } catch (e) {
-      console.warn('⚠️ localStorage에 draft 저장 실패:', e);
-    }
-  };
+	// ⭐ localStorage에서 draft 복원 (뒤로가기 대응)
+	const loadDraftFromStorage = (): TranslationDraft | null => {
+		try {
+			const saved = localStorage.getItem("transflow-draft");
+			if (saved) {
+				const parsed = JSON.parse(saved);
+				console.log("📦 localStorage에서 draft 복원:", parsed);
+				return parsed;
+			}
+		} catch (e) {
+			console.warn("⚠️ localStorage에서 draft 복원 실패:", e);
+		}
+		return null;
+	};
 
-  // 초기 draft 상태 (항상 빈 상태로 시작 - 새 번역은 항상 새로운 작업)
-  const [draft, setDraft] = useState<TranslationDraft>(() => {
-    return {
-      url: '',
-      selectedAreas: [],
-      originalHtml: '',
-      originalHtmlWithIds: '', // STEP 2의 iframe HTML (data-transflow-id 포함)
-      state: DocumentState.DRAFT,
-    };
-  });
-  const [documentId, setDocumentId] = useState<number | null>(null);
-  const [step6Data, setStep6Data] = useState<{ title?: string; categoryId?: number; estimatedLength?: number } | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
-  const [loadingProgress, setLoadingProgress] = useState(0);
-  const [isTranslating, setIsTranslating] = useState(false);
-  const [translatingProgress, setTranslatingProgress] = useState(0);
-  const [isCreating, setIsCreating] = useState(false);
-  const [lastSaved, setLastSaved] = useState<Date | null>(null);
-  const [saveError, setSaveError] = useState<string | null>(null);
-  const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
-  const [draftDocuments, setDraftDocuments] = useState<DocumentResponse[]>([]);
-  const step6Ref = React.useRef<{ handleDraftSave: () => void; handlePublish: () => void } | null>(null);
-  // Step 5용 패널 접기/펼치기 상태
-  const [step5CollapsedPanels, setStep5CollapsedPanels] = useState<Set<string>>(new Set());
-  const [showStep5Version0Glossary, setShowStep5Version0Glossary] = useState(false);
-  const [step5GlossaryTerms, setStep5GlossaryTerms] = useState<GlossaryTermPair[]>([]);
-  const [showUrlModal, setShowUrlModal] = useState(false);
-  const [urlModalInput, setUrlModalInput] = useState('');
+	// ⭐ localStorage에 draft 저장
+	const saveDraftToStorage = (draftToSave: TranslationDraft) => {
+		try {
+			localStorage.setItem("transflow-draft", JSON.stringify(draftToSave));
+			console.log("💾 localStorage에 draft 저장 완료");
+		} catch (e) {
+			console.warn("⚠️ localStorage에 draft 저장 실패:", e);
+		}
+	};
 
-  const userRole = useMemo(() => {
-    if (!user) return null;
-    return roleLevelToRole(user.roleLevel);
-  }, [user]);
+	// 초기 draft 상태 (항상 빈 상태로 시작 - 새 번역은 항상 새로운 작업)
+	const [draft, setDraft] = useState<TranslationDraft>(() => {
+		return {
+			url: "",
+			selectedAreas: [],
+			originalHtml: "",
+			originalHtmlWithIds: "", // STEP 2의 iframe HTML (data-transflow-id 포함)
+			state: DocumentState.DRAFT,
+		};
+	});
+	const [documentId, setDocumentId] = useState<number | null>(null);
+	const [step6Data, setStep6Data] = useState<{
+		title?: string;
+		categoryId?: number;
+		estimatedLength?: number;
+	} | null>(null);
+	const [isLoading, setIsLoading] = useState(false);
+	const [loadingProgress, setLoadingProgress] = useState(0);
+	const [isTranslating, setIsTranslating] = useState(false);
+	const [translatingProgress, setTranslatingProgress] = useState(0);
+	const [isCreating, setIsCreating] = useState(false);
+	const [lastSaved, setLastSaved] = useState<Date | null>(null);
+	const [saveError, setSaveError] = useState<string | null>(null);
+	const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
+	const [draftDocuments, setDraftDocuments] = useState<DocumentResponse[]>([]);
+	const step6Ref = React.useRef<{
+		handleDraftSave: () => void;
+		handlePublish: () => void;
+	} | null>(null);
+	// Step 5용 패널 접기/펼치기 상태
+	const [step5CollapsedPanels, setStep5CollapsedPanels] = useState<Set<string>>(
+		new Set(),
+	);
+	const [showStep5Version0Glossary, setShowStep5Version0Glossary] =
+		useState(false);
+	const [step5GlossaryTerms, setStep5GlossaryTerms] = useState<
+		GlossaryTermPair[]
+	>([]);
+	const [showUrlModal, setShowUrlModal] = useState(false);
+	const [urlModalInput, setUrlModalInput] = useState("");
 
-  const isAuthorized = useMemo(() => {
-    return userRole === UserRole.SUPER_ADMIN || userRole === UserRole.ADMIN;
-  }, [userRole]);
+	const userRole = useMemo(() => {
+		if (!user) return null;
+		return roleLevelToRole(user.roleLevel);
+	}, [user]);
 
-  // 사이드바 자동 접기 제거 (사용자가 직접 제어)
+	const isAuthorized = useMemo(() => {
+		return userRole === UserRole.SUPER_ADMIN || userRole === UserRole.ADMIN;
+	}, [userRole]);
 
-  // ⭐ 새 번역 시작 시 localStorage draft 초기화 (다른 기기/브라우저에서 예전 데이터가 남아있는 문제 해결)
-  useEffect(() => {
-    // 컴포넌트 마운트 시 localStorage의 draft 초기화
-    // "새 번역 만들기"는 항상 새로운 작업을 시작하는 것이므로
-    try {
-      localStorage.removeItem('transflow-draft');
-      console.log('🗑️ 새 번역 시작: localStorage draft 초기화 완료');
-    } catch (e) {
-      console.warn('⚠️ localStorage 초기화 실패:', e);
-    }
-  }, []); // 컴포넌트 마운트 시 한 번만 실행
+	// 사이드바 자동 접기 제거 (사용자가 직접 제어)
 
-  // 임시저장 문서 로드
-  useEffect(() => {
-    const loadDraftDocuments = async () => {
-      try {
-        const allDocs = await documentApi.getAllDocuments();
-        console.log('📋 [NewTranslation] 전체 문서 조회:', allDocs.length, '개');
-        console.log('📋 [NewTranslation] 문서 샘플:', allDocs.slice(0, 3).map(doc => ({
-          id: doc.id,
-          title: doc.title,
-          status: doc.status,
-          hasVersions: doc.hasVersions,
-          versionCount: doc.versionCount
-        })));
-        const draftOnlyDocs = allDocs.filter(doc => 
-          doc.status === 'DRAFT' && doc.hasVersions !== true
-        );
-        console.log('📋 [NewTranslation] 임시저장 문서 필터링 결과:', draftOnlyDocs.length, '개');
-        setDraftDocuments(draftOnlyDocs);
-        console.log('📋 임시저장 문서 로드 완료:', draftOnlyDocs.length, '개');
-      } catch (error) {
-        console.error('임시저장 문서 로드 실패:', error);
-      }
-    };
-    loadDraftDocuments();
-  }, []);
+	// ⭐ 새 번역 시작 시 localStorage draft 초기화 (다른 기기/브라우저에서 예전 데이터가 남아있는 문제 해결)
+	useEffect(() => {
+		// 컴포넌트 마운트 시 localStorage의 draft 초기화
+		// "새 번역 만들기"는 항상 새로운 작업을 시작하는 것이므로
+		try {
+			localStorage.removeItem("transflow-draft");
+			console.log("🗑️ 새 번역 시작: localStorage draft 초기화 완료");
+		} catch (e) {
+			console.warn("⚠️ localStorage 초기화 실패:", e);
+		}
+	}, []); // 컴포넌트 마운트 시 한 번만 실행
 
-  // Step 5 (Version 0) 용어집 sourceTerm 로드
-  useEffect(() => {
-    const loadStep5GlossaryTerms = async () => {
-      try {
-        const sourceLangRaw = (draft.sourceLang || '').toUpperCase();
-        const sourceLang = sourceLangRaw === 'AUTO' ? 'EN' : sourceLangRaw;
-        const targetLang = (draft.targetLang || '').toUpperCase();
+	// 임시저장 문서 로드
+	useEffect(() => {
+		const loadDraftDocuments = async () => {
+			try {
+				const allDocs = await documentApi.getAllDocuments();
+				console.log(
+					"📋 [NewTranslation] 전체 문서 조회:",
+					allDocs.length,
+					"개",
+				);
+				console.log(
+					"📋 [NewTranslation] 문서 샘플:",
+					allDocs.slice(0, 3).map((doc) => ({
+						id: doc.id,
+						title: doc.title,
+						status: doc.status,
+						hasVersions: doc.hasVersions,
+						versionCount: doc.versionCount,
+					})),
+				);
+				const draftOnlyDocs = allDocs.filter(
+					(doc) => doc.status === "DRAFT" && doc.hasVersions !== true,
+				);
+				console.log(
+					"📋 [NewTranslation] 임시저장 문서 필터링 결과:",
+					draftOnlyDocs.length,
+					"개",
+				);
+				setDraftDocuments(draftOnlyDocs);
+				console.log("📋 임시저장 문서 로드 완료:", draftOnlyDocs.length, "개");
+			} catch (error) {
+				console.error("임시저장 문서 로드 실패:", error);
+			}
+		};
+		loadDraftDocuments();
+	}, []);
 
-        if (!sourceLang || !targetLang) {
-          setStep5GlossaryTerms([]);
-          return;
-        }
+	// Step 5 (Version 0) 용어집 sourceTerm 로드
+	useEffect(() => {
+		const loadStep5GlossaryTerms = async () => {
+			try {
+				const sourceLangRaw = (draft.sourceLang || "").toUpperCase();
+				const sourceLang = sourceLangRaw === "AUTO" ? "EN" : sourceLangRaw;
+				const targetLang = (draft.targetLang || "").toUpperCase();
 
-        const termRes = await termApi.getAllTerms({ sourceLang, targetLang, page: 0, size: 1000 });
-        setStep5GlossaryTerms(
-          (termRes.content || [])
-            .filter((t) => t.sourceTerm && t.targetTerm)
-            .map((t) => ({ sourceTerm: t.sourceTerm, targetTerm: t.targetTerm }))
-        );
-      } catch (e) {
-        console.warn('Step 5 용어집 로드 실패:', e);
-        setStep5GlossaryTerms([]);
-      }
-    };
+				if (!sourceLang || !targetLang) {
+					setStep5GlossaryTerms([]);
+					return;
+				}
 
-    loadStep5GlossaryTerms();
-  }, [draft.sourceLang, draft.targetLang]);
+				const termRes = await termApi.getAllTerms({
+					sourceLang,
+					targetLang,
+					page: 0,
+					size: 1000,
+				});
+				setStep5GlossaryTerms(
+					(termRes.content || [])
+						.filter((t) => t.sourceTerm && t.targetTerm)
+						.map((t) => ({
+							sourceTerm: t.sourceTerm,
+							targetTerm: t.targetTerm,
+						})),
+				);
+			} catch (e) {
+				console.warn("Step 5 용어집 로드 실패:", e);
+				setStep5GlossaryTerms([]);
+			}
+		};
 
-  // 권한 체크
-  useEffect(() => {
-    if (user && !isAuthorized) {
-      navigate('/dashboard');
-    }
-  }, [user, isAuthorized, navigate]);
+		loadStep5GlossaryTerms();
+	}, [draft.sourceLang, draft.targetLang]);
 
-  // ⭐ draft가 변경될 때마다 localStorage에 저장 (뒤로가기 대응)
-  useEffect(() => {
-    // 빈 draft는 저장하지 않음
-    if (draft.url || draft.originalHtml || draft.selectedAreas.length > 0) {
-      saveDraftToStorage(draft);
-    }
-  }, [draft]);
+	// 권한 체크
+	useEffect(() => {
+		if (user && !isAuthorized) {
+			navigate("/dashboard");
+		}
+	}, [user, isAuthorized, navigate]);
 
-  // 변경 사항 추적
-  useEffect(() => {
-    if (draft.editedHtml && draft.editedHtml !== draft.originalHtml) {
-      setHasUnsavedChanges(true);
-    } else if (draft.translatedHtml) {
-      setHasUnsavedChanges(true);
-    }
-  }, [draft.editedHtml, draft.translatedHtml, draft.originalHtml]);
+	// ⭐ draft가 변경될 때마다 localStorage에 저장 (뒤로가기 대응)
+	useEffect(() => {
+		// 빈 draft는 저장하지 않음
+		if (draft.url || draft.originalHtml || draft.selectedAreas.length > 0) {
+			saveDraftToStorage(draft);
+		}
+	}, [draft]);
 
-  // 이탈 경고
-  useEffect(() => {
-    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
-      e.preventDefault();
-      e.returnValue = '';
-    };
+	// 변경 사항 추적
+	useEffect(() => {
+		if (draft.editedHtml && draft.editedHtml !== draft.originalHtml) {
+			setHasUnsavedChanges(true);
+		} else if (draft.translatedHtml) {
+			setHasUnsavedChanges(true);
+		}
+	}, [draft.editedHtml, draft.translatedHtml, draft.originalHtml]);
 
-    window.addEventListener('beforeunload', handleBeforeUnload);
-    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
-  }, []);
+	// 이탈 경고
+	useEffect(() => {
+		const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+			e.preventDefault();
+			e.returnValue = "";
+		};
 
-  const isLikelyErrorPageResponse = (response: any): boolean => {
-    if (response?.errorPage) return true;
-    if (typeof response?.httpStatus === 'number' && response.httpStatus >= 400) return true;
-    const html = (response?.originalHtml || '').toLowerCase();
-    if (!html) return false;
-    return html.includes('[get] "/api/validate-page-locale')
-      || html.includes('403 forbidden')
-      || html.includes('error: 403')
-      || html.includes('access denied')
-      || html.includes('just a moment')
-      || html.includes('verify you are human')
-      || html.includes('enable javascript and cookies')
-      || html.includes('checking your browser');
-  };
+		window.addEventListener("beforeunload", handleBeforeUnload);
+		return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+	}, []);
 
-  const handleCrawling = async () => {
-    if (!draft.url.trim()) {
-      setSaveError('URL을 입력해주세요.');
-      return;
-    }
+	const isLikelyErrorPageResponse = (response: any): boolean => {
+		if (response?.errorPage) return true;
+		if (typeof response?.httpStatus === "number" && response.httpStatus >= 400)
+			return true;
+		const html = (response?.originalHtml || "").toLowerCase();
+		if (!html) return false;
+		return (
+			html.includes('[get] "/api/validate-page-locale') ||
+			html.includes("403 forbidden") ||
+			html.includes("error: 403") ||
+			html.includes("access denied") ||
+			html.includes("just a moment") ||
+			html.includes("verify you are human") ||
+			html.includes("enable javascript and cookies") ||
+			html.includes("checking your browser")
+		);
+	};
 
-    // URL 유효성 검사
-    try {
-      new URL(draft.url);
-    } catch {
-      setSaveError('올바른 URL 형식이 아닙니다. (예: https://example.com)');
-      return;
-    }
+	const handleCrawling = async () => {
+		if (!draft.url.trim()) {
+			setSaveError("URL을 입력해주세요.");
+			return;
+		}
 
-    // 이미 해당 URL로 초벌 번역된 문서가 있는지 확인
-    try {
-      const { exists } = await documentApi.checkUrlExists(draft.url.trim());
-      if (exists) {
-        const proceed = window.confirm(
-          '이미 이 주소로 초벌 번역이 진행된 문서가 있습니다. 그대로 새로 진행하시겠습니까?'
-        );
-        if (!proceed) return;
-      }
-    } catch (err) {
-      console.warn('URL 중복 체크 실패 (크롤링 계속 진행):', err);
-    }
+		// URL 유효성 검사
+		try {
+			new URL(draft.url);
+		} catch {
+			setSaveError("올바른 URL 형식이 아닙니다. (예: https://example.com)");
+			return;
+		}
 
-    setIsLoading(true);
-    setLoadingProgress(0);
-    setSaveError(null);
-    
-    // 가짜 진행률 (실제 백엔드에서 진행률을 반환하지 않으므로)
-    const progressInterval = setInterval(() => {
-      setLoadingProgress(prev => {
-        if (prev >= 90) return prev;
-        return prev + Math.random() * 15;
-      });
-    }, 300);
-    
-    try {
-      // Translation.jsx와 동일한 방식으로 크롤링
-      const response = await translationApi.translateWebPage({
-        url: draft.url.trim(),
-        targetLang: 'NONE', // 번역하지 않음을 나타내는 특수 값
-        sourceLang: undefined,
-      });
+		// 이미 해당 URL로 초벌 번역된 문서가 있는지 확인
+		try {
+			const { exists } = await documentApi.checkUrlExists(draft.url.trim());
+			if (exists) {
+				const proceed = window.confirm(
+					"이미 이 주소로 초벌 번역이 진행된 문서가 있습니다. 그대로 새로 진행하시겠습니까?",
+				);
+				if (!proceed) return;
+			}
+		} catch (err) {
+			console.warn("URL 중복 체크 실패 (크롤링 계속 진행):", err);
+		}
 
-      const errorPageDetected = isLikelyErrorPageResponse(response);
-      if (response.success && !errorPageDetected) {
-        console.log('원본 페이지 로드 성공:', {
-          hasOriginalHtml: !!response.originalHtml,
-          originalHtmlLength: response.originalHtml?.length,
-          hasCss: !!response.css,
-          cssLength: response.css?.length
-        });
-        
-        // HTML 구조 확인 및 보완 (Translation.jsx와 동일)
-        let htmlContent = response.originalHtml || '';
-        const hasDoctype = htmlContent.trim().toLowerCase().startsWith('<!doctype');
-        const hasHtml = htmlContent.includes('<html');
-        const hasBody = htmlContent.includes('<body');
-        
-        // 완전한 HTML 문서 구조가 아니면 감싸기
-        if (!hasDoctype || !hasHtml || !hasBody) {
-          console.log('HTML이 완전한 문서 구조가 아님. 감싸는 중...', { hasDoctype, hasHtml, hasBody });
-          
-          if (htmlContent.includes('<body')) {
-            // body 태그는 이미 있으므로 그대로 사용
-          } else {
-            // body 태그가 없으면 body로 감싸기
-            htmlContent = `<body>${htmlContent}</body>`;
-          }
-          
-          // html 태그가 없으면 html로 감싸기
-          if (!htmlContent.includes('<html')) {
-            htmlContent = `<html>${htmlContent}</html>`;
-          }
-          
-          // head 태그 추가
-          if (!htmlContent.includes('<head>')) {
-            htmlContent = htmlContent.replace('<html>', '<html><head></head>');
-          }
-          
-          // DOCTYPE 추가
-          if (!hasDoctype) {
-            htmlContent = `<!DOCTYPE html>${htmlContent}`;
-          }
-        }
-        
-        // CSS를 <style> 태그로 추가 (Translation.jsx와 동일)
-        if (response.css) {
-          const cssTag = `<style id="transflow-css">\n${response.css}\n</style>`;
-          if (htmlContent.includes('</head>')) {
-            htmlContent = htmlContent.replace('</head>', `${cssTag}\n</head>`);
-          } else if (htmlContent.includes('<html')) {
-            // head가 없으면 head 추가
-            htmlContent = htmlContent.replace('<html>', `<html><head>${cssTag}</head>`);
-          } else {
-            htmlContent = cssTag + '\n' + htmlContent;
-          }
-        }
+		setIsLoading(true);
+		setLoadingProgress(0);
+		setSaveError(null);
 
-        console.log('최종 HTML 구조:', htmlContent.substring(0, 500));
+		// 가짜 진행률 (실제 백엔드에서 진행률을 반환하지 않으므로)
+		const progressInterval = setInterval(() => {
+			setLoadingProgress((prev) => {
+				if (prev >= 90) return prev;
+				return prev + Math.random() * 15;
+			});
+		}, 300);
 
-        setDraft((prev) => ({
-          ...prev,
-          originalHtml: htmlContent,
-          selectedAreas: [], // ⭐ 새로 크롤링하면 선택 영역 초기화
-          originalHtmlWithIds: '', // ⭐ 이전 HTML with IDs도 초기화
-        }));
-        setIsManualPasteMode(false);
-        setCurrentStep(2);
-      } else {
-        const fallbackMessage = response.errorMessage || '웹 페이지 오류가 감지되어 수동 서식 넣기로 이동합니다.';
-        setSaveError(fallbackMessage);
-        if (errorPageDetected) {
-          handleManualPaste();
-          return;
-        }
-      }
-    } catch (error: any) {
-      console.error('Crawling error:', error);
-      setSaveError(
-        error?.response?.data?.errorMessage || 
-        error?.message || 
-        '서버와 통신할 수 없습니다. 백엔드가 실행 중인지 확인해주세요.'
-      );
-    } finally {
-      setIsLoading(false);
-    }
-  };
+		try {
+			// Translation.jsx와 동일한 방식으로 크롤링
+			const response = await translationApi.translateWebPage({
+				url: draft.url.trim(),
+				targetLang: "NONE", // 번역하지 않음을 나타내는 특수 값
+				sourceLang: undefined,
+			});
 
-  const handleAreaSelect = (area: SelectedArea) => {
-    setDraft((prev) => ({
-      ...prev,
-      selectedAreas: [...prev.selectedAreas, area],
-    }));
-  };
+			const errorPageDetected = isLikelyErrorPageResponse(response);
+			if (response.success && !errorPageDetected) {
+				console.log("원본 페이지 로드 성공:", {
+					hasOriginalHtml: !!response.originalHtml,
+					originalHtmlLength: response.originalHtml?.length,
+					hasCss: !!response.css,
+					cssLength: response.css?.length,
+				});
 
-  const handleManualPaste = () => {
-    setDraft({
-      url: draft.url,
-      selectedAreas: [],
-      originalHtml: MANUAL_PASTE_HTML,
-      originalHtmlWithIds: MANUAL_PASTE_HTML,
-      editedHtml: '',
-      state: DocumentState.DRAFT,
-    });
-    setIsManualPasteMode(true);
-    setCurrentStep(3);
-  };
+				// HTML 구조 확인 및 보완 (Translation.jsx와 동일)
+				let htmlContent = response.originalHtml || "";
+				const hasDoctype = htmlContent
+					.trim()
+					.toLowerCase()
+					.startsWith("<!doctype");
+				const hasHtml = htmlContent.includes("<html");
+				const hasBody = htmlContent.includes("<body");
 
-  const handleAreaRemove = (id: string) => {
-    setDraft((prev) => ({
-      ...prev,
-      selectedAreas: prev.selectedAreas.filter((area) => area.id !== id),
-    }));
-  };
+				// 완전한 HTML 문서 구조가 아니면 감싸기
+				if (!hasDoctype || !hasHtml || !hasBody) {
+					console.log("HTML이 완전한 문서 구조가 아님. 감싸는 중...", {
+						hasDoctype,
+						hasHtml,
+						hasBody,
+					});
 
-  const handleTranslation = async (sourceLang: string, targetLang: string) => {
-    console.log('🔄 번역 시작:', { sourceLang, targetLang });
-    
-    setIsTranslating(true);
-    setTranslatingProgress(0);
-    setSaveError(null);
-    
-    // 가짜 진행률
-    const progressInterval = setInterval(() => {
-      setTranslatingProgress(prev => {
-        if (prev >= 90) return prev;
-        return prev + Math.random() * 12;
-      });
-    }, 400);
-    
-    try {
-      // 번역 실행 - STEP 3에서 편집된 HTML만 번역 (선택된 영역만)
-      const htmlToTranslate = draft.editedHtml || draft.originalHtmlWithIds || draft.originalHtml;
-      console.log('🌐 번역 API 호출 중...');
-      console.log('📝 번역할 HTML 길이:', htmlToTranslate.length);
-      console.log('📝 번역할 HTML 미리보기:', htmlToTranslate.substring(0, 300));
-      
-      if (!draft.editedHtml) {
-        console.warn('⚠️ draft.editedHtml이 없습니다. STEP 3에서 편집 내용이 저장되지 않았을 수 있습니다.');
-      }
-      
-      const translatedHtml = await documentApi.translateHtml(
-        htmlToTranslate,
-        sourceLang,
-        targetLang
-      );
-      clearInterval(progressInterval);
-      setTranslatingProgress(100);
-      console.log('✅ 번역 완료, 번역된 HTML 길이:', translatedHtml.length);
+					if (htmlContent.includes("<body")) {
+						// body 태그는 이미 있으므로 그대로 사용
+					} else {
+						// body 태그가 없으면 body로 감싸기
+						htmlContent = `<body>${htmlContent}</body>`;
+					}
 
-      setDraft((prev) => ({
-        ...prev,
-        translatedHtml,
-        sourceLang,
-        targetLang,
-      }));
+					// html 태그가 없으면 html로 감싸기
+					if (!htmlContent.includes("<html")) {
+						htmlContent = `<html>${htmlContent}</html>`;
+					}
 
-      // 문서는 STEP 6에서 생성하므로 여기서는 번역만 수행
-      console.log('✅ 번역 완료, STEP 5로 이동');
-      setCurrentStep(5);
-    } catch (error: any) {
-      console.error('❌ 번역 실패:', error);
-      clearInterval(progressInterval);
-      setSaveError(error?.response?.data?.message || '번역 실패');
-    } finally {
-      setIsTranslating(false);
-      setTimeout(() => setTranslatingProgress(0), 1000);
-    }
-  };
+					// head 태그 추가
+					if (!htmlContent.includes("<head>")) {
+						htmlContent = htmlContent.replace("<html>", "<html><head></head>");
+					}
 
-  const handleNext = async () => {
-    if (currentStep < 6) {
-      // STEP 1: URL 입력 및 크롤링 확인
-      if (currentStep === 1) {
-        if (!draft.url.trim()) {
-          alert('URL을 입력해주세요.');
-          return;
-        }
-        if (!draft.originalHtml) {
-          alert('크롤링을 먼저 실행해주세요.');
-          return;
-        }
-      }
-      
-      // STEP 2: 영역 선택 확인 (선택하지 않으면 전체 선택)
-      if (currentStep === 2) {
-        if (draft.selectedAreas.length === 0) {
-          alert('선택된 영역이 없습니다. 전체 화면이 선택됩니다.');
-          // 전체 화면 선택: body의 모든 자식을 selectedAreas에 추가
-          // 실제로는 originalHtml을 그대로 사용
-        }
-      }
-      
-      // STEP 3에서 STEP 4로 넘어갈 때: 원문 URL이 비어있으면 모달로 입력받기
-      if (currentStep === 3) {
-        if (!draft.url?.trim()) {
-          setUrlModalInput('');
-          setShowUrlModal(true);
-          return;
-        }
-        console.log('💾 STEP 3 → STEP 4: 편집된 HTML 저장 중...');
-        if (!draft.editedHtml) {
-          console.warn('⚠️ draft.editedHtml이 없습니다. STEP 3에서 편집 내용이 저장되지 않았을 수 있습니다.');
-        } else {
-          console.log('✅ draft.editedHtml 확인:', draft.editedHtml.substring(0, 200));
-        }
-        setHasUnsavedChanges(false);
-      }
-      
-      // STEP 4: 번역 실행 확인
-      if (currentStep === 4) {
-        if (!draft.translatedHtml) {
-          alert('번역을 먼저 실행해주세요.');
-          return;
-        }
-      }
-      
-      // 다음으로 넘어갈 때는 자동 저장 (STEP 3 포함) - 모달 표시 안 함
-      if (hasUnsavedChanges) {
-        await handleSaveDraft(undefined, true); // isAutoSave = true
-      }
-      setCurrentStep(currentStep + 1);
-    }
-  };
+					// DOCTYPE 추가
+					if (!hasDoctype) {
+						htmlContent = `<!DOCTYPE html>${htmlContent}`;
+					}
+				}
 
-  const handleUrlModalConfirm = async () => {
-    const url = urlModalInput?.trim() || '';
-    if (!url) {
-      alert('원문 URL을 입력해주세요.');
-      return;
-    }
-    try {
-      new URL(url);
-    } catch {
-      alert('올바른 URL 형식이 아닙니다. (예: https://example.com)');
-      return;
-    }
-    setDraft(prev => ({ ...prev, url }));
-    setShowUrlModal(false);
-    setUrlModalInput('');
-    setHasUnsavedChanges(false);
-    await handleSaveDraft(undefined, true, { url });
-    setCurrentStep(currentStep + 1);
-  };
+				// CSS를 <style> 태그로 추가 (Translation.jsx와 동일)
+				if (response.css) {
+					const cssTag = `<style id="transflow-css">\n${response.css}\n</style>`;
+					if (htmlContent.includes("</head>")) {
+						htmlContent = htmlContent.replace("</head>", `${cssTag}\n</head>`);
+					} else if (htmlContent.includes("<html")) {
+						// head가 없으면 head 추가
+						htmlContent = htmlContent.replace(
+							"<html>",
+							`<html><head>${cssTag}</head>`,
+						);
+					} else {
+						htmlContent = cssTag + "\n" + htmlContent;
+					}
+				}
 
-  const handlePrev = () => {
-    if (currentStep > 1) {
-      if (hasUnsavedChanges && !lastSaved) {
-        if (!window.confirm('저장되지 않은 변경사항이 있습니다. 뒤로 가시겠습니까?')) {
-          return;
-        }
-      }
-      
-      // Step 3에서 돌아갈 때
-      if (currentStep === 3) {
-        if (isManualPasteMode) {
-          // 수동 모드: Step 1로
-          setIsManualPasteMode(false);
-          setDraft(prev => ({
-            ...prev,
-            selectedAreas: [],
-            originalHtml: '',
-            originalHtmlWithIds: '',
-            editedHtml: '',
-          }));
-          setCurrentStep(1);
-          return;
-        }
-        setDraft(prev => ({
-          ...prev,
-          selectedAreas: [],
-          originalHtmlWithIds: '',
-          editedHtml: '',
-        }));
-      }
-      
-      setCurrentStep(currentStep - 1);
-    }
-  };
+				console.log("최종 HTML 구조:", htmlContent.substring(0, 500));
 
-  const handleCreateDocument = async (data: { title: string; categoryId?: number; estimatedLength?: number; status: string }) => {
-    console.log('📝 문서 생성 시작:', data, '상태:', data.status);
-    
-    setIsCreating(true);
-    setSaveError(null);
-    const previousDraftDocumentId = documentId;
+				setDraft((prev) => ({
+					...prev,
+					originalHtml: htmlContent,
+					selectedAreas: [], // ⭐ 새로 크롤링하면 선택 영역 초기화
+					originalHtmlWithIds: "", // ⭐ 이전 HTML with IDs도 초기화
+				}));
+				setIsManualPasteMode(false);
+				setCurrentStep(2);
+			} else {
+				const fallbackMessage =
+					response.errorMessage ||
+					"웹 페이지 오류가 감지되어 수동 서식 넣기로 이동합니다.";
+				setSaveError(fallbackMessage);
+				if (errorPageDetected) {
+					handleManualPaste();
+					return;
+				}
+			}
+		} catch (error: any) {
+			console.error("Crawling error:", error);
+			setSaveError(
+				error?.response?.data?.errorMessage ||
+					error?.message ||
+					"서버와 통신할 수 없습니다. 백엔드가 실행 중인지 확인해주세요.",
+			);
+		} finally {
+			setIsLoading(false);
+		}
+	};
 
-    try {
-      // 1. 문서 생성 (또는 기존 문서 업데이트)
-      const response = await documentApi.createDocument({
-        title: data.title,
-        originalUrl: draft.url,
-        sourceLang: draft.sourceLang || 'auto',
-        targetLang: draft.targetLang || 'ko',
-        categoryId: data.categoryId,
-        estimatedLength: data.estimatedLength,
-        status: data.status,
-      });
-      setDocumentId(response.id);
-      console.log('✅ 문서 생성/업데이트 완료:', response.id);
+	const handleAreaSelect = (area: SelectedArea) => {
+		setDraft((prev) => ({
+			...prev,
+			selectedAreas: [...prev.selectedAreas, area],
+		}));
+	};
 
-      // 2. 기존 버전 삭제 (Step 6에서 새로 생성하기 전에 기존 버전 정리)
-      try {
-        await documentApi.deleteAllVersions(response.id);
-        console.log('🗑️ 기존 버전 삭제 완료');
-      } catch (error: any) {
-        console.warn('⚠️ 기존 버전 삭제 실패 (무시):', error);
-        // 버전이 없을 수도 있으므로 에러는 무시
-      }
+	const handleManualPaste = () => {
+		setDraft({
+			url: draft.url,
+			selectedAreas: [],
+			originalHtml: MANUAL_PASTE_HTML,
+			originalHtmlWithIds: MANUAL_PASTE_HTML,
+			editedHtml: "",
+			state: DocumentState.DRAFT,
+		});
+		setIsManualPasteMode(true);
+		setCurrentStep(3);
+	};
 
-      // 3. 원문 버전 생성 (선택한 영역)
-      await documentApi.createDocumentVersion(response.id, {
-        versionType: 'ORIGINAL',
-        content: draft.editedHtml || draft.originalHtmlWithIds || draft.originalHtml,
-        isFinal: false,
-      });
-      console.log('✅ 원문 버전 저장 완료');
+	const handleAreaRemove = (id: string) => {
+		setDraft((prev) => ({
+			...prev,
+			selectedAreas: prev.selectedAreas.filter((area) => area.id !== id),
+		}));
+	};
 
-      // 4. AI 번역 버전 생성
-      if (draft.translatedHtml) {
-        await documentApi.createDocumentVersion(response.id, {
-          versionType: 'AI_DRAFT',
-          content: draft.translatedHtml,
-          isFinal: false,
-        });
-        console.log('✅ AI 번역 버전 저장 완료');
-      }
+	const handleTranslation = async (sourceLang: string, targetLang: string) => {
+		console.log("🔄 번역 시작:", { sourceLang, targetLang });
 
-      // 임시저장으로 만들어 둔 문서는 최종 문서와 별도 행이므로 삭제
-      if (previousDraftDocumentId != null && previousDraftDocumentId !== response.id) {
-        try {
-          await documentApi.deleteDocument(previousDraftDocumentId);
-          console.log('🗑️ 임시저장 문서 삭제:', previousDraftDocumentId);
-        } catch (e: any) {
-          console.warn('⚠️ 임시저장 문서 삭제 실패 (무시):', e);
-        }
-      }
+		setIsTranslating(true);
+		setTranslatingProgress(0);
+		setSaveError(null);
 
-      // 4. 완료 후 localStorage 클리어 및 문서 관리 페이지로 이동
-      const statusText = data.status === 'PENDING_TRANSLATION' ? '번역 대기 상태로' : '초안 상태로';
-      setSaveError(null);
-      
-      // ⭐ 문서 생성 완료 시 localStorage 클리어
-      try {
-        localStorage.removeItem('transflow-draft');
-        console.log('🗑️ localStorage draft 클리어 완료');
-      } catch (e) {
-        console.warn('⚠️ localStorage 클리어 실패:', e);
-      }
-      
-      navigate('/translations/pending');
-    } catch (error: any) {
-      console.error('❌ 문서 생성 실패:', error);
-      setSaveError(error?.response?.data?.message || '문서 생성 실패');
-    } finally {
-      setIsCreating(false);
-    }
-  };
+		// 가짜 진행률
+		const progressInterval = setInterval(() => {
+			setTranslatingProgress((prev) => {
+				if (prev >= 90) return prev;
+				return prev + Math.random() * 12;
+			});
+		}, 400);
 
-  // 임시저장 문서 불러오기
-  const handleLoadDraft = async (doc: DocumentResponse) => {
-    try {
-      console.log('🔄 임시저장 문서 불러오기 시작:', doc.id);
-      console.log('📦 draftData:', doc.draftData ? `존재 (${doc.draftData.length}자)` : '없음');
-      console.log('📦 draftData 내용:', doc.draftData);
-      
-      // draftData가 있고 빈 문자열이 아닌 경우에만 파싱
-      if (doc.draftData && doc.draftData.trim() !== '') {
-        try {
-          // 저장된 draftData가 있으면 파싱해서 복원
-          const parsedData = JSON.parse(doc.draftData);
-          console.log('✅ JSON 파싱 성공:', parsedData);
-          
-          let savedStep = parsedData.currentStep || 1;
-          const savedDraft = parsedData.draft || {};
-          const savedStep6Data = parsedData.step6Data || null;
+		try {
+			// 번역 실행 - STEP 3에서 편집된 HTML만 번역 (선택된 영역만)
+			const htmlToTranslate =
+				draft.editedHtml || draft.originalHtmlWithIds || draft.originalHtml;
+			console.log("🌐 번역 API 호출 중...");
+			console.log("📝 번역할 HTML 길이:", htmlToTranslate.length);
+			console.log(
+				"📝 번역할 HTML 미리보기:",
+				htmlToTranslate.substring(0, 300),
+			);
 
-          // Step 2, 4에서 저장된 경우 Step 3으로 이동
-          // - Step 2: 임시저장 불가 (선택만 하는 단계)
-          // - Step 4: 단순 번역 확인 단계, 편집 내용은 Step 3에서 복원
-          if (savedStep === 2 || savedStep === 4) {
-            savedStep = 3;
-          }
+			if (!draft.editedHtml) {
+				console.warn(
+					"⚠️ draft.editedHtml이 없습니다. STEP 3에서 편집 내용이 저장되지 않았을 수 있습니다.",
+				);
+			}
 
-          setDraft({
-            url: savedDraft.url || doc.originalUrl,
-            selectedAreas: savedDraft.selectedAreas || [],
-            originalHtml: savedDraft.originalHtml || '',
-            originalHtmlWithIds: savedDraft.originalHtmlWithIds || '',
-            editedHtml: savedDraft.editedHtml,
-            translatedHtml: savedDraft.translatedHtml,
-            sourceLang: savedDraft.sourceLang || doc.sourceLang || 'auto',
-            targetLang: savedDraft.targetLang || doc.targetLang || 'ko',
-            state: savedDraft.state || DocumentState.DRAFT,
-          });
-          setDocumentId(doc.id);
-          setCurrentStep(savedStep);
-          
-          // Step 6 데이터 저장 (Step 6 컴포넌트에서 사용)
-          if (savedStep === 6 && savedStep6Data) {
-            setStep6Data(savedStep6Data);
-          } else {
-            setStep6Data(null);
-          }
-          
-          console.log('✅ 임시저장 문서 불러오기 완료:', doc.id, 'Step', savedStep);
-          alert('임시저장 문서를 불러왔습니다.');
-        } catch (parseError) {
-          console.error('❌ JSON 파싱 실패:', parseError);
-          console.error('❌ 손상된 draftData:', doc.draftData);
-          throw new Error(`JSON 파싱 실패: ${parseError instanceof Error ? parseError.message : String(parseError)}`);
-        }
-      } else {
-        // draftData가 없거나 빈 문자열이면 기본값으로 복원 (하위 호환성)
-        console.log('⚠️ draftData가 없거나 비어있어 기본값으로 복원');
-        setDraft({
-          url: doc.originalUrl,
-          sourceLang: doc.sourceLang || 'auto',
-          targetLang: doc.targetLang || 'ko',
-          selectedAreas: [],
-          originalHtml: '',
-          originalHtmlWithIds: '',
-          state: DocumentState.DRAFT,
-        });
-        setDocumentId(doc.id);
-        setCurrentStep(1);
-        console.log('✅ 임시저장 문서 불러오기 완료 (기본값):', doc.id);
-        alert('임시저장 문서를 불러왔습니다. (기본값으로 복원)');
-      }
-    } catch (error) {
-      console.error('❌ 임시저장 문서 불러오기 실패:', error);
-      console.error('❌ 오류 상세:', error instanceof Error ? error.message : String(error));
-      alert(`임시저장 문서를 불러오는데 실패했습니다.\n오류: ${error instanceof Error ? error.message : String(error)}`);
-    }
-  };
+			const translatedHtml = await documentApi.translateHtml(
+				htmlToTranslate,
+				sourceLang,
+				targetLang,
+			);
+			clearInterval(progressInterval);
+			setTranslatingProgress(100);
+			console.log("✅ 번역 완료, 번역된 HTML 길이:", translatedHtml.length);
 
-  const handleSaveDraft = async (step6Data?: { title?: string; categoryId?: number; estimatedLength?: number }, isAutoSave: boolean = false, draftOverrides?: { url?: string }) => {
-    try {
-      const urlToUse = draftOverrides?.url ?? draft.url;
-      const draftData = JSON.stringify({
-        currentStep,
-        draft: {
-          url: urlToUse,
-          selectedAreas: draft.selectedAreas,
-          originalHtml: draft.originalHtml,
-          originalHtmlWithIds: draft.originalHtmlWithIds,
-          editedHtml: draft.editedHtml,
-          translatedHtml: draft.translatedHtml,
-          sourceLang: draft.sourceLang,
-          targetLang: draft.targetLang,
-          state: draft.state,
-        },
-        // Step 6의 입력값들도 저장
-        step6Data: step6Data || null,
-      });
+			setDraft((prev) => ({
+				...prev,
+				translatedHtml,
+				sourceLang,
+				targetLang,
+			}));
 
-      // Step 6에서 임시저장할 때는 제목도 업데이트
-      const documentTitle = step6Data?.title || `번역 문서 - ${new Date().toLocaleString()}`;
+			// 문서는 STEP 6에서 생성하므로 여기서는 번역만 수행
+			console.log("✅ 번역 완료, STEP 5로 이동");
+			setCurrentStep(5);
+		} catch (error: any) {
+			console.error("❌ 번역 실패:", error);
+			clearInterval(progressInterval);
+			setSaveError(error?.response?.data?.message || "번역 실패");
+		} finally {
+			setIsTranslating(false);
+			setTimeout(() => setTranslatingProgress(0), 1000);
+		}
+	};
 
-      if (!documentId) {
-        // 문서가 없으면 먼저 생성 (버전은 생성하지 않음 - Step 6에서만 생성)
-        const response = await documentApi.createDocument({
-          title: documentTitle,
-          originalUrl: urlToUse || 'https://manual-paste.local',
-          sourceLang: draft.sourceLang || 'auto',
-          targetLang: draft.targetLang || 'ko',
-          status: 'DRAFT',
-          categoryId: step6Data?.categoryId,
-          estimatedLength: step6Data?.estimatedLength,
-          draftData: draftData,
-        });
-        setDocumentId(response.id);
-        console.log('✅ 임시저장 완료 (문서 생성):', response.id, 'Step', currentStep);
-      } else {
-        // 문서가 있으면 문서만 업데이트 (버전은 생성하지 않음)
-        const updateData: any = {
-          draftData: draftData, // 항상 draftData는 업데이트
-        };
-        // Step 6 데이터가 있으면 추가
-        if (step6Data) {
-          if (step6Data.title) updateData.title = step6Data.title;
-          if (step6Data.categoryId) updateData.categoryId = step6Data.categoryId;
-          if (step6Data.estimatedLength) updateData.estimatedLength = step6Data.estimatedLength;
-        }
-        await documentApi.updateDocument(documentId, updateData);
-        console.log('✅ 임시저장 완료 (문서 업데이트):', documentId, 'Step', currentStep);
-      }
+	const handleNext = async () => {
+		if (currentStep < 6) {
+			// STEP 1: URL 입력 및 크롤링 확인
+			if (currentStep === 1) {
+				if (!draft.url.trim()) {
+					alert("URL을 입력해주세요.");
+					return;
+				}
+				if (!draft.originalHtml) {
+					alert("크롤링을 먼저 실행해주세요.");
+					return;
+				}
+			}
 
-      setLastSaved(new Date());
-      setHasUnsavedChanges(false);
-      setSaveError(null);
+			// STEP 2: 영역 선택 확인 (선택하지 않으면 전체 선택)
+			if (currentStep === 2) {
+				if (draft.selectedAreas.length === 0) {
+					alert("선택된 영역이 없습니다. 전체 화면이 선택됩니다.");
+					// 전체 화면 선택: body의 모든 자식을 selectedAreas에 추가
+					// 실제로는 originalHtml을 그대로 사용
+				}
+			}
 
-      // ⭐ 임시저장 문서 목록 다시 로드
-      const allDocs = await documentApi.getAllDocuments();
-      const draftOnlyDocs = allDocs.filter(doc => 
-        doc.status === 'DRAFT' && doc.hasVersions !== true
-      );
-      setDraftDocuments(draftOnlyDocs);
-      console.log('✅ 임시저장 목록 갱신 완료:', draftOnlyDocs.length, '개');
-      
-      // ⭐ 임시저장 완료 모달 표시 (자동 저장이 아닐 때만)
-      if (!isAutoSave) {
-        alert('임시저장되었습니다.');
-      }
-    } catch (error: any) {
-      console.error('Save error:', error);
-      setSaveError(error?.response?.data?.message || '저장 실패');
-      if (!isAutoSave) {
-        alert(`임시저장에 실패했습니다.\n오류: ${error?.response?.data?.message || error.message || '저장 실패'}`);
-      }
-    }
-  };
+			// STEP 3에서 STEP 4로 넘어갈 때: 원문 URL이 비어있으면 모달로 입력받기
+			if (currentStep === 3) {
+				if (!draft.url?.trim()) {
+					setUrlModalInput("");
+					setShowUrlModal(true);
+					return;
+				}
+				console.log("💾 STEP 3 → STEP 4: 편집된 HTML 저장 중...");
+				if (!draft.editedHtml) {
+					console.warn(
+						"⚠️ draft.editedHtml이 없습니다. STEP 3에서 편집 내용이 저장되지 않았을 수 있습니다.",
+					);
+				} else {
+					console.log(
+						"✅ draft.editedHtml 확인:",
+						draft.editedHtml.substring(0, 200),
+					);
+				}
+				setHasUnsavedChanges(false);
+			}
 
-  if (!isAuthorized) {
-    return null;
-  }
+			// STEP 4: 번역 실행 확인
+			if (currentStep === 4) {
+				if (!draft.translatedHtml) {
+					alert("번역을 먼저 실행해주세요.");
+					return;
+				}
+			}
 
-  const renderStep = () => {
-    switch (currentStep) {
-      case 1:
-        return (
-          <Step1CrawlingInput
-            url={draft.url}
-            setUrl={(url) => setDraft((prev) => ({ ...prev, url }))}
-            onExecute={handleCrawling}
-            onManualPaste={handleManualPaste}
-            isLoading={isLoading}
-            loadingProgress={loadingProgress}
-            draftDocuments={draftDocuments}
-            onLoadDraft={handleLoadDraft}
-          />
-        );
-      case 2:
-        return (
-          <Step2AreaSelection
-            html={draft.originalHtmlWithIds || draft.originalHtml}
-            selectedAreas={draft.selectedAreas}
-            onAreaSelect={handleAreaSelect}
-            onAreaRemove={handleAreaRemove}
-            onHtmlUpdate={(html) => {
-              // STEP 2의 iframe HTML (data-transflow-id 포함)을 저장
-              setDraft((prev) => ({ ...prev, originalHtmlWithIds: html }));
-            }}
-          />
-        );
-      case 3:
-        console.log('🎯 Step 3 렌더링:', {
-          editedHtml: draft.editedHtml?.substring(0, 100),
-          originalHtml: draft.originalHtml?.substring(0, 100),
-          originalHtmlWithIds: draft.originalHtmlWithIds?.substring(0, 100),
-          selectedAreasCount: draft.selectedAreas.length,
-          selectedAreasData: draft.selectedAreas
-        });
-        return (
-          <Step3PreEdit
-            html={draft.editedHtml || draft.originalHtmlWithIds || draft.originalHtml}
-            onHtmlChange={(html) => setDraft((prev) => ({ ...prev, editedHtml: html }))}
-            selectedAreas={draft.selectedAreas}
-            isManualPasteMode={isManualPasteMode}
-            onClearForManualPaste={() => {}}
-          />
-        );
-      case 4:
-        return (
-          <Step4Translation
-            onConfirm={handleTranslation}
-            onCancel={() => setCurrentStep(3)}
-            isTranslating={isTranslating}
-            translatingProgress={translatingProgress}
-          />
-        );
-      case 5:
-        return (
-          <Step5ParallelEdit
-            crawledHtml={draft.originalHtml} // STEP 1에서 크롤링한 전체 원문
-            selectedHtml={draft.editedHtml || draft.originalHtmlWithIds || ''} // STEP 2/3에서 선택한 영역
-            translatedHtml={removeLegacyGlossaryMarkup(draft.translatedHtml || '')}
-            onTranslatedChange={(html) => setDraft((prev) => ({ ...prev, translatedHtml: html }))}
-            collapsedPanels={step5CollapsedPanels}
-            showVersion0Glossary={showStep5Version0Glossary}
-            glossaryTerms={step5GlossaryTerms}
-            onTogglePanel={(panelId) => {
-              setStep5CollapsedPanels(prev => {
-                const newSet = new Set(prev);
-                if (newSet.has(panelId)) {
-                  newSet.delete(panelId);
-                } else {
-                  newSet.add(panelId);
-                }
-                return newSet;
-              });
-            }}
-          />
-        );
-      case 6:
-        return (
-          <Step6CreateDocument
-            ref={step6Ref}
-            draft={draft}
-            onCreateDocument={(data) => {
-              // Step6CreateDocument에서 status를 포함하여 전달
-              handleCreateDocument(data);
-            }}
-            onSaveDraft={(data) => {
-              // Step 6에서 임시저장
-              handleSaveDraft(data);
-            }}
-            step6Data={step6Data || undefined}
-            isCreating={isCreating}
-          />
-        );
-      default:
-        return null;
-    }
-  };
+			// 다음으로 넘어갈 때는 자동 저장 (STEP 3 포함) - 모달 표시 안 함
+			if (hasUnsavedChanges) {
+				await handleSaveDraft(undefined, true); // isAutoSave = true
+			}
+			setCurrentStep(currentStep + 1);
+		}
+	};
 
-  return (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        height: '100vh',
-        backgroundColor: '#DCDCDC',
-      }}
-    >
-      {/* 상단 상태 바 */}
-      <div
-        style={{
-          padding: '12px 24px',
-          borderBottom: '1px solid #C0C0C0',
-          backgroundColor: '#FFFFFF',
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          gap: '16px',
-        }}
-      >
-        {/* 왼쪽: STEP 정보 */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: '16px', flex: 1 }}>
-            <div
-              style={{
-                fontSize: '13px',
-                fontWeight: 500,
-                color: '#000000',
-                fontFamily: 'system-ui, Pretendard, sans-serif',
-              }}
-            >
-              STEP {currentStep} / 6
-            </div>
-            <div
-              style={{
-                fontSize: '12px',
-                color: '#696969',
-                fontFamily: 'system-ui, Pretendard, sans-serif',
-                fontWeight: 500,
-              }}
-            >
-              {currentStep === 1 && '가져올 웹사이트 주소 입력'}
-              {currentStep === 2 && '영역 선택'}
-              {currentStep === 3 && '번역 전 편집'}
-              {currentStep === 4 && '번역 실행'}
-              {currentStep === 5 && '번역 후 편집'}
-              {currentStep === 6 && '문서 정보 입력 및 생성'}
-            </div>
-            <div
-              style={{
-                fontSize: '12px',
-                color: '#696969',
-                fontFamily: 'system-ui, Pretendard, sans-serif',
-              }}
-            >
-              {currentStep >= 3 && lastSaved ? `마지막 저장: ${lastSaved.toLocaleTimeString()}` : currentStep >= 3 ? '저장되지 않음' : ''}
-            </div>
-            {saveError && (
-              <div
-                style={{
-                  fontSize: '12px',
-                  color: '#000000',
-                  fontFamily: 'system-ui, Pretendard, sans-serif',
-                  backgroundColor: '#D3D3D3',
-                  padding: '4px 8px',
-                  borderRadius: '4px',
-                }}
-              >
-                {saveError}
-              </div>
-            )}
-          </div>
+	const handleUrlModalConfirm = async () => {
+		const url = urlModalInput?.trim() || "";
+		if (!url) {
+			alert("원문 URL을 입력해주세요.");
+			return;
+		}
+		try {
+			new URL(url);
+		} catch {
+			alert("올바른 URL 형식이 아닙니다. (예: https://example.com)");
+			return;
+		}
+		setDraft((prev) => ({ ...prev, url }));
+		setShowUrlModal(false);
+		setUrlModalInput("");
+		setHasUnsavedChanges(false);
+		await handleSaveDraft(undefined, true, { url });
+		setCurrentStep(currentStep + 1);
+	};
 
-        {/* 중앙: 문서 보기 옵션 (Step 5일 때만 표시) */}
-        {currentStep === 5 && (
-          <div style={{ 
-            display: 'flex', 
-            alignItems: 'center', 
-            gap: '24px',
-            padding: '6px 16px',
-            backgroundColor: '#F8F9FA',
-            borderRadius: '6px',
-            border: '1px solid #D3D3D3',
-          }}>
-            <span style={{ fontSize: '12px', fontWeight: 600, color: '#000000' }}>문서 보기:</span>
-            <label style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: '8px',
-              fontSize: '13px',
-              cursor: 'pointer',
-              fontWeight: 500,
-              color: '#7a4b00',
-            }}>
-              <input
-                type="checkbox"
-                checked={showStep5Version0Glossary}
-                onChange={(e) => setShowStep5Version0Glossary(e.target.checked)}
-                style={{ cursor: 'pointer', width: '16px', height: '16px' }}
-              />
-              <span>Version 0 용어집 적용 구간 보기</span>
-            </label>
-            <label style={{ 
-              display: 'flex', 
-              alignItems: 'center', 
-              gap: '8px', 
-              fontSize: '13px', 
-              cursor: 'pointer',
-              fontWeight: 500,
-            }}>
-              <input
-                type="checkbox"
-                checked={!step5CollapsedPanels.has('crawled')}
-                onChange={() => {
-                  setStep5CollapsedPanels(prev => {
-                    const newSet = new Set(prev);
-                    if (newSet.has('crawled')) {
-                      newSet.delete('crawled');
-                    } else {
-                      newSet.add('crawled');
-                    }
-                    return newSet;
-                  });
-                }}
-                style={{
-                  cursor: 'pointer',
-                  width: '16px',
-                  height: '16px',
-                }}
-              />
-              <span>원본 웹사이트</span>
-            </label>
-            <label style={{ 
-              display: 'flex', 
-              alignItems: 'center', 
-              gap: '8px', 
-              fontSize: '13px', 
-              cursor: 'pointer',
-              fontWeight: 500,
-            }}>
-              <input
-                type="checkbox"
-                checked={!step5CollapsedPanels.has('selected')}
-                onChange={() => {
-                  setStep5CollapsedPanels(prev => {
-                    const newSet = new Set(prev);
-                    if (newSet.has('selected')) {
-                      newSet.delete('selected');
-                    } else {
-                      newSet.add('selected');
-                    }
-                    return newSet;
-                  });
-                }}
-                style={{ 
-                  cursor: 'pointer',
-                  width: '16px',
-                  height: '16px',
-                }}
-              />
-              <span>Version 0</span>
-            </label>
-            <label style={{ 
-              display: 'flex', 
-              alignItems: 'center', 
-              gap: '8px', 
-              fontSize: '13px', 
-              cursor: 'pointer',
-              fontWeight: 500,
-            }}>
-              <input
-                type="checkbox"
-                checked={!step5CollapsedPanels.has('translated')}
-                onChange={() => {
-                  setStep5CollapsedPanels(prev => {
-                    const newSet = new Set(prev);
-                    if (newSet.has('translated')) {
-                      newSet.delete('translated');
-                    } else {
-                      newSet.add('translated');
-                    }
-                    return newSet;
-                  });
-                }}
-                style={{ 
-                  cursor: 'pointer',
-                  width: '16px',
-                  height: '16px',
-                }}
-              />
-              <span>Version 1 (AI 초벌 번역)</span>
-            </label>
-          </div>
-        )}
+	const handlePrev = () => {
+		if (currentStep > 1) {
+			if (hasUnsavedChanges && !lastSaved) {
+				if (
+					!window.confirm(
+						"저장되지 않은 변경사항이 있습니다. 뒤로 가시겠습니까?",
+					)
+				) {
+					return;
+				}
+			}
 
-        {/* 오른쪽: 임시 저장 버튼 (Step 3부터만 표시) */}
-        <div>
-          {currentStep >= 3 && (
-            <Button variant="secondary" onClick={() => handleSaveDraft()} style={{ fontSize: '12px', padding: '4px 8px' }}>
-              임시 저장
-            </Button>
-          )}
-        </div>
-      </div>
+			// Step 3에서 돌아갈 때
+			if (currentStep === 3) {
+				if (isManualPasteMode) {
+					// 수동 모드: Step 1로
+					setIsManualPasteMode(false);
+					setDraft((prev) => ({
+						...prev,
+						selectedAreas: [],
+						originalHtml: "",
+						originalHtmlWithIds: "",
+						editedHtml: "",
+					}));
+					setCurrentStep(1);
+					return;
+				}
+				setDraft((prev) => ({
+					...prev,
+					selectedAreas: [],
+					originalHtmlWithIds: "",
+					editedHtml: "",
+				}));
+			}
 
-      {/* 메인 작업 영역 */}
-      <div
-        style={{
-          flex: 1,
-          padding: '16px',
-          overflow: 'auto',
-        }}
-      >
-        {renderStep()}
-      </div>
+			setCurrentStep(currentStep - 1);
+		}
+	};
 
-      {/* 하단 네비게이션 */}
-      <div
-        style={{
-          padding: '16px',
-          borderTop: '1px solid #C0C0C0',
-          backgroundColor: '#FFFFFF',
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-        }}
-      >
-        <div>
-          {currentStep > 1 && (
-            <Button variant="secondary" onClick={handlePrev}>
-              이전
-            </Button>
-          )}
-        </div>
-        <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
-          {currentStep < 6 && (
-            <Button variant="primary" onClick={handleNext}>
-              다음
-            </Button>
-          )}
-        </div>
-      </div>
+	const handleCreateDocument = async (data: {
+		title: string;
+		categoryId?: number;
+		estimatedLength?: number;
+		status: string;
+	}) => {
+		console.log("📝 문서 생성 시작:", data, "상태:", data.status);
 
-      <Modal
-        isOpen={showUrlModal}
-        onClose={() => { setShowUrlModal(false); setUrlModalInput(''); }}
-        title="원문 URL 입력"
-        onConfirm={handleUrlModalConfirm}
-        confirmText="확인"
-        cancelText="취소"
-      >
-        <p style={{ marginBottom: '12px', fontSize: '14px' }}>임시저장을 위해 원문 URL을 입력해주세요.</p>
-        <input
-          type="text"
-          value={urlModalInput}
-          onChange={(e) => setUrlModalInput(e.target.value)}
-          placeholder="https://example.com"
-          style={{
-            width: '100%',
-            padding: '8px 12px',
-            fontSize: '14px',
-            border: '1px solid #ccc',
-            borderRadius: '4px',
-            boxSizing: 'border-box',
-          }}
-          onKeyDown={(e) => { if (e.key === 'Enter') handleUrlModalConfirm(); }}
-        />
-      </Modal>
-    </div>
-  );
+		setIsCreating(true);
+		setSaveError(null);
+		const previousDraftDocumentId = documentId;
+
+		try {
+			// 1. 문서 생성 (또는 기존 문서 업데이트)
+			const response = await documentApi.createDocument({
+				title: data.title,
+				originalUrl: draft.url,
+				sourceLang: draft.sourceLang || "auto",
+				targetLang: draft.targetLang || "ko",
+				categoryId: data.categoryId,
+				estimatedLength: data.estimatedLength,
+				status: data.status,
+			});
+			setDocumentId(response.id);
+			console.log("✅ 문서 생성/업데이트 완료:", response.id);
+
+			// 2. 기존 버전 삭제 (Step 6에서 새로 생성하기 전에 기존 버전 정리)
+			try {
+				await documentApi.deleteAllVersions(response.id);
+				console.log("🗑️ 기존 버전 삭제 완료");
+			} catch (error: any) {
+				console.warn("⚠️ 기존 버전 삭제 실패 (무시):", error);
+				// 버전이 없을 수도 있으므로 에러는 무시
+			}
+
+			// 3. 원문 버전 생성 (선택한 영역)
+			await documentApi.createDocumentVersion(response.id, {
+				versionType: "ORIGINAL",
+				content:
+					draft.editedHtml || draft.originalHtmlWithIds || draft.originalHtml,
+				isFinal: false,
+			});
+			console.log("✅ 원문 버전 저장 완료");
+
+			// 4. AI 번역 버전 생성
+			if (draft.translatedHtml) {
+				await documentApi.createDocumentVersion(response.id, {
+					versionType: "AI_DRAFT",
+					content: draft.translatedHtml,
+					isFinal: false,
+				});
+				console.log("✅ AI 번역 버전 저장 완료");
+			}
+
+			// 임시저장으로 만들어 둔 문서는 최종 문서와 별도 행이므로 삭제
+			if (
+				previousDraftDocumentId != null &&
+				previousDraftDocumentId !== response.id
+			) {
+				try {
+					await documentApi.deleteDocument(previousDraftDocumentId);
+					console.log("🗑️ 임시저장 문서 삭제:", previousDraftDocumentId);
+				} catch (e: any) {
+					console.warn("⚠️ 임시저장 문서 삭제 실패 (무시):", e);
+				}
+			}
+
+			// 4. 완료 후 localStorage 클리어 및 문서 관리 페이지로 이동
+			const statusText =
+				data.status === "PENDING_TRANSLATION"
+					? "번역 대기 상태로"
+					: "초안 상태로";
+			setSaveError(null);
+
+			// ⭐ 문서 생성 완료 시 localStorage 클리어
+			try {
+				localStorage.removeItem("transflow-draft");
+				console.log("🗑️ localStorage draft 클리어 완료");
+			} catch (e) {
+				console.warn("⚠️ localStorage 클리어 실패:", e);
+			}
+
+			navigate("/translations/pending");
+		} catch (error: any) {
+			console.error("❌ 문서 생성 실패:", error);
+			setSaveError(error?.response?.data?.message || "문서 생성 실패");
+		} finally {
+			setIsCreating(false);
+		}
+	};
+
+	// 임시저장 문서 불러오기
+	const handleLoadDraft = async (doc: DocumentResponse) => {
+		try {
+			console.log("🔄 임시저장 문서 불러오기 시작:", doc.id);
+			console.log(
+				"📦 draftData:",
+				doc.draftData ? `존재 (${doc.draftData.length}자)` : "없음",
+			);
+			console.log("📦 draftData 내용:", doc.draftData);
+
+			// draftData가 있고 빈 문자열이 아닌 경우에만 파싱
+			if (doc.draftData && doc.draftData.trim() !== "") {
+				try {
+					// 저장된 draftData가 있으면 파싱해서 복원
+					const parsedData = JSON.parse(doc.draftData);
+					console.log("✅ JSON 파싱 성공:", parsedData);
+
+					let savedStep = parsedData.currentStep || 1;
+					const savedDraft = parsedData.draft || {};
+					const savedStep6Data = parsedData.step6Data || null;
+
+					// Step 2, 4에서 저장된 경우 Step 3으로 이동
+					// - Step 2: 임시저장 불가 (선택만 하는 단계)
+					// - Step 4: 단순 번역 확인 단계, 편집 내용은 Step 3에서 복원
+					if (savedStep === 2 || savedStep === 4) {
+						savedStep = 3;
+					}
+
+					setDraft({
+						url: savedDraft.url || doc.originalUrl,
+						selectedAreas: savedDraft.selectedAreas || [],
+						originalHtml: savedDraft.originalHtml || "",
+						originalHtmlWithIds: savedDraft.originalHtmlWithIds || "",
+						editedHtml: savedDraft.editedHtml,
+						translatedHtml: savedDraft.translatedHtml,
+						sourceLang: savedDraft.sourceLang || doc.sourceLang || "auto",
+						targetLang: savedDraft.targetLang || doc.targetLang || "ko",
+						state: savedDraft.state || DocumentState.DRAFT,
+					});
+					setDocumentId(doc.id);
+					setCurrentStep(savedStep);
+
+					// Step 6 데이터 저장 (Step 6 컴포넌트에서 사용)
+					if (savedStep === 6 && savedStep6Data) {
+						setStep6Data(savedStep6Data);
+					} else {
+						setStep6Data(null);
+					}
+
+					console.log(
+						"✅ 임시저장 문서 불러오기 완료:",
+						doc.id,
+						"Step",
+						savedStep,
+					);
+					alert("임시저장 문서를 불러왔습니다.");
+				} catch (parseError) {
+					console.error("❌ JSON 파싱 실패:", parseError);
+					console.error("❌ 손상된 draftData:", doc.draftData);
+					throw new Error(
+						`JSON 파싱 실패: ${parseError instanceof Error ? parseError.message : String(parseError)}`,
+					);
+				}
+			} else {
+				// draftData가 없거나 빈 문자열이면 기본값으로 복원 (하위 호환성)
+				console.log("⚠️ draftData가 없거나 비어있어 기본값으로 복원");
+				setDraft({
+					url: doc.originalUrl,
+					sourceLang: doc.sourceLang || "auto",
+					targetLang: doc.targetLang || "ko",
+					selectedAreas: [],
+					originalHtml: "",
+					originalHtmlWithIds: "",
+					state: DocumentState.DRAFT,
+				});
+				setDocumentId(doc.id);
+				setCurrentStep(1);
+				console.log("✅ 임시저장 문서 불러오기 완료 (기본값):", doc.id);
+				alert("임시저장 문서를 불러왔습니다. (기본값으로 복원)");
+			}
+		} catch (error) {
+			console.error("❌ 임시저장 문서 불러오기 실패:", error);
+			console.error(
+				"❌ 오류 상세:",
+				error instanceof Error ? error.message : String(error),
+			);
+			alert(
+				`임시저장 문서를 불러오는데 실패했습니다.\n오류: ${error instanceof Error ? error.message : String(error)}`,
+			);
+		}
+	};
+
+	const handleSaveDraft = async (
+		step6Data?: {
+			title?: string;
+			categoryId?: number;
+			estimatedLength?: number;
+		},
+		isAutoSave = false,
+		draftOverrides?: { url?: string },
+	) => {
+		try {
+			const urlToUse = draftOverrides?.url ?? draft.url;
+			const draftData = JSON.stringify({
+				currentStep,
+				draft: {
+					url: urlToUse,
+					selectedAreas: draft.selectedAreas,
+					originalHtml: draft.originalHtml,
+					originalHtmlWithIds: draft.originalHtmlWithIds,
+					editedHtml: draft.editedHtml,
+					translatedHtml: draft.translatedHtml,
+					sourceLang: draft.sourceLang,
+					targetLang: draft.targetLang,
+					state: draft.state,
+				},
+				// Step 6의 입력값들도 저장
+				step6Data: step6Data || null,
+			});
+
+			// Step 6에서 임시저장할 때는 제목도 업데이트
+			const documentTitle =
+				step6Data?.title || `번역 문서 - ${new Date().toLocaleString()}`;
+
+			if (!documentId) {
+				// 문서가 없으면 먼저 생성 (버전은 생성하지 않음 - Step 6에서만 생성)
+				const response = await documentApi.createDocument({
+					title: documentTitle,
+					originalUrl: urlToUse || "https://manual-paste.local",
+					sourceLang: draft.sourceLang || "auto",
+					targetLang: draft.targetLang || "ko",
+					status: "DRAFT",
+					categoryId: step6Data?.categoryId,
+					estimatedLength: step6Data?.estimatedLength,
+					draftData: draftData,
+				});
+				setDocumentId(response.id);
+				console.log(
+					"✅ 임시저장 완료 (문서 생성):",
+					response.id,
+					"Step",
+					currentStep,
+				);
+			} else {
+				// 문서가 있으면 문서만 업데이트 (버전은 생성하지 않음)
+				const updateData: any = {
+					draftData: draftData, // 항상 draftData는 업데이트
+				};
+				// Step 6 데이터가 있으면 추가
+				if (step6Data) {
+					if (step6Data.title) updateData.title = step6Data.title;
+					if (step6Data.categoryId)
+						updateData.categoryId = step6Data.categoryId;
+					if (step6Data.estimatedLength)
+						updateData.estimatedLength = step6Data.estimatedLength;
+				}
+				await documentApi.updateDocument(documentId, updateData);
+				console.log(
+					"✅ 임시저장 완료 (문서 업데이트):",
+					documentId,
+					"Step",
+					currentStep,
+				);
+			}
+
+			setLastSaved(new Date());
+			setHasUnsavedChanges(false);
+			setSaveError(null);
+
+			// ⭐ 임시저장 문서 목록 다시 로드
+			const allDocs = await documentApi.getAllDocuments();
+			const draftOnlyDocs = allDocs.filter(
+				(doc) => doc.status === "DRAFT" && doc.hasVersions !== true,
+			);
+			setDraftDocuments(draftOnlyDocs);
+			console.log("✅ 임시저장 목록 갱신 완료:", draftOnlyDocs.length, "개");
+
+			// ⭐ 임시저장 완료 모달 표시 (자동 저장이 아닐 때만)
+			if (!isAutoSave) {
+				alert("임시저장되었습니다.");
+			}
+		} catch (error: any) {
+			console.error("Save error:", error);
+			setSaveError(error?.response?.data?.message || "저장 실패");
+			if (!isAutoSave) {
+				alert(
+					`임시저장에 실패했습니다.\n오류: ${error?.response?.data?.message || error.message || "저장 실패"}`,
+				);
+			}
+		}
+	};
+
+	if (!isAuthorized) {
+		return null;
+	}
+
+	const renderStep = () => {
+		switch (currentStep) {
+			case 1:
+				return (
+					<Step1CrawlingInput
+						url={draft.url}
+						setUrl={(url) => setDraft((prev) => ({ ...prev, url }))}
+						onExecute={handleCrawling}
+						onManualPaste={handleManualPaste}
+						isLoading={isLoading}
+						loadingProgress={loadingProgress}
+						draftDocuments={draftDocuments}
+						onLoadDraft={handleLoadDraft}
+					/>
+				);
+			case 2:
+				return (
+					<Step2AreaSelection
+						html={draft.originalHtmlWithIds || draft.originalHtml}
+						selectedAreas={draft.selectedAreas}
+						onAreaSelect={handleAreaSelect}
+						onAreaRemove={handleAreaRemove}
+						onHtmlUpdate={(html) => {
+							// STEP 2의 iframe HTML (data-transflow-id 포함)을 저장
+							setDraft((prev) => ({ ...prev, originalHtmlWithIds: html }));
+						}}
+					/>
+				);
+			case 3:
+				console.log("🎯 Step 3 렌더링:", {
+					editedHtml: draft.editedHtml?.substring(0, 100),
+					originalHtml: draft.originalHtml?.substring(0, 100),
+					originalHtmlWithIds: draft.originalHtmlWithIds?.substring(0, 100),
+					selectedAreasCount: draft.selectedAreas.length,
+					selectedAreasData: draft.selectedAreas,
+				});
+				return (
+					<Step3PreEdit
+						html={
+							draft.editedHtml ||
+							draft.originalHtmlWithIds ||
+							draft.originalHtml
+						}
+						onHtmlChange={(html) =>
+							setDraft((prev) => ({ ...prev, editedHtml: html }))
+						}
+						selectedAreas={draft.selectedAreas}
+						isManualPasteMode={isManualPasteMode}
+						onClearForManualPaste={() => {}}
+					/>
+				);
+			case 4:
+				return (
+					<Step4Translation
+						onConfirm={handleTranslation}
+						onCancel={() => setCurrentStep(3)}
+						isTranslating={isTranslating}
+						translatingProgress={translatingProgress}
+					/>
+				);
+			case 5:
+				return (
+					<Step5ParallelEdit
+						crawledHtml={draft.originalHtml} // STEP 1에서 크롤링한 전체 원문
+						selectedHtml={draft.editedHtml || draft.originalHtmlWithIds || ""} // STEP 2/3에서 선택한 영역
+						translatedHtml={removeLegacyGlossaryMarkup(
+							draft.translatedHtml || "",
+						)}
+						onTranslatedChange={(html) =>
+							setDraft((prev) => ({ ...prev, translatedHtml: html }))
+						}
+						collapsedPanels={step5CollapsedPanels}
+						showVersion0Glossary={showStep5Version0Glossary}
+						glossaryTerms={step5GlossaryTerms}
+						onTogglePanel={(panelId) => {
+							setStep5CollapsedPanels((prev) => {
+								const newSet = new Set(prev);
+								if (newSet.has(panelId)) {
+									newSet.delete(panelId);
+								} else {
+									newSet.add(panelId);
+								}
+								return newSet;
+							});
+						}}
+					/>
+				);
+			case 6:
+				return (
+					<Step6CreateDocument
+						ref={step6Ref}
+						draft={draft}
+						onCreateDocument={(data) => {
+							// Step6CreateDocument에서 status를 포함하여 전달
+							handleCreateDocument(data);
+						}}
+						onSaveDraft={(data) => {
+							// Step 6에서 임시저장
+							handleSaveDraft(data);
+						}}
+						step6Data={step6Data || undefined}
+						isCreating={isCreating}
+					/>
+				);
+			default:
+				return null;
+		}
+	};
+
+	return (
+		<div
+			style={{
+				display: "flex",
+				flexDirection: "column",
+				height: "100vh",
+				backgroundColor: "#DCDCDC",
+			}}
+		>
+			{/* 상단 상태 바 */}
+			<div
+				style={{
+					padding: "12px 24px",
+					borderBottom: "1px solid #C0C0C0",
+					backgroundColor: "#FFFFFF",
+					display: "flex",
+					justifyContent: "space-between",
+					alignItems: "center",
+					gap: "16px",
+				}}
+			>
+				{/* 왼쪽: STEP 정보 */}
+				<div
+					style={{
+						display: "flex",
+						alignItems: "center",
+						gap: "16px",
+						flex: 1,
+					}}
+				>
+					<div
+						style={{
+							fontSize: "13px",
+							fontWeight: 500,
+							color: "#000000",
+							fontFamily: "system-ui, Pretendard, sans-serif",
+						}}
+					>
+						STEP {currentStep} / 6
+					</div>
+					<div
+						style={{
+							fontSize: "12px",
+							color: "#696969",
+							fontFamily: "system-ui, Pretendard, sans-serif",
+							fontWeight: 500,
+						}}
+					>
+						{currentStep === 1 && "가져올 웹사이트 주소 입력"}
+						{currentStep === 2 && "영역 선택"}
+						{currentStep === 3 && "번역 전 편집"}
+						{currentStep === 4 && "번역 실행"}
+						{currentStep === 5 && "번역 후 편집"}
+						{currentStep === 6 && "문서 정보 입력 및 생성"}
+					</div>
+					<div
+						style={{
+							fontSize: "12px",
+							color: "#696969",
+							fontFamily: "system-ui, Pretendard, sans-serif",
+						}}
+					>
+						{currentStep >= 3 && lastSaved
+							? `마지막 저장: ${lastSaved.toLocaleTimeString()}`
+							: currentStep >= 3
+								? "저장되지 않음"
+								: ""}
+					</div>
+					{saveError && (
+						<div
+							style={{
+								fontSize: "12px",
+								color: "#000000",
+								fontFamily: "system-ui, Pretendard, sans-serif",
+								backgroundColor: "#D3D3D3",
+								padding: "4px 8px",
+								borderRadius: "4px",
+							}}
+						>
+							{saveError}
+						</div>
+					)}
+				</div>
+
+				{/* 중앙: 문서 보기 옵션 (Step 5일 때만 표시) */}
+				{currentStep === 5 && (
+					<div
+						style={{
+							display: "flex",
+							alignItems: "center",
+							gap: "24px",
+							padding: "6px 16px",
+							backgroundColor: "#F8F9FA",
+							borderRadius: "6px",
+							border: "1px solid #D3D3D3",
+						}}
+					>
+						<span
+							style={{ fontSize: "12px", fontWeight: 600, color: "#000000" }}
+						>
+							문서 보기:
+						</span>
+						<label
+							style={{
+								display: "flex",
+								alignItems: "center",
+								gap: "8px",
+								fontSize: "13px",
+								cursor: "pointer",
+								fontWeight: 500,
+								color: "#7a4b00",
+							}}
+						>
+							<input
+								type="checkbox"
+								checked={showStep5Version0Glossary}
+								onChange={(e) => setShowStep5Version0Glossary(e.target.checked)}
+								style={{ cursor: "pointer", width: "16px", height: "16px" }}
+							/>
+							<span>Version 0 용어집 적용 구간 보기</span>
+						</label>
+						<label
+							style={{
+								display: "flex",
+								alignItems: "center",
+								gap: "8px",
+								fontSize: "13px",
+								cursor: "pointer",
+								fontWeight: 500,
+							}}
+						>
+							<input
+								type="checkbox"
+								checked={!step5CollapsedPanels.has("crawled")}
+								onChange={() => {
+									setStep5CollapsedPanels((prev) => {
+										const newSet = new Set(prev);
+										if (newSet.has("crawled")) {
+											newSet.delete("crawled");
+										} else {
+											newSet.add("crawled");
+										}
+										return newSet;
+									});
+								}}
+								style={{
+									cursor: "pointer",
+									width: "16px",
+									height: "16px",
+								}}
+							/>
+							<span style={{ color: "#000000" }}>원본 웹사이트</span>
+						</label>
+						<label
+							style={{
+								display: "flex",
+								alignItems: "center",
+								gap: "8px",
+								fontSize: "13px",
+								cursor: "pointer",
+								fontWeight: 500,
+							}}
+						>
+							<input
+								type="checkbox"
+								checked={!step5CollapsedPanels.has("selected")}
+								onChange={() => {
+									setStep5CollapsedPanels((prev) => {
+										const newSet = new Set(prev);
+										if (newSet.has("selected")) {
+											newSet.delete("selected");
+										} else {
+											newSet.add("selected");
+										}
+										return newSet;
+									});
+								}}
+								style={{
+									cursor: "pointer",
+									width: "16px",
+									height: "16px",
+								}}
+							/>
+							<span style={{ color: "#000000" }}>Version 0</span>
+						</label>
+						<label
+							style={{
+								display: "flex",
+								alignItems: "center",
+								gap: "8px",
+								fontSize: "13px",
+								cursor: "pointer",
+								fontWeight: 500,
+							}}
+						>
+							<input
+								type="checkbox"
+								checked={!step5CollapsedPanels.has("translated")}
+								onChange={() => {
+									setStep5CollapsedPanels((prev) => {
+										const newSet = new Set(prev);
+										if (newSet.has("translated")) {
+											newSet.delete("translated");
+										} else {
+											newSet.add("translated");
+										}
+										return newSet;
+									});
+								}}
+								style={{
+									cursor: "pointer",
+									width: "16px",
+									height: "16px",
+								}}
+							/>
+							<span style={{ color: "#000000" }}>Version 1 (AI 초벌 번역)</span>
+						</label>
+					</div>
+				)}
+
+				{/* 오른쪽: 임시 저장 버튼 (Step 3부터만 표시) */}
+				<div>
+					{currentStep >= 3 && (
+						<Button
+							variant="secondary"
+							onClick={() => handleSaveDraft()}
+							style={{ fontSize: "12px", padding: "4px 8px" }}
+						>
+							임시 저장
+						</Button>
+					)}
+				</div>
+			</div>
+
+			{/* 메인 작업 영역 */}
+			<div
+				style={{
+					flex: 1,
+					padding: "16px",
+					overflow: "auto",
+				}}
+			>
+				{renderStep()}
+			</div>
+
+			{/* 하단 네비게이션 */}
+			<div
+				style={{
+					padding: "16px",
+					borderTop: "1px solid #C0C0C0",
+					backgroundColor: "#FFFFFF",
+					display: "flex",
+					justifyContent: "space-between",
+					alignItems: "center",
+				}}
+			>
+				<div>
+					{currentStep > 1 && (
+						<Button variant="secondary" onClick={handlePrev}>
+							이전
+						</Button>
+					)}
+				</div>
+				<div style={{ display: "flex", gap: "8px", alignItems: "center" }}>
+					{currentStep < 6 && (
+						<Button variant="primary" onClick={handleNext}>
+							다음
+						</Button>
+					)}
+				</div>
+			</div>
+
+			<Modal
+				isOpen={showUrlModal}
+				onClose={() => {
+					setShowUrlModal(false);
+					setUrlModalInput("");
+				}}
+				title="원문 URL 입력"
+				onConfirm={handleUrlModalConfirm}
+				confirmText="확인"
+				cancelText="취소"
+			>
+				<p style={{ marginBottom: "12px", fontSize: "14px" }}>
+					임시저장을 위해 원문 URL을 입력해주세요.
+				</p>
+				<input
+					type="text"
+					value={urlModalInput}
+					onChange={(e) => setUrlModalInput(e.target.value)}
+					placeholder="https://example.com"
+					style={{
+						width: "100%",
+						padding: "8px 12px",
+						fontSize: "14px",
+						border: "1px solid #ccc",
+						borderRadius: "4px",
+						boxSizing: "border-box",
+					}}
+					onKeyDown={(e) => {
+						if (e.key === "Enter") handleUrlModalConfirm();
+					}}
+				/>
+			</Modal>
+		</div>
+	);
 };
 
 export default NewTranslation;
-

--- a/src/pages/Reviews.tsx
+++ b/src/pages/Reviews.tsx
@@ -256,11 +256,12 @@ export default function Reviews() {
     {
       key: 'action',
       label: '',
-      width: '13%',
-      align: 'right',
+      width: '96px',
+      align: 'center',
+      cellStyle: { overflow: 'visible' },
       render: (item) => {
         return (
-          <div style={{ display: 'flex', gap: '8px', alignItems: 'center', justifyContent: 'flex-end' }}>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: '100%' }}>
             <Button
               variant="primary"
               onClick={(e) => {
@@ -271,7 +272,9 @@ export default function Reviews() {
               }}
               style={{ 
                 fontSize: '12px', 
-                padding: '6px 12px',
+                padding: '6px 10px',
+                minWidth: '74px',
+                whiteSpace: 'nowrap',
               }}
             >
               검토하기

--- a/src/pages/TranslationWork.tsx
+++ b/src/pages/TranslationWork.tsx
@@ -1,599 +1,736 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { useParams, useNavigate, useLocation } from 'react-router-dom';
-import { translationWorkApi, LockStatusResponse } from '../services/translationWorkApi';
-import { documentApi, DocumentResponse } from '../services/documentApi';
-import { documentApi as docApi, DocumentVersionResponse } from '../services/documentApi';
-import { colors } from '../constants/designTokens';
-import { Button } from '../components/Button';
+import type React from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
+import { useParams, useNavigate, useLocation } from "react-router-dom";
 import {
-  extractParagraphs,
-  getParagraphs,
-  getParagraphAtScrollPosition,
-  highlightParagraph,
-  clearAllHighlights,
-  Paragraph,
-} from '../utils/paragraphUtils';
-import ErrorBoundary from '../components/ErrorBoundary';
-import { AlignLeft, AlignCenter, AlignRight, AlignJustify, List, ListOrdered, Palette, Quote, Minus, Link2, Highlighter, Image, Table, Code, Superscript, Subscript, MoreVertical, Undo2, Redo2 } from 'lucide-react';
-import './TranslationWork.css';
-import { useUser } from '../contexts/UserContext';
-import { DocumentChat } from '../components/DocumentChat';
-import { termApi } from '../services/termApi';
+	translationWorkApi,
+	type LockStatusResponse,
+} from "../services/translationWorkApi";
+import { documentApi, type DocumentResponse } from "../services/documentApi";
+import {
+	documentApi as docApi,
+	DocumentVersionResponse,
+} from "../services/documentApi";
+import { colors } from "../constants/designTokens";
+import { Button } from "../components/Button";
+import {
+	extractParagraphs,
+	getParagraphs,
+	getParagraphAtScrollPosition,
+	highlightParagraph,
+	clearAllHighlights,
+	Paragraph,
+} from "../utils/paragraphUtils";
+import ErrorBoundary from "../components/ErrorBoundary";
+import {
+	AlignLeft,
+	AlignCenter,
+	AlignRight,
+	AlignJustify,
+	List,
+	ListOrdered,
+	Palette,
+	Quote,
+	Minus,
+	Link2,
+	Highlighter,
+	Image,
+	Table,
+	Code,
+	Superscript,
+	Subscript,
+	MoreVertical,
+	Undo2,
+	Redo2,
+} from "lucide-react";
+import "./TranslationWork.css";
+import { useUser } from "../contexts/UserContext";
+import { DocumentChat } from "../components/DocumentChat";
+import { termApi } from "../services/termApi";
 
 const WORD_CHAR_REGEX = /[A-Za-z0-9_]/;
 type GlossaryTermPair = { sourceTerm: string; targetTerm: string };
 
-const highlightGlossaryInOriginalIframe = (doc: Document, glossaryTerms: GlossaryTermPair[]) => {
-  if (!doc.body || glossaryTerms.length === 0) return;
+const highlightGlossaryInOriginalIframe = (
+	doc: Document,
+	glossaryTerms: GlossaryTermPair[],
+) => {
+	if (!doc.body || glossaryTerms.length === 0) return;
 
-  const sortedTerms = [...glossaryTerms]
-    .map((t) => ({ sourceTerm: t.sourceTerm.trim(), targetTerm: t.targetTerm.trim() }))
-    .filter((t) => t.sourceTerm.length > 1 && t.targetTerm.length > 0)
-    .sort((a, b) => b.sourceTerm.length - a.sourceTerm.length);
-  if (sortedTerms.length === 0) return;
+	const sortedTerms = [...glossaryTerms]
+		.map((t) => ({
+			sourceTerm: t.sourceTerm.trim(),
+			targetTerm: t.targetTerm.trim(),
+		}))
+		.filter((t) => t.sourceTerm.length > 1 && t.targetTerm.length > 0)
+		.sort((a, b) => b.sourceTerm.length - a.sourceTerm.length);
+	if (sortedTerms.length === 0) return;
 
-  const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_TEXT);
-  const textNodes: Text[] = [];
-  let current: Node | null = walker.nextNode();
-  while (current) {
-    const parentTag = (current.parentElement?.tagName || '').toLowerCase();
-    if (parentTag !== 'script' && parentTag !== 'style' && current.textContent?.trim()) {
-      textNodes.push(current as Text);
-    }
-    current = walker.nextNode();
-  }
+	const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_TEXT);
+	const textNodes: Text[] = [];
+	let current: Node | null = walker.nextNode();
+	while (current) {
+		const parentTag = (current.parentElement?.tagName || "").toLowerCase();
+		if (
+			parentTag !== "script" &&
+			parentTag !== "style" &&
+			current.textContent?.trim()
+		) {
+			textNodes.push(current as Text);
+		}
+		current = walker.nextNode();
+	}
 
-  textNodes.forEach((textNode) => {
-    const source = textNode.textContent || '';
-    const lower = source.toLowerCase();
-    let cursor = 0;
-    const fragment = doc.createDocumentFragment();
-    let matched = false;
+	textNodes.forEach((textNode) => {
+		const source = textNode.textContent || "";
+		const lower = source.toLowerCase();
+		let cursor = 0;
+		const fragment = doc.createDocumentFragment();
+		let matched = false;
 
-    while (cursor < source.length) {
-      let bestStart = -1;
-      let bestEnd = -1;
-      let bestTerm: GlossaryTermPair | null = null;
+		while (cursor < source.length) {
+			let bestStart = -1;
+			let bestEnd = -1;
+			let bestTerm: GlossaryTermPair | null = null;
 
-      for (const term of sortedTerms) {
-        const termLower = term.sourceTerm.toLowerCase();
-        const found = lower.indexOf(termLower, cursor);
-        if (found === -1) continue;
-        const end = found + termLower.length;
+			for (const term of sortedTerms) {
+				const termLower = term.sourceTerm.toLowerCase();
+				const found = lower.indexOf(termLower, cursor);
+				if (found === -1) continue;
+				const end = found + termLower.length;
 
-        const before = found > 0 ? source[found - 1] : '';
-        const after = end < source.length ? source[end] : '';
-        const leftBoundary = !before || !WORD_CHAR_REGEX.test(before);
-        const rightBoundary = !after || !WORD_CHAR_REGEX.test(after);
-        if (!leftBoundary || !rightBoundary) continue;
+				const before = found > 0 ? source[found - 1] : "";
+				const after = end < source.length ? source[end] : "";
+				const leftBoundary = !before || !WORD_CHAR_REGEX.test(before);
+				const rightBoundary = !after || !WORD_CHAR_REGEX.test(after);
+				if (!leftBoundary || !rightBoundary) continue;
 
-        if (bestStart === -1 || found < bestStart || (found === bestStart && bestTerm && term.sourceTerm.length > bestTerm.sourceTerm.length)) {
-          bestStart = found;
-          bestEnd = end;
-          bestTerm = term;
-        }
-      }
+				if (
+					bestStart === -1 ||
+					found < bestStart ||
+					(found === bestStart &&
+						bestTerm &&
+						term.sourceTerm.length > bestTerm.sourceTerm.length)
+				) {
+					bestStart = found;
+					bestEnd = end;
+					bestTerm = term;
+				}
+			}
 
-      if (bestStart === -1) {
-        fragment.appendChild(doc.createTextNode(source.slice(cursor)));
-        break;
-      }
+			if (bestStart === -1) {
+				fragment.appendChild(doc.createTextNode(source.slice(cursor)));
+				break;
+			}
 
-      if (bestStart > cursor) {
-        fragment.appendChild(doc.createTextNode(source.slice(cursor, bestStart)));
-      }
+			if (bestStart > cursor) {
+				fragment.appendChild(
+					doc.createTextNode(source.slice(cursor, bestStart)),
+				);
+			}
 
-      const span = doc.createElement('span');
-      span.className = 'original-glossary-term';
-      span.setAttribute('data-source-term', bestTerm?.sourceTerm || '');
-      span.setAttribute('data-target-term', bestTerm?.targetTerm || '');
-      span.textContent = `${source.slice(bestStart, bestEnd)}(${bestTerm?.targetTerm || ''})`;
-      fragment.appendChild(span);
+			const span = doc.createElement("span");
+			span.className = "original-glossary-term";
+			span.setAttribute("data-source-term", bestTerm?.sourceTerm || "");
+			span.setAttribute("data-target-term", bestTerm?.targetTerm || "");
+			span.textContent = `${source.slice(bestStart, bestEnd)}(${bestTerm?.targetTerm || ""})`;
+			fragment.appendChild(span);
 
-      matched = true;
-      cursor = bestEnd;
-    }
+			matched = true;
+			cursor = bestEnd;
+		}
 
-    if (matched) textNode.replaceWith(fragment);
-  });
+		if (matched) textNode.replaceWith(fragment);
+	});
 };
 
 // 과거 버전에서 AI_DRAFT에 삽입된 glossary-term 마크업 제거
 const removeLegacyGlossaryMarkup = (html: string) => {
-  if (!html) return html;
-  try {
-    const parser = new DOMParser();
-    const doc = parser.parseFromString(html, 'text/html');
-    const glossaryNodes = doc.querySelectorAll('span.glossary-term');
+	if (!html) return html;
+	try {
+		const parser = new DOMParser();
+		const doc = parser.parseFromString(html, "text/html");
+		const glossaryNodes = doc.querySelectorAll("span.glossary-term");
 
-    glossaryNodes.forEach((node) => {
-      const original = node.getAttribute('data-original') || '';
-      const text = node.textContent || '';
-      const suffix = original ? `(${original})` : '';
-      const restored = suffix && text.endsWith(suffix) ? text.slice(0, -suffix.length) : text;
-      node.replaceWith(doc.createTextNode(restored));
-    });
+		glossaryNodes.forEach((node) => {
+			const original = node.getAttribute("data-original") || "";
+			const text = node.textContent || "";
+			const suffix = original ? `(${original})` : "";
+			const restored =
+				suffix && text.endsWith(suffix) ? text.slice(0, -suffix.length) : text;
+			node.replaceWith(doc.createTextNode(restored));
+		});
 
-    return doc.documentElement.outerHTML;
-  } catch {
-    return html;
-  }
+		return doc.documentElement.outerHTML;
+	} catch {
+		return html;
+	}
 };
 
 export default function TranslationWork() {
-  const { id } = useParams<{ id: string }>();
-  const navigate = useNavigate();
-  const location = useLocation();
-  const fromPath = (location.state as { from?: string } | null)?.from || '/translations/pending';
-  const documentId = id ? parseInt(id, 10) : null;
-  const { user } = useUser();
+	const { id } = useParams<{ id: string }>();
+	const navigate = useNavigate();
+	const location = useLocation();
+	const fromPath =
+		(location.state as { from?: string } | null)?.from ||
+		"/translations/pending";
+	const documentId = id ? Number.parseInt(id, 10) : null;
+	const { user } = useUser();
 
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [lockStatus, setLockStatus] = useState<LockStatusResponse | null>(null);
-  const [document, setDocument] = useState<DocumentResponse | null>(null);
-  const [originalContent, setOriginalContent] = useState<string>('');
-  const [aiDraftContent, setAiDraftContent] = useState<string>('');
-  const [progress, setProgress] = useState({ completed: 0, total: 0 });
-  const [completedParagraphs, setCompletedParagraphs] = useState<Set<number>>(new Set());
-  const [highlightedParagraphIndex, setHighlightedParagraphIndex] = useState<number | null>(null);
-  const [showHandoverModal, setShowHandoverModal] = useState(false);
-  const [handoverSubmitting, setHandoverSubmitting] = useState(false);
-  const [handoverMemo, setHandoverMemo] = useState('');
-  const [handoverTerms, setHandoverTerms] = useState('');
-  const [showHandoverInfoModal, setShowHandoverInfoModal] = useState(false);
-  
-  // 링크 편집 모달 상태
-  const [showLinkModal, setShowLinkModal] = useState(false);
-  const [editingLink, setEditingLink] = useState<HTMLAnchorElement | null>(null);
-  const [linkUrl, setLinkUrl] = useState('');
-  
-  // 더보기 메뉴 상태
-  const [showMoreMenu, setShowMoreMenu] = useState(false);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+	const [lockStatus, setLockStatus] = useState<LockStatusResponse | null>(null);
+	const [document, setDocument] = useState<DocumentResponse | null>(null);
+	const [originalContent, setOriginalContent] = useState<string>("");
+	const [aiDraftContent, setAiDraftContent] = useState<string>("");
+	const [progress, setProgress] = useState({ completed: 0, total: 0 });
+	const [completedParagraphs, setCompletedParagraphs] = useState<Set<number>>(
+		new Set(),
+	);
+	const [highlightedParagraphIndex, setHighlightedParagraphIndex] = useState<
+		number | null
+	>(null);
+	const [showHandoverModal, setShowHandoverModal] = useState(false);
+	const [handoverSubmitting, setHandoverSubmitting] = useState(false);
+	const [handoverMemo, setHandoverMemo] = useState("");
+	const [handoverTerms, setHandoverTerms] = useState("");
+	const [showHandoverInfoModal, setShowHandoverInfoModal] = useState(false);
 
-  // 패널 접기/전체화면 상태
-  const [collapsedPanels, setCollapsedPanels] = useState<Set<string>>(new Set());
-  const [fullscreenPanel, setFullscreenPanel] = useState<string | null>(null);
-  const [allPanelsCollapsed, setAllPanelsCollapsed] = useState(false);
+	// 링크 편집 모달 상태
+	const [showLinkModal, setShowLinkModal] = useState(false);
+	const [editingLink, setEditingLink] = useState<HTMLAnchorElement | null>(
+		null,
+	);
+	const [linkUrl, setLinkUrl] = useState("");
 
-  // 소통 채팅 패널 표시 여부
-  const [showChat, setShowChat] = useState(false);
-  const [showOriginalGlossary, setShowOriginalGlossary] = useState(false);
-  const [originalGlossaryTerms, setOriginalGlossaryTerms] = useState<GlossaryTermPair[]>([]);
+	// 더보기 메뉴 상태
+	const [showMoreMenu, setShowMoreMenu] = useState(false);
 
-  // 패널 refs (iframe으로 변경)
-  const originalIframeRef = useRef<HTMLIFrameElement>(null);
-  const aiDraftIframeRef = useRef<HTMLIFrameElement>(null);
-  const isScrollingRef = useRef(false);
+	// 패널 접기/전체화면 상태
+	const [collapsedPanels, setCollapsedPanels] = useState<Set<string>>(
+		new Set(),
+	);
+	const [fullscreenPanel, setFullscreenPanel] = useState<string | null>(null);
+	const [allPanelsCollapsed, setAllPanelsCollapsed] = useState(false);
 
-  // 원본 HTML 저장 (iframe 렌더링용)
-  const [originalHtml, setOriginalHtml] = useState<string>('');
-  const [aiDraftHtml, setAiDraftHtml] = useState<string>('');
-  const [savedTranslationHtml, setSavedTranslationHtml] = useState<string>('');
-  const [lastSavedHtml, setLastSavedHtml] = useState<string>(''); // 마지막 저장된 HTML
+	// 소통 채팅 패널 표시 여부
+	const [showChat, setShowChat] = useState(false);
+	const [showOriginalGlossary, setShowOriginalGlossary] = useState(false);
+	const [originalGlossaryTerms, setOriginalGlossaryTerms] = useState<
+		GlossaryTermPair[]
+	>([]);
 
-  // 내 번역 에디터 상태 (iframe 기반)
-  const myTranslationIframeRef = useRef<HTMLIFrameElement>(null);
-  const [isTranslationEditorInitialized, setIsTranslationEditorInitialized] = useState(false);
-  const [editorMode, setEditorMode] = useState<'text' | 'component'>('text');
-  const [selectedElements, setSelectedElements] = useState<HTMLElement[]>([]);
-  
-  // Undo/Redo Stack for component editing
-  const undoStackRef = useRef<string[]>([]);
-  const redoStackRef = useRef<string[]>([]);
-  const currentEditorHtmlRef = useRef<string>('');
-  
-  // 이벤트 핸들러 저장 (제거를 위해)
-  const componentClickHandlersRef = useRef<Map<HTMLElement, (e: Event) => void>>(new Map());
-  const linkClickHandlersRef = useRef<Map<HTMLElement, (e: Event) => void>>(new Map());
-  const windowKeydownHandlerRef = useRef<((e: KeyboardEvent) => void) | null>(null);
-  const iframeKeydownHandlerRef = useRef<((e: KeyboardEvent) => void) | null>(null);
-  
-  // iframe 렌더링 상태 추적
-  const hasRenderedMyTranslation = useRef(false);
-  
+	// 패널 refs (iframe으로 변경)
+	const originalIframeRef = useRef<HTMLIFrameElement>(null);
+	const aiDraftIframeRef = useRef<HTMLIFrameElement>(null);
+	const isScrollingRef = useRef(false);
 
-  // 마우스 호버로 문단 하이라이트 (useEffect보다 먼저 선언)
-  const handleParagraphHover = useCallback((index: number) => {
-    console.log(`🔍 문단 ${index} 하이라이트 요청`);
-    setHighlightedParagraphIndex(index);
-  }, []);
+	// 원본 HTML 저장 (iframe 렌더링용)
+	const [originalHtml, setOriginalHtml] = useState<string>("");
+	const [aiDraftHtml, setAiDraftHtml] = useState<string>("");
+	const [savedTranslationHtml, setSavedTranslationHtml] = useState<string>("");
+	const [lastSavedHtml, setLastSavedHtml] = useState<string>(""); // 마지막 저장된 HTML
 
-  // 페이지 나갈 때 저장 확인 및 락 유지
-  useEffect(() => {
-    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
-      // 변경사항이 있을 때만 경고
-      if (savedTranslationHtml && savedTranslationHtml.trim() !== '') {
-        e.preventDefault();
-        e.returnValue = ''; // Chrome에서 필요
-        return ''; // 일부 브라우저에서 필요
-      }
-    };
+	// 내 번역 에디터 상태 (iframe 기반)
+	const myTranslationIframeRef = useRef<HTMLIFrameElement>(null);
+	const [isTranslationEditorInitialized, setIsTranslationEditorInitialized] =
+		useState(false);
+	const [editorMode, setEditorMode] = useState<"text" | "component">("text");
+	const [selectedElements, setSelectedElements] = useState<HTMLElement[]>([]);
 
-    const handleUnload = async () => {
-      // 페이지를 나갈 때 락은 유지 (다른 사용자가 이어서 작업할 수 있도록)
-      // 락은 "인계 요청" 또는 "번역 완료" 버튼을 눌렀을 때만 해제됨
-      console.log('🚪 페이지를 나갑니다. 락은 유지됩니다.');
-    };
+	// Undo/Redo Stack for component editing
+	const undoStackRef = useRef<string[]>([]);
+	const redoStackRef = useRef<string[]>([]);
+	const currentEditorHtmlRef = useRef<string>("");
 
-    window.addEventListener('beforeunload', handleBeforeUnload);
-    window.addEventListener('unload', handleUnload);
+	// 이벤트 핸들러 저장 (제거를 위해)
+	const componentClickHandlersRef = useRef<
+		Map<HTMLElement, (e: Event) => void>
+	>(new Map());
+	const linkClickHandlersRef = useRef<Map<HTMLElement, (e: Event) => void>>(
+		new Map(),
+	);
+	const windowKeydownHandlerRef = useRef<((e: KeyboardEvent) => void) | null>(
+		null,
+	);
+	const iframeKeydownHandlerRef = useRef<((e: KeyboardEvent) => void) | null>(
+		null,
+	);
 
-    return () => {
-      window.removeEventListener('beforeunload', handleBeforeUnload);
-      window.removeEventListener('unload', handleUnload);
-    };
-  }, [savedTranslationHtml]);
+	// iframe 렌더링 상태 추적
+	const hasRenderedMyTranslation = useRef(false);
 
-  // 초기 데이터 로드
-  useEffect(() => {
-    if (!documentId) {
-      setError('문서 ID가 없습니다.');
-      setLoading(false);
-      return;
-    }
+	// 마우스 호버로 문단 하이라이트 (useEffect보다 먼저 선언)
+	const handleParagraphHover = useCallback((index: number) => {
+		console.log(`🔍 문단 ${index} 하이라이트 요청`);
+		setHighlightedParagraphIndex(index);
+	}, []);
 
-    const loadData = async () => {
-      try {
-        setLoading(true);
-        setError(null);
+	// 페이지 나갈 때 저장 확인 및 락 유지
+	useEffect(() => {
+		const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+			// 변경사항이 있을 때만 경고
+			if (savedTranslationHtml && savedTranslationHtml.trim() !== "") {
+				e.preventDefault();
+				e.returnValue = ""; // Chrome에서 필요
+				return ""; // 일부 브라우저에서 필요
+			}
+		};
 
-        // 1. 문서 정보 가져오기
-        console.log('📄 문서 조회 시작:', documentId);
-        const doc = await documentApi.getDocument(documentId);
-        console.log('✅ 문서 조회 성공:', doc);
-        setDocument(doc);
+		const handleUnload = async () => {
+			// 페이지를 나갈 때 락은 유지 (다른 사용자가 이어서 작업할 수 있도록)
+			// 락은 "인계 요청" 또는 "번역 완료" 버튼을 눌렀을 때만 해제됨
+			console.log("🚪 페이지를 나갑니다. 락은 유지됩니다.");
+		};
 
-        // 원문(Version 0)용 용어집 sourceTerm 로드
-        try {
-          const sourceLangRaw = (doc.sourceLang || '').toUpperCase();
-          const sourceLang = sourceLangRaw === 'AUTO' ? 'EN' : sourceLangRaw;
-          const targetLang = (doc.targetLang || '').toUpperCase();
-          if (sourceLang && targetLang) {
-            const termRes = await termApi.getAllTerms({ sourceLang, targetLang, page: 0, size: 1000 });
-            setOriginalGlossaryTerms(
-              (termRes.content || [])
-                .filter((t) => t.sourceTerm && t.targetTerm)
-                .map((t) => ({ sourceTerm: t.sourceTerm, targetTerm: t.targetTerm }))
-            );
-          } else {
-            setOriginalGlossaryTerms([]);
-          }
-        } catch (e) {
-          console.warn('원문 용어집 로드 실패:', e);
-          setOriginalGlossaryTerms([]);
-        }
+		window.addEventListener("beforeunload", handleBeforeUnload);
+		window.addEventListener("unload", handleUnload);
 
-        // 2. 완료된 문단은 문서에서 로드 (락 제거됨)
-        if (doc.completedParagraphs && doc.completedParagraphs.length > 0) {
-          console.log('📊 기존 완료된 문단 로드:', doc.completedParagraphs);
-          setCompletedParagraphs(new Set(doc.completedParagraphs));
-        }
-        setLockStatus(null);
+		return () => {
+			window.removeEventListener("beforeunload", handleBeforeUnload);
+			window.removeEventListener("unload", handleUnload);
+		};
+	}, [savedTranslationHtml]);
 
-        // 3. 버전 정보 가져오기
-        try {
-          const versions = await docApi.getDocumentVersions(documentId);
-          console.log('📦 문서 버전 목록:', versions.map(v => ({ type: v.versionType, number: v.versionNumber })));
-          
-          if (!versions || versions.length === 0) {
-            console.warn('⚠️ 문서 버전이 없습니다.');
-            setError('문서 버전 정보를 찾을 수 없습니다. 문서가 제대로 생성되었는지 확인해주세요.');
-            setLoading(false);
-            return;
-          }
-          
-          // ORIGINAL 버전 찾기
-          const originalVersion = versions.find(v => v.versionType === 'ORIGINAL');
-          if (originalVersion) {
-            // 문단 ID 부여 (iframe 렌더링용)
-            const processedOriginal = extractParagraphs(originalVersion.content, 'original');
-            setOriginalHtml(processedOriginal); // ⭐ 처리된 HTML을 iframe용으로 저장
-            setOriginalContent(processedOriginal);
-            console.log('✅ 원문 버전 로드 완료 (문단 ID 추가됨)');
-          } else {
-            console.warn('⚠️ ORIGINAL 버전이 없습니다.');
-          }
+	// 초기 데이터 로드
+	useEffect(() => {
+		if (!documentId) {
+			setError("문서 ID가 없습니다.");
+			setLoading(false);
+			return;
+		}
 
-          // AI_DRAFT 버전 찾기
-          const aiDraftVersion = versions.find(v => v.versionType === 'AI_DRAFT');
-          if (aiDraftVersion) {
-            // 문단 ID 부여 (iframe 렌더링용)
-            const cleanedAiDraft = removeLegacyGlossaryMarkup(aiDraftVersion.content);
-            const processedAiDraft = extractParagraphs(cleanedAiDraft, 'ai-draft');
-            setAiDraftHtml(processedAiDraft); // ⭐ 처리된 HTML을 iframe용으로 저장
-            setAiDraftContent(processedAiDraft);
-            console.log('✅ AI 초벌 번역 버전 로드 완료 (문단 ID 추가됨)');
-          } else {
-            console.warn('⚠️ AI_DRAFT 버전이 없습니다.');
-          }
+		const loadData = async () => {
+			try {
+				setLoading(true);
+				setError(null);
 
-          // MANUAL_TRANSLATION 버전 찾기 (사용자가 저장한 번역 - 우선 로드)
-          const manualTranslationVersion = versions
-            .filter(v => v.versionType === 'MANUAL_TRANSLATION')
-            .sort((a, b) => (b.versionNumber || 0) - (a.versionNumber || 0))[0]; // 최신 버전
-          
-          if (manualTranslationVersion) {
-            console.log('✅ 저장된 번역 발견:', manualTranslationVersion.versionNumber, '버전');
-            // 저장된 번역 HTML에 문단 ID 추가
-            const processedManual = extractParagraphs(manualTranslationVersion.content, 'manual');
-            setSavedTranslationHtml(processedManual);
-            setLastSavedHtml(processedManual); // 마지막 저장 상태 기록
-          } else if (aiDraftVersion) {
-            console.log('ℹ️ 저장된 번역이 없어 AI 초벌 번역 사용');
-            // MANUAL_TRANSLATION이 없으면 AI_DRAFT를 에디터에 설정 (문단 ID 추가)
-            const cleanedAiDraft = removeLegacyGlossaryMarkup(aiDraftVersion.content);
-            const processedAiDraft = extractParagraphs(cleanedAiDraft, 'ai-draft-editor');
-            setSavedTranslationHtml(processedAiDraft);
-            setLastSavedHtml(processedAiDraft); // 마지막 저장 상태 기록
-          } else if (originalVersion) {
-            console.log('ℹ️ AI 초벌 번역도 없어 원문 사용');
-            // AI_DRAFT도 없으면 ORIGINAL을 기본값으로 (문단 ID 추가)
-            const processedOriginal = extractParagraphs(originalVersion.content, 'original-editor');
-            setSavedTranslationHtml(processedOriginal);
-            setLastSavedHtml(processedOriginal); // 마지막 저장 상태 기록
-          } else {
-            console.warn('⚠️ 사용 가능한 버전이 없습니다.');
-            setError('표시할 문서 내용이 없습니다.');
-            setLoading(false);
-            return;
-          }
+				// 1. 문서 정보 가져오기
+				console.log("📄 문서 조회 시작:", documentId);
+				const doc = await documentApi.getDocument(documentId);
+				console.log("✅ 문서 조회 성공:", doc);
+				setDocument(doc);
 
-          // 문단 개수 계산
-          setTimeout(() => {
-            if (originalIframeRef.current?.contentDocument?.body) {
-              const paragraphs = getParagraphs(originalIframeRef.current.contentDocument.body as HTMLElement);
-              setProgress((prev) => ({ ...prev, total: paragraphs.length }));
-            } else if (originalHtml) {
-              // iframe이 아직 로드되지 않았으면 HTML에서 직접 계산
-              const parser = new DOMParser();
-              const doc = parser.parseFromString(originalHtml, 'text/html');
-              const paragraphs = getParagraphs(doc.body);
-              setProgress((prev) => ({ ...prev, total: paragraphs.length }));
-            }
-          }, 500);
-        } catch (versionError: any) {
-          console.error('버전 정보 조회 실패:', versionError);
-          setError('문서 버전 정보를 불러오는데 실패했습니다: ' + (versionError.message || '알 수 없는 오류'));
-          setLoading(false);
-          return;
-        }
+				// 원문(Version 0)용 용어집 sourceTerm 로드
+				try {
+					const sourceLangRaw = (doc.sourceLang || "").toUpperCase();
+					const sourceLang = sourceLangRaw === "AUTO" ? "EN" : sourceLangRaw;
+					const targetLang = (doc.targetLang || "").toUpperCase();
+					if (sourceLang && targetLang) {
+						const termRes = await termApi.getAllTerms({
+							sourceLang,
+							targetLang,
+							page: 0,
+							size: 1000,
+						});
+						setOriginalGlossaryTerms(
+							(termRes.content || [])
+								.filter((t) => t.sourceTerm && t.targetTerm)
+								.map((t) => ({
+									sourceTerm: t.sourceTerm,
+									targetTerm: t.targetTerm,
+								})),
+						);
+					} else {
+						setOriginalGlossaryTerms([]);
+					}
+				} catch (e) {
+					console.warn("원문 용어집 로드 실패:", e);
+					setOriginalGlossaryTerms([]);
+				}
 
-      } catch (err: any) {
-        console.error('데이터 로드 실패:', err);
-        console.error('에러 상세:', {
-          response: err.response,
-          data: err.response?.data,
-          status: err.response?.status,
-          message: err.message,
-        });
-        
-        // 에러 메시지 추출 (다양한 응답 형식 지원)
-        let errorMessage = '데이터를 불러오는데 실패했습니다.';
-        
-        // Spring 기본 에러 메시지 필터링
-        const isSpringDefaultError = (msg: string) => {
-          return msg === 'No message available' || 
-                 msg === 'No message' || 
-                 msg === '' || 
-                 !msg || 
-                 msg.trim() === '';
-        };
-        
-        if (err.response?.data) {
-          if (typeof err.response.data === 'string') {
-            if (!isSpringDefaultError(err.response.data)) {
-              errorMessage = err.response.data;
-            }
-          } else if (err.response.data.message) {
-            if (!isSpringDefaultError(err.response.data.message)) {
-              errorMessage = err.response.data.message;
-            }
-          } else if (err.response.data.error) {
-            if (!isSpringDefaultError(err.response.data.error)) {
-              errorMessage = err.response.data.error;
-            }
-          } else if (err.response.data.errorMessage) {
-            if (!isSpringDefaultError(err.response.data.errorMessage)) {
-              errorMessage = err.response.data.errorMessage;
-            }
-          }
-        } else if (err.message && !isSpringDefaultError(err.message)) {
-          errorMessage = err.message;
-        }
-        
-        // HTTP 상태 코드 기반 메시지 추가
-        if (err.response?.status) {
-          const statusMessages: Record<number, string> = {
-            400: '잘못된 요청입니다.',
-            401: '인증이 필요합니다.',
-            403: '권한이 없습니다.',
-            404: err.config?.url?.includes('/lock') 
-              ? '문서 락 API를 찾을 수 없습니다. 백엔드가 실행 중인지 확인해주세요.'
-              : err.config?.url?.includes('/documents/') && !err.config?.url?.includes('/lock')
-              ? `문서 ID ${documentId}를 찾을 수 없습니다.`
-              : '요청한 리소스를 찾을 수 없습니다.',
-            409: '문서가 이미 다른 사용자에 의해 잠겨있습니다.',
-            500: '서버 오류가 발생했습니다.',
-          };
-          
-          if (statusMessages[err.response.status] && isSpringDefaultError(errorMessage)) {
-            errorMessage = statusMessages[err.response.status];
-          } else if (err.response.status === 404) {
-            // 404 에러는 항상 명확한 메시지 제공
-            errorMessage = statusMessages[404];
-          }
-        }
-        
-        setError(errorMessage);
-      } finally {
-        setLoading(false);
-      }
-    };
+				// 2. 완료된 문단은 문서에서 로드 (락 제거됨)
+				if (doc.completedParagraphs && doc.completedParagraphs.length > 0) {
+					console.log("📊 기존 완료된 문단 로드:", doc.completedParagraphs);
+					setCompletedParagraphs(new Set(doc.completedParagraphs));
+				}
+				setLockStatus(null);
 
-    loadData();
-  }, [documentId]); // editor는 의존성에서 제거 (에디터가 없어도 데이터는 로드 가능)
+				// 3. 버전 정보 가져오기
+				try {
+					const versions = await docApi.getDocumentVersions(documentId);
+					console.log(
+						"📦 문서 버전 목록:",
+						versions.map((v) => ({
+							type: v.versionType,
+							number: v.versionNumber,
+						})),
+					);
 
-  /** 관리자(복사본 작업): 세션 시작·하트비트·종료 — 동일 원문 봉사자 편집 차단 */
-  useEffect(() => {
-    if (!documentId || !document?.sourceDocumentId) return;
-    if (!user || user.roleLevel > 2) return;
+					if (!versions || versions.length === 0) {
+						console.warn("⚠️ 문서 버전이 없습니다.");
+						setError(
+							"문서 버전 정보를 찾을 수 없습니다. 문서가 제대로 생성되었는지 확인해주세요.",
+						);
+						setLoading(false);
+						return;
+					}
 
-    translationWorkApi.startAdminTranslationSession(documentId).catch(() => {});
-    const hb = setInterval(() => {
-      translationWorkApi.heartbeatAdminTranslationSession(documentId).catch(() => {});
-    }, 60_000);
-    return () => {
-      clearInterval(hb);
-      translationWorkApi.endAdminTranslationSession(documentId).catch(() => {});
-    };
-  }, [documentId, document?.sourceDocumentId, user?.roleLevel]);
+					// ORIGINAL 버전 찾기
+					const originalVersion = versions.find(
+						(v) => v.versionType === "ORIGINAL",
+					);
+					if (originalVersion) {
+						// 문단 ID 부여 (iframe 렌더링용)
+						const processedOriginal = extractParagraphs(
+							originalVersion.content,
+							"original",
+						);
+						setOriginalHtml(processedOriginal); // ⭐ 처리된 HTML을 iframe용으로 저장
+						setOriginalContent(processedOriginal);
+						console.log("✅ 원문 버전 로드 완료 (문단 ID 추가됨)");
+					} else {
+						console.warn("⚠️ ORIGINAL 버전이 없습니다.");
+					}
 
-  /** 봉사자: 관리자 세션 여부 갱신 */
-  useEffect(() => {
-    if (!documentId || !user || user.roleLevel <= 2) return;
-    const t = setInterval(() => {
-      documentApi.getDocument(documentId).then(setDocument).catch(() => {});
-    }, 45_000);
-    return () => clearInterval(t);
-  }, [documentId, user?.roleLevel]);
+					// AI_DRAFT 버전 찾기
+					const aiDraftVersion = versions.find(
+						(v) => v.versionType === "AI_DRAFT",
+					);
+					if (aiDraftVersion) {
+						// 문단 ID 부여 (iframe 렌더링용)
+						const cleanedAiDraft = removeLegacyGlossaryMarkup(
+							aiDraftVersion.content,
+						);
+						const processedAiDraft = extractParagraphs(
+							cleanedAiDraft,
+							"ai-draft",
+						);
+						setAiDraftHtml(processedAiDraft); // ⭐ 처리된 HTML을 iframe용으로 저장
+						setAiDraftContent(processedAiDraft);
+						console.log("✅ AI 초벌 번역 버전 로드 완료 (문단 ID 추가됨)");
+					} else {
+						console.warn("⚠️ AI_DRAFT 버전이 없습니다.");
+					}
 
-  // 내 번역 iframe 렌더링 (HTML 구조 보존) + 약한 연동
-  useEffect(() => {
-    if (isTranslationEditorInitialized) return; // 이미 초기화되었으면 스킵
-    
-    const iframe = myTranslationIframeRef.current;
-    if (!iframe || !savedTranslationHtml) return;
+					// MANUAL_TRANSLATION 버전 찾기 (사용자가 저장한 번역 - 우선 로드)
+					const manualTranslationVersion = versions
+						.filter((v) => v.versionType === "MANUAL_TRANSLATION")
+						.sort((a, b) => (b.versionNumber || 0) - (a.versionNumber || 0))[0]; // 최신 버전
 
-    console.log('📝 내 번역 iframe 렌더링 시작');
-    const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
+					if (manualTranslationVersion) {
+						console.log(
+							"✅ 저장된 번역 발견:",
+							manualTranslationVersion.versionNumber,
+							"버전",
+						);
+						// 저장된 번역 HTML에 문단 ID 추가
+						const processedManual = extractParagraphs(
+							manualTranslationVersion.content,
+							"manual",
+						);
+						setSavedTranslationHtml(processedManual);
+						setLastSavedHtml(processedManual); // 마지막 저장 상태 기록
+					} else if (aiDraftVersion) {
+						console.log("ℹ️ 저장된 번역이 없어 AI 초벌 번역 사용");
+						// MANUAL_TRANSLATION이 없으면 AI_DRAFT를 에디터에 설정 (문단 ID 추가)
+						const cleanedAiDraft = removeLegacyGlossaryMarkup(
+							aiDraftVersion.content,
+						);
+						const processedAiDraft = extractParagraphs(
+							cleanedAiDraft,
+							"ai-draft-editor",
+						);
+						setSavedTranslationHtml(processedAiDraft);
+						setLastSavedHtml(processedAiDraft); // 마지막 저장 상태 기록
+					} else if (originalVersion) {
+						console.log("ℹ️ AI 초벌 번역도 없어 원문 사용");
+						// AI_DRAFT도 없으면 ORIGINAL을 기본값으로 (문단 ID 추가)
+						const processedOriginal = extractParagraphs(
+							originalVersion.content,
+							"original-editor",
+						);
+						setSavedTranslationHtml(processedOriginal);
+						setLastSavedHtml(processedOriginal); // 마지막 저장 상태 기록
+					} else {
+						console.warn("⚠️ 사용 가능한 버전이 없습니다.");
+						setError("표시할 문서 내용이 없습니다.");
+						setLoading(false);
+						return;
+					}
 
-    if (iframeDoc) {
-      try {
-        iframeDoc.open();
-        iframeDoc.write(savedTranslationHtml);
-        iframeDoc.close();
-        
-        // ⭐ 기본 경계선 제거 CSS 주입 (텍스트 편집 모드용)
-        const baseStyle = iframeDoc.createElement('style');
-        baseStyle.id = 'base-styles';
-        baseStyle.textContent = `
+					// 문단 개수 계산
+					setTimeout(() => {
+						if (originalIframeRef.current?.contentDocument?.body) {
+							const paragraphs = getParagraphs(
+								originalIframeRef.current.contentDocument.body as HTMLElement,
+							);
+							setProgress((prev) => ({ ...prev, total: paragraphs.length }));
+						} else if (originalHtml) {
+							// iframe이 아직 로드되지 않았으면 HTML에서 직접 계산
+							const parser = new DOMParser();
+							const doc = parser.parseFromString(originalHtml, "text/html");
+							const paragraphs = getParagraphs(doc.body);
+							setProgress((prev) => ({ ...prev, total: paragraphs.length }));
+						}
+					}, 500);
+				} catch (versionError: any) {
+					console.error("버전 정보 조회 실패:", versionError);
+					setError(
+						"문서 버전 정보를 불러오는데 실패했습니다: " +
+							(versionError.message || "알 수 없는 오류"),
+					);
+					setLoading(false);
+					return;
+				}
+			} catch (err: any) {
+				console.error("데이터 로드 실패:", err);
+				console.error("에러 상세:", {
+					response: err.response,
+					data: err.response?.data,
+					status: err.response?.status,
+					message: err.message,
+				});
+
+				// 에러 메시지 추출 (다양한 응답 형식 지원)
+				let errorMessage = "데이터를 불러오는데 실패했습니다.";
+
+				// Spring 기본 에러 메시지 필터링
+				const isSpringDefaultError = (msg: string) => {
+					return (
+						msg === "No message available" ||
+						msg === "No message" ||
+						msg === "" ||
+						!msg ||
+						msg.trim() === ""
+					);
+				};
+
+				if (err.response?.data) {
+					if (typeof err.response.data === "string") {
+						if (!isSpringDefaultError(err.response.data)) {
+							errorMessage = err.response.data;
+						}
+					} else if (err.response.data.message) {
+						if (!isSpringDefaultError(err.response.data.message)) {
+							errorMessage = err.response.data.message;
+						}
+					} else if (err.response.data.error) {
+						if (!isSpringDefaultError(err.response.data.error)) {
+							errorMessage = err.response.data.error;
+						}
+					} else if (err.response.data.errorMessage) {
+						if (!isSpringDefaultError(err.response.data.errorMessage)) {
+							errorMessage = err.response.data.errorMessage;
+						}
+					}
+				} else if (err.message && !isSpringDefaultError(err.message)) {
+					errorMessage = err.message;
+				}
+
+				// HTTP 상태 코드 기반 메시지 추가
+				if (err.response?.status) {
+					const statusMessages: Record<number, string> = {
+						400: "잘못된 요청입니다.",
+						401: "인증이 필요합니다.",
+						403: "권한이 없습니다.",
+						404: err.config?.url?.includes("/lock")
+							? "문서 락 API를 찾을 수 없습니다. 백엔드가 실행 중인지 확인해주세요."
+							: err.config?.url?.includes("/documents/") &&
+									!err.config?.url?.includes("/lock")
+								? `문서 ID ${documentId}를 찾을 수 없습니다.`
+								: "요청한 리소스를 찾을 수 없습니다.",
+						409: "문서가 이미 다른 사용자에 의해 잠겨있습니다.",
+						500: "서버 오류가 발생했습니다.",
+					};
+
+					if (
+						statusMessages[err.response.status] &&
+						isSpringDefaultError(errorMessage)
+					) {
+						errorMessage = statusMessages[err.response.status];
+					} else if (err.response.status === 404) {
+						// 404 에러는 항상 명확한 메시지 제공
+						errorMessage = statusMessages[404];
+					}
+				}
+
+				setError(errorMessage);
+			} finally {
+				setLoading(false);
+			}
+		};
+
+		loadData();
+	}, [documentId]); // editor는 의존성에서 제거 (에디터가 없어도 데이터는 로드 가능)
+
+	/** 관리자(복사본 작업): 세션 시작·하트비트·종료 — 동일 원문 봉사자 편집 차단 */
+	useEffect(() => {
+		if (!documentId || !document?.sourceDocumentId) return;
+		if (!user || user.roleLevel > 2) return;
+
+		translationWorkApi.startAdminTranslationSession(documentId).catch(() => {});
+		const hb = setInterval(() => {
+			translationWorkApi
+				.heartbeatAdminTranslationSession(documentId)
+				.catch(() => {});
+		}, 60_000);
+		return () => {
+			clearInterval(hb);
+			translationWorkApi.endAdminTranslationSession(documentId).catch(() => {});
+		};
+	}, [documentId, document?.sourceDocumentId, user?.roleLevel]);
+
+	/** 봉사자: 관리자 세션 여부 갱신 */
+	useEffect(() => {
+		if (!documentId || !user || user.roleLevel <= 2) return;
+		const t = setInterval(() => {
+			documentApi
+				.getDocument(documentId)
+				.then(setDocument)
+				.catch(() => {});
+		}, 45_000);
+		return () => clearInterval(t);
+	}, [documentId, user?.roleLevel]);
+
+	// 내 번역 iframe 렌더링 (HTML 구조 보존) + 약한 연동
+	useEffect(() => {
+		if (isTranslationEditorInitialized) return; // 이미 초기화되었으면 스킵
+
+		const iframe = myTranslationIframeRef.current;
+		if (!iframe || !savedTranslationHtml) return;
+
+		console.log("📝 내 번역 iframe 렌더링 시작");
+		const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
+
+		if (iframeDoc) {
+			try {
+				iframeDoc.open();
+				iframeDoc.write(savedTranslationHtml);
+				iframeDoc.close();
+
+				// ⭐ 기본 경계선 제거 CSS 주입 (텍스트 편집 모드용)
+				const baseStyle = iframeDoc.createElement("style");
+				baseStyle.id = "base-styles";
+				baseStyle.textContent = `
           * {
             outline: none !important;
           }
         `;
-        iframeDoc.head.appendChild(baseStyle);
-        
-        // ⭐ 약한 연동: 내 번역 문단 클릭 시 원문/AI 초벌 번역 하이라이트 (조용히 실패)
-        const paragraphs = iframeDoc.querySelectorAll('[data-paragraph-index]');
-        paragraphs.forEach(para => {
-          para.addEventListener('click', () => {
-            try {
-              const index = parseInt((para as HTMLElement).getAttribute('data-paragraph-index') || '0', 10);
-              setHighlightedParagraphIndex(index);
-              console.log(`📍 내 번역 문단 ${index} 클릭 (약한 연동)`);
-            } catch (e) {
-              // 조용히 실패 (에러 표시 없음)
-              console.debug('내 번역 문단 연동 실패 (정상):', e);
-            }
-          });
-        });
-        
-        console.log(`✅ 내 번역 iframe 렌더링 완료 (문단 ${paragraphs.length}개)`);
-      } catch (error) {
-        console.warn('translation iframe write error (ignored):', error);
-      }
+				iframeDoc.head.appendChild(baseStyle);
 
-      // 에러 전파 방지
-      if (iframe.contentWindow) {
-        iframe.contentWindow.addEventListener('error', (e) => {
-          e.stopPropagation();
-          e.preventDefault();
-        }, true);
-      }
+				// ⭐ 약한 연동: 내 번역 문단 클릭 시 원문/AI 초벌 번역 하이라이트 (조용히 실패)
+				const paragraphs = iframeDoc.querySelectorAll("[data-paragraph-index]");
+				paragraphs.forEach((para) => {
+					para.addEventListener("click", () => {
+						try {
+							const index = Number.parseInt(
+								(para as HTMLElement).getAttribute("data-paragraph-index") ||
+									"0",
+								10,
+							);
+							setHighlightedParagraphIndex(index);
+							console.log(`📍 내 번역 문단 ${index} 클릭 (약한 연동)`);
+						} catch (e) {
+							// 조용히 실패 (에러 표시 없음)
+							console.debug("내 번역 문단 연동 실패 (정상):", e);
+						}
+					});
+				});
 
-      if (!isTranslationEditorInitialized) {
-        // 초기 HTML을 currentHtmlRef에 저장
-        currentEditorHtmlRef.current = savedTranslationHtml;
-        undoStackRef.current = [];
-        redoStackRef.current = [];
-        setIsTranslationEditorInitialized(true);
-      }
-    }
-  }); // ⭐ Step 5 방식: 의존성 배열 제거하여 savedTranslationHtml 변경 시 트리거되지 않도록 함 (한 번만 실행)
+				console.log(
+					`✅ 내 번역 iframe 렌더링 완료 (문단 ${paragraphs.length}개)`,
+				);
+			} catch (error) {
+				console.warn("translation iframe write error (ignored):", error);
+			}
 
+			// 에러 전파 방지
+			if (iframe.contentWindow) {
+				iframe.contentWindow.addEventListener(
+					"error",
+					(e) => {
+						e.stopPropagation();
+						e.preventDefault();
+					},
+					true,
+				);
+			}
 
-  // 편집 모드 처리 (텍스트/컴포넌트)
-  useEffect(() => {
-    if (!isTranslationEditorInitialized || !myTranslationIframeRef.current) return;
+			if (!isTranslationEditorInitialized) {
+				// 초기 HTML을 currentHtmlRef에 저장
+				currentEditorHtmlRef.current = savedTranslationHtml;
+				undoStackRef.current = [];
+				redoStackRef.current = [];
+				setIsTranslationEditorInitialized(true);
+			}
+		}
+	}); // ⭐ Step 5 방식: 의존성 배열 제거하여 savedTranslationHtml 변경 시 트리거되지 않도록 함 (한 번만 실행)
 
-    const iframe = myTranslationIframeRef.current;
-    const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-    if (!iframeDoc) return;
+	// 편집 모드 처리 (텍스트/컴포넌트)
+	useEffect(() => {
+		if (!isTranslationEditorInitialized || !myTranslationIframeRef.current)
+			return;
 
-    console.log('🎨 편집 모드:', editorMode);
+		const iframe = myTranslationIframeRef.current;
+		const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
+		if (!iframeDoc) return;
 
-    // 기존 스타일 제거
-    const existingStyle = iframeDoc.querySelector('#editor-styles');
-    if (existingStyle) existingStyle.remove();
+		console.log("🎨 편집 모드:", editorMode);
 
-    // 기존 이벤트 리스너 제거 (새로 추가할 예정)
-    const allElements = iframeDoc.querySelectorAll('*');
-    allElements.forEach(el => {
-      const clone = el.cloneNode(true);
-      el.parentNode?.replaceChild(clone, el);
-    });
+		// 기존 스타일 제거
+		const existingStyle = iframeDoc.querySelector("#editor-styles");
+		if (existingStyle) existingStyle.remove();
 
-    if (editorMode === 'text') {
-      // 텍스트 편집 모드
-      console.log('📝 [TranslationWork] 텍스트 편집 모드 활성화');
+		// 기존 이벤트 리스너 제거 (새로 추가할 예정)
+		const allElements = iframeDoc.querySelectorAll("*");
+		allElements.forEach((el) => {
+			const clone = el.cloneNode(true);
+			el.parentNode?.replaceChild(clone, el);
+		});
 
-      // ⭐ 컴포넌트 클릭 핸들러 제거
-      componentClickHandlersRef.current.forEach((handler, el) => {
-        el.removeEventListener('click', handler, true);
-      });
-      componentClickHandlersRef.current.clear();
+		if (editorMode === "text") {
+			// 텍스트 편집 모드
+			console.log("📝 [TranslationWork] 텍스트 편집 모드 활성화");
 
-      // ⭐ 모든 요소의 검은색 테두리 제거 (computed style 기반)
-      const allElements = iframeDoc.querySelectorAll('*');
-      allElements.forEach(el => {
-        const htmlEl = el as HTMLElement;
-        const computedStyle = iframeDoc.defaultView?.getComputedStyle(htmlEl);
-        if (computedStyle) {
-          const outline = computedStyle.outline;
-          const outlineColor = computedStyle.outlineColor;
-          if (outline && outline !== 'none' && (
-            outlineColor === 'rgb(0, 0, 0)' || 
-            outlineColor === '#000000' || 
-            outlineColor === 'black' ||
-            outline.includes('3px solid') ||
-            outline.includes('black')
-          )) {
-            htmlEl.style.outline = '';
-            htmlEl.style.outlineOffset = '';
-          }
-        }
-        if (htmlEl.style.outline && (
-          htmlEl.style.outline.includes('3px solid') ||
-          htmlEl.style.outline.includes('black') ||
-          htmlEl.style.outline.includes('#000')
-        )) {
-          htmlEl.style.outline = '';
-        }
-        htmlEl.classList.remove('component-selected');
-        htmlEl.removeAttribute('data-component-editable');
-      });
+			// ⭐ 컴포넌트 클릭 핸들러 제거
+			componentClickHandlersRef.current.forEach((handler, el) => {
+				el.removeEventListener("click", handler, true);
+			});
+			componentClickHandlersRef.current.clear();
 
-      // ⭐ 컴포넌트 선택 스타일 제거
-      const editorStyles = iframeDoc.getElementById('editor-styles');
-      if (editorStyles) {
-        editorStyles.remove();
-      }
+			// ⭐ 모든 요소의 검은색 테두리 제거 (computed style 기반)
+			const allElements = iframeDoc.querySelectorAll("*");
+			allElements.forEach((el) => {
+				const htmlEl = el as HTMLElement;
+				const computedStyle = iframeDoc.defaultView?.getComputedStyle(htmlEl);
+				if (computedStyle) {
+					const outline = computedStyle.outline;
+					const outlineColor = computedStyle.outlineColor;
+					if (
+						outline &&
+						outline !== "none" &&
+						(outlineColor === "rgb(0, 0, 0)" ||
+							outlineColor === "#000000" ||
+							outlineColor === "black" ||
+							outline.includes("3px solid") ||
+							outline.includes("black"))
+					) {
+						htmlEl.style.outline = "";
+						htmlEl.style.outlineOffset = "";
+					}
+				}
+				if (
+					htmlEl.style.outline &&
+					(htmlEl.style.outline.includes("3px solid") ||
+						htmlEl.style.outline.includes("black") ||
+						htmlEl.style.outline.includes("#000"))
+				) {
+					htmlEl.style.outline = "";
+				}
+				htmlEl.classList.remove("component-selected");
+				htmlEl.removeAttribute("data-component-editable");
+			});
 
-      // ⭐ 컴포넌트 선택 스타일을 완전히 무효화하는 CSS 추가
-      const textEditOverrideStyle = iframeDoc.createElement('style');
-      textEditOverrideStyle.id = 'text-edit-override-styles';
-      textEditOverrideStyle.textContent = `
+			// ⭐ 컴포넌트 선택 스타일 제거
+			const editorStyles = iframeDoc.getElementById("editor-styles");
+			if (editorStyles) {
+				editorStyles.remove();
+			}
+
+			// ⭐ 컴포넌트 선택 스타일을 완전히 무효화하는 CSS 추가
+			const textEditOverrideStyle = iframeDoc.createElement("style");
+			textEditOverrideStyle.id = "text-edit-override-styles";
+			textEditOverrideStyle.textContent = `
         .component-selected,
         [data-component-editable] {
           outline: none !important;
@@ -608,96 +745,105 @@ export default function TranslationWork() {
           outline: none !important;
         }
       `;
-      const existingOverride = iframeDoc.getElementById('text-edit-override-styles');
-      if (existingOverride) {
-        existingOverride.remove();
-      }
-      iframeDoc.head.appendChild(textEditOverrideStyle);
+			const existingOverride = iframeDoc.getElementById(
+				"text-edit-override-styles",
+			);
+			if (existingOverride) {
+				existingOverride.remove();
+			}
+			iframeDoc.head.appendChild(textEditOverrideStyle);
 
-      // ⭐ contentEditable 설정 (cross-element selection을 위해)
-      if (iframeDoc.body) {
-        iframeDoc.body.contentEditable = 'true';
-        iframeDoc.body.style.cursor = 'text';
-      }
+			// ⭐ contentEditable 설정 (cross-element selection을 위해)
+			if (iframeDoc.body) {
+				iframeDoc.body.contentEditable = "true";
+				iframeDoc.body.style.cursor = "text";
+			}
 
-      // 모든 텍스트 요소를 편집 가능하게
-      const editableElements = iframeDoc.querySelectorAll('p, h1, h2, h3, h4, h5, h6, span, div, li, td, th, label, a, button, article, section, header, footer, main, aside');
-      editableElements.forEach((el) => {
-        if (el.tagName && !['SCRIPT', 'STYLE', 'NOSCRIPT'].includes(el.tagName)) {
-        (el as HTMLElement).contentEditable = 'true';
-        (el as HTMLElement).style.cursor = 'text';
-        }
-      });
+			// 모든 텍스트 요소를 편집 가능하게
+			const editableElements = iframeDoc.querySelectorAll(
+				"p, h1, h2, h3, h4, h5, h6, span, div, li, td, th, label, a, button, article, section, header, footer, main, aside",
+			);
+			editableElements.forEach((el) => {
+				if (
+					el.tagName &&
+					!["SCRIPT", "STYLE", "NOSCRIPT"].includes(el.tagName)
+				) {
+					(el as HTMLElement).contentEditable = "true";
+					(el as HTMLElement).style.cursor = "text";
+				}
+			});
 
-      // 스크립트, 스타일 태그는 편집 불가능하게
-      const scripts = iframeDoc.querySelectorAll('script, style, noscript');
-      scripts.forEach((el) => {
-        (el as HTMLElement).contentEditable = 'false';
-      });
+			// 스크립트, 스타일 태그는 편집 불가능하게
+			const scripts = iframeDoc.querySelectorAll("script, style, noscript");
+			scripts.forEach((el) => {
+				(el as HTMLElement).contentEditable = "false";
+			});
 
-      // ⭐ user-select 스타일 추가 (cross-element selection)
-      const textEditStyle = iframeDoc.createElement('style');
-      textEditStyle.id = 'text-edit-styles';
-      textEditStyle.textContent = `
+			// ⭐ user-select 스타일 추가 (cross-element selection)
+			const textEditStyle = iframeDoc.createElement("style");
+			textEditStyle.id = "text-edit-styles";
+			textEditStyle.textContent = `
         body, * {
           user-select: text !important;
           -webkit-user-select: text !important;
           cursor: text !important;
         }
       `;
-      const existingTextStyle = iframeDoc.getElementById('text-edit-styles');
-      if (existingTextStyle) {
-        existingTextStyle.remove();
-      }
-      iframeDoc.head.appendChild(textEditStyle);
+			const existingTextStyle = iframeDoc.getElementById("text-edit-styles");
+			if (existingTextStyle) {
+				existingTextStyle.remove();
+			}
+			iframeDoc.head.appendChild(textEditStyle);
 
-      // ⭐ currentEditorHtmlRef 초기화 (텍스트 편집 모드)
-      const initialHtml = iframeDoc.documentElement.outerHTML;
-      currentEditorHtmlRef.current = initialHtml;
-      console.log('💾 TranslationWork 텍스트 편집 모드 currentEditorHtmlRef 초기화 완료');
+			// ⭐ currentEditorHtmlRef 초기화 (텍스트 편집 모드)
+			const initialHtml = iframeDoc.documentElement.outerHTML;
+			currentEditorHtmlRef.current = initialHtml;
+			console.log(
+				"💾 TranslationWork 텍스트 편집 모드 currentEditorHtmlRef 초기화 완료",
+			);
 
-      // ⭐ 링크 클릭 방지 (다른 사이트로 이동 방지)
-      // 기존 링크 클릭 핸들러 제거
-      linkClickHandlersRef.current.forEach((handler, link) => {
-        link.removeEventListener('click', handler, true);
-      });
-      linkClickHandlersRef.current.clear();
+			// ⭐ 링크 클릭 방지 (다른 사이트로 이동 방지)
+			// 기존 링크 클릭 핸들러 제거
+			linkClickHandlersRef.current.forEach((handler, link) => {
+				link.removeEventListener("click", handler, true);
+			});
+			linkClickHandlersRef.current.clear();
 
-      // 모든 링크에 클릭 핸들러 추가 (편집 모달 띄우기)
-      const allLinks = iframeDoc.querySelectorAll('a');
-      const handleLinkClick = (e: Event) => {
-        const mouseEvent = e as MouseEvent;
-        
-        // Ctrl/Cmd 키를 누른 상태면 기본 동작 허용 (새 탭에서 열기)
-        if (mouseEvent.ctrlKey || mouseEvent.metaKey) {
-          return true;
-        }
-        
-        e.preventDefault();
-        e.stopPropagation();
-        e.stopImmediatePropagation();
-        
-        const linkElement = e.currentTarget as HTMLAnchorElement;
-        setEditingLink(linkElement);
-        setLinkUrl(linkElement.href || '');
-        setShowLinkModal(true);
-        
-        return false;
-      };
+			// 모든 링크에 클릭 핸들러 추가 (편집 모달 띄우기)
+			const allLinks = iframeDoc.querySelectorAll("a");
+			const handleLinkClick = (e: Event) => {
+				const mouseEvent = e as MouseEvent;
 
-      allLinks.forEach(link => {
-        const htmlLink = link as HTMLElement;
-        htmlLink.addEventListener('click', handleLinkClick, true);
-        linkClickHandlersRef.current.set(htmlLink, handleLinkClick);
-        // 링크 스타일 변경 (편집 모드임을 표시)
-        htmlLink.style.cursor = 'pointer';
-        htmlLink.style.textDecoration = 'underline';
-      });
+				// Ctrl/Cmd 키를 누른 상태면 기본 동작 허용 (새 탭에서 열기)
+				if (mouseEvent.ctrlKey || mouseEvent.metaKey) {
+					return true;
+				}
 
-      // 링크 스타일 CSS 추가
-      const linkStyle = iframeDoc.createElement('style');
-      linkStyle.id = 'text-edit-link-style';
-      linkStyle.textContent = `
+				e.preventDefault();
+				e.stopPropagation();
+				e.stopImmediatePropagation();
+
+				const linkElement = e.currentTarget as HTMLAnchorElement;
+				setEditingLink(linkElement);
+				setLinkUrl(linkElement.href || "");
+				setShowLinkModal(true);
+
+				return false;
+			};
+
+			allLinks.forEach((link) => {
+				const htmlLink = link as HTMLElement;
+				htmlLink.addEventListener("click", handleLinkClick, true);
+				linkClickHandlersRef.current.set(htmlLink, handleLinkClick);
+				// 링크 스타일 변경 (편집 모드임을 표시)
+				htmlLink.style.cursor = "pointer";
+				htmlLink.style.textDecoration = "underline";
+			});
+
+			// 링크 스타일 CSS 추가
+			const linkStyle = iframeDoc.createElement("style");
+			linkStyle.id = "text-edit-link-style";
+			linkStyle.textContent = `
         a {
           cursor: text !important;
           pointer-events: auto !important;
@@ -706,137 +852,152 @@ export default function TranslationWork() {
           text-decoration: underline !important;
         }
       `;
-      const existingLinkStyle = iframeDoc.getElementById('text-edit-link-style');
-      if (existingLinkStyle) {
-        existingLinkStyle.remove();
-      }
-      iframeDoc.head.appendChild(linkStyle);
+			const existingLinkStyle = iframeDoc.getElementById(
+				"text-edit-link-style",
+			);
+			if (existingLinkStyle) {
+				existingLinkStyle.remove();
+			}
+			iframeDoc.head.appendChild(linkStyle);
 
-      // ⭐ Step 5와 동일한 방식으로 키보드 이벤트 처리
-      const handleKeyDown = (e: KeyboardEvent) => {
-        // Cmd+Z (Mac) 또는 Ctrl+Z (Windows) - Undo
-        if ((e.ctrlKey || e.metaKey) && e.key === 'z' && !e.shiftKey) {
-          e.preventDefault();
-          e.stopImmediatePropagation();
-          iframeDoc.execCommand('undo', false);
-          const updatedHtml = iframeDoc.documentElement.outerHTML;
-          currentEditorHtmlRef.current = updatedHtml;
-          // ⭐ setSavedTranslationHtml 제거 - Step 5와 동일하게 useEffect 재트리거 방지
-          console.log('↩️ Undo (TranslationWork 텍스트 편집)');
-        }
-        // Cmd+Shift+Z (Mac) 또는 Ctrl+Y (Windows) - Redo
-        else if ((e.ctrlKey || e.metaKey) && (e.key === 'y' || (e.key === 'z' && e.shiftKey))) {
-          e.preventDefault();
-          e.stopImmediatePropagation();
-          iframeDoc.execCommand('redo', false);
-          const updatedHtml = iframeDoc.documentElement.outerHTML;
-          currentEditorHtmlRef.current = updatedHtml;
-          // ⭐ setSavedTranslationHtml 제거 - Step 5와 동일하게 useEffect 재트리거 방지
-          console.log('↪️ Redo (TranslationWork 텍스트 편집)');
-        }
+			// ⭐ Step 5와 동일한 방식으로 키보드 이벤트 처리
+			const handleKeyDown = (e: KeyboardEvent) => {
+				// Cmd+Z (Mac) 또는 Ctrl+Z (Windows) - Undo
+				if ((e.ctrlKey || e.metaKey) && e.key === "z" && !e.shiftKey) {
+					e.preventDefault();
+					e.stopImmediatePropagation();
+					iframeDoc.execCommand("undo", false);
+					const updatedHtml = iframeDoc.documentElement.outerHTML;
+					currentEditorHtmlRef.current = updatedHtml;
+					// ⭐ setSavedTranslationHtml 제거 - Step 5와 동일하게 useEffect 재트리거 방지
+					console.log("↩️ Undo (TranslationWork 텍스트 편집)");
+				}
+				// Cmd+Shift+Z (Mac) 또는 Ctrl+Y (Windows) - Redo
+				else if (
+					(e.ctrlKey || e.metaKey) &&
+					(e.key === "y" || (e.key === "z" && e.shiftKey))
+				) {
+					e.preventDefault();
+					e.stopImmediatePropagation();
+					iframeDoc.execCommand("redo", false);
+					const updatedHtml = iframeDoc.documentElement.outerHTML;
+					currentEditorHtmlRef.current = updatedHtml;
+					// ⭐ setSavedTranslationHtml 제거 - Step 5와 동일하게 useEffect 재트리거 방지
+					console.log("↪️ Redo (TranslationWork 텍스트 편집)");
+				}
 
-        // ⭐ 백스페이스 키 처리 (브라우저 기본 동작 허용)
-        if (e.key === 'Backspace' && !e.ctrlKey && !e.metaKey && !e.altKey) {
-          // 브라우저가 알아서 처리하게 놔둠
-          console.log('⌫ 백스페이스 (TranslationWork 텍스트 편집)');
-        }
-      };
+				// ⭐ 백스페이스 키 처리 (브라우저 기본 동작 허용)
+				if (e.key === "Backspace" && !e.ctrlKey && !e.metaKey && !e.altKey) {
+					// 브라우저가 알아서 처리하게 놔둠
+					console.log("⌫ 백스페이스 (TranslationWork 텍스트 편집)");
+				}
+			};
 
-      // 기존 iframe 리스너 제거
-      if (iframeKeydownHandlerRef.current && iframeDoc) {
-        iframeDoc.removeEventListener('keydown', iframeKeydownHandlerRef.current, true);
-      }
-      // 새 iframe 리스너 등록 및 저장
-      iframeKeydownHandlerRef.current = handleKeyDown;
-      iframeDoc.addEventListener('keydown', handleKeyDown, true);
-      console.log('✅ TranslationWork 텍스트 모드 키보드 단축키 등록 완료 (iframe)');
+			// 기존 iframe 리스너 제거
+			if (iframeKeydownHandlerRef.current && iframeDoc) {
+				iframeDoc.removeEventListener(
+					"keydown",
+					iframeKeydownHandlerRef.current,
+					true,
+				);
+			}
+			// 새 iframe 리스너 등록 및 저장
+			iframeKeydownHandlerRef.current = handleKeyDown;
+			iframeDoc.addEventListener("keydown", handleKeyDown, true);
+			console.log(
+				"✅ TranslationWork 텍스트 모드 키보드 단축키 등록 완료 (iframe)",
+			);
 
-      // ⚡ 최적화: input 이벤트 디바운스 (메모리 사용 감소)
-      let inputTimeoutId: ReturnType<typeof setTimeout> | null = null;
-      const handleInput = () => {
-        // 기존 타이머 취소
-        if (inputTimeoutId) {
-          clearTimeout(inputTimeoutId);
-        }
-        
-        // 500ms 후에 HTML 추출 (디바운스)
-        inputTimeoutId = setTimeout(() => {
-          const updatedHtml = iframeDoc.documentElement.outerHTML;
-          setSavedTranslationHtml(updatedHtml);
-          inputTimeoutId = null;
-        }, 500);
-      };
-      iframeDoc.body.addEventListener('input', handleInput);
+			// ⚡ 최적화: input 이벤트 디바운스 (메모리 사용 감소)
+			let inputTimeoutId: ReturnType<typeof setTimeout> | null = null;
+			const handleInput = () => {
+				// 기존 타이머 취소
+				if (inputTimeoutId) {
+					clearTimeout(inputTimeoutId);
+				}
 
-    } else if (editorMode === 'component') {
-      // 컴포넌트 편집 모드
-      console.log('🧩 [TranslationWork] 컴포넌트 편집 모드 활성화');
+				// 500ms 후에 HTML 추출 (디바운스)
+				inputTimeoutId = setTimeout(() => {
+					const updatedHtml = iframeDoc.documentElement.outerHTML;
+					setSavedTranslationHtml(updatedHtml);
+					inputTimeoutId = null;
+				}, 500);
+			};
+			iframeDoc.body.addEventListener("input", handleInput);
+		} else if (editorMode === "component") {
+			// 컴포넌트 편집 모드
+			console.log("🧩 [TranslationWork] 컴포넌트 편집 모드 활성화");
 
-      // ⭐ 1. 브라우저 텍스트 선택 초기화
-      const selection = iframeDoc.defaultView?.getSelection();
-      if (selection) {
-        selection.removeAllRanges();
-      }
+			// ⭐ 1. 브라우저 텍스트 선택 초기화
+			const selection = iframeDoc.defaultView?.getSelection();
+			if (selection) {
+				selection.removeAllRanges();
+			}
 
-      // ⭐ 2. selectedElements state 초기화
-      setSelectedElements([]);
+			// ⭐ 2. selectedElements state 초기화
+			setSelectedElements([]);
 
-      // ⭐ 3. 모든 .component-selected 클래스 제거 및 기존 핸들러 제거
-      const existingSelected = iframeDoc.querySelectorAll('.component-selected');
-      existingSelected.forEach(el => {
-        const htmlEl = el as HTMLElement;
-        htmlEl.classList.remove('component-selected');
-        htmlEl.style.outline = '';
-        htmlEl.style.boxShadow = '';
-        htmlEl.style.backgroundColor = '';
-        htmlEl.style.outlineOffset = '';
+			// ⭐ 3. 모든 .component-selected 클래스 제거 및 기존 핸들러 제거
+			const existingSelected = iframeDoc.querySelectorAll(
+				".component-selected",
+			);
+			existingSelected.forEach((el) => {
+				const htmlEl = el as HTMLElement;
+				htmlEl.classList.remove("component-selected");
+				htmlEl.style.outline = "";
+				htmlEl.style.boxShadow = "";
+				htmlEl.style.backgroundColor = "";
+				htmlEl.style.outlineOffset = "";
 
-        // 기존 핸들러 제거
-        const handler = componentClickHandlersRef.current.get(htmlEl);
-        if (handler) {
-          htmlEl.removeEventListener('click', handler, true);
-          componentClickHandlersRef.current.delete(htmlEl);
-        }
-      });
+				// 기존 핸들러 제거
+				const handler = componentClickHandlersRef.current.get(htmlEl);
+				if (handler) {
+					htmlEl.removeEventListener("click", handler, true);
+					componentClickHandlersRef.current.delete(htmlEl);
+				}
+			});
 
-      // 모든 컴포넌트 클릭 핸들러 제거
-      componentClickHandlersRef.current.forEach((handler, el) => {
-        el.removeEventListener('click', handler, true);
-      });
-      componentClickHandlersRef.current.clear();
+			// 모든 컴포넌트 클릭 핸들러 제거
+			componentClickHandlersRef.current.forEach((handler, el) => {
+				el.removeEventListener("click", handler, true);
+			});
+			componentClickHandlersRef.current.clear();
 
-      // ⭐ 4. 텍스트 편집 모드 스타일 태그 제거
-      const textEditOverrideStyle = iframeDoc.getElementById('text-edit-override-styles');
-      if (textEditOverrideStyle) {
-        textEditOverrideStyle.remove();
-      }
-      const textEditStyle = iframeDoc.getElementById('text-edit-styles');
-      if (textEditStyle) {
-        textEditStyle.remove();
-      }
+			// ⭐ 4. 텍스트 편집 모드 스타일 태그 제거
+			const textEditOverrideStyle = iframeDoc.getElementById(
+				"text-edit-override-styles",
+			);
+			if (textEditOverrideStyle) {
+				textEditOverrideStyle.remove();
+			}
+			const textEditStyle = iframeDoc.getElementById("text-edit-styles");
+			if (textEditStyle) {
+				textEditStyle.remove();
+			}
 
-      // ⭐ 5. 링크 클릭 핸들러 제거
-      linkClickHandlersRef.current.forEach((handler, link) => {
-        link.removeEventListener('click', handler, true);
-      });
-      linkClickHandlersRef.current.clear();
+			// ⭐ 5. 링크 클릭 핸들러 제거
+			linkClickHandlersRef.current.forEach((handler, link) => {
+				link.removeEventListener("click", handler, true);
+			});
+			linkClickHandlersRef.current.clear();
 
-      // 링크 스타일 태그 제거
-      const linkStyle = iframeDoc.getElementById('text-edit-link-style');
-      if (linkStyle) {
-        linkStyle.remove();
-      }
+			// 링크 스타일 태그 제거
+			const linkStyle = iframeDoc.getElementById("text-edit-link-style");
+			if (linkStyle) {
+				linkStyle.remove();
+			}
 
-      // contentEditable 비활성화
-      const allEditableElements = iframeDoc.querySelectorAll('[contenteditable]');
-      allEditableElements.forEach(el => {
-        (el as HTMLElement).contentEditable = 'false';
-      });
+			// contentEditable 비활성화
+			const allEditableElements =
+				iframeDoc.querySelectorAll("[contenteditable]");
+			allEditableElements.forEach((el) => {
+				(el as HTMLElement).contentEditable = "false";
+			});
 
-      // 스타일 추가
-      const style = iframeDoc.createElement('style');
-      style.id = 'editor-styles';
-      style.textContent = `
+			// 스타일 추가
+			const style = iframeDoc.createElement("style");
+			style.id = "editor-styles";
+			style.textContent = `
         div[data-component-editable],
         section[data-component-editable],
         article[data-component-editable],
@@ -894,312 +1055,386 @@ export default function TranslationWork() {
           to { opacity: 1; transform: translateY(0); }
         }
       `;
-      iframeDoc.head.appendChild(style);
+			iframeDoc.head.appendChild(style);
 
-      // 클릭 가능한 컴포넌트 표시 (a 태그도 포함)
-      const componentElements = iframeDoc.querySelectorAll('div, section, article, header, footer, main, aside, nav, p, h1, h2, h3, h4, h5, h6, a');
+			// 클릭 가능한 컴포넌트 표시 (a 태그도 포함)
+			const componentElements = iframeDoc.querySelectorAll(
+				"div, section, article, header, footer, main, aside, nav, p, h1, h2, h3, h4, h5, h6, a",
+			);
 
-      // Cmd+Z / Cmd+Y 지원 (컴포넌트 편집 모드) - 커스텀 Undo Stack 사용
-      const handleKeydown = (e: KeyboardEvent) => {
-        console.log('🔑 TranslationWork iframe 키 감지:', e.key, 'ctrl:', e.ctrlKey, 'meta:', e.metaKey, 'shift:', e.shiftKey);
-        // Cmd+Z (Mac) 또는 Ctrl+Z (Windows) - Undo
-        if ((e.ctrlKey || e.metaKey) && e.key === 'z' && !e.shiftKey) {
-          e.preventDefault(); // ⭐ 항상 preventDefault 호출 (undo stack이 비어있어도 시스템 단축키 방지)
-          e.stopImmediatePropagation();
+			// Cmd+Z / Cmd+Y 지원 (컴포넌트 편집 모드) - 커스텀 Undo Stack 사용
+			const handleKeydown = (e: KeyboardEvent) => {
+				console.log(
+					"🔑 TranslationWork iframe 키 감지:",
+					e.key,
+					"ctrl:",
+					e.ctrlKey,
+					"meta:",
+					e.metaKey,
+					"shift:",
+					e.shiftKey,
+				);
+				// Cmd+Z (Mac) 또는 Ctrl+Z (Windows) - Undo
+				if ((e.ctrlKey || e.metaKey) && e.key === "z" && !e.shiftKey) {
+					e.preventDefault(); // ⭐ 항상 preventDefault 호출 (undo stack이 비어있어도 시스템 단축키 방지)
+					e.stopImmediatePropagation();
 
-          if (undoStackRef.current.length > 0) {
-            console.log('↩️ Undo (컴포넌트 편집) - stack:', undoStackRef.current.length);
+					if (undoStackRef.current.length > 0) {
+						console.log(
+							"↩️ Undo (컴포넌트 편집) - stack:",
+							undoStackRef.current.length,
+						);
 
-            // 현재 상태를 redo stack에 저장
-            redoStackRef.current.push(currentEditorHtmlRef.current);
+						// 현재 상태를 redo stack에 저장
+						redoStackRef.current.push(currentEditorHtmlRef.current);
 
-            // undo stack에서 이전 상태 복원
-            const previousHtml = undoStackRef.current.pop()!;
-            currentEditorHtmlRef.current = previousHtml;
+						// undo stack에서 이전 상태 복원
+						const previousHtml = undoStackRef.current.pop()!;
+						currentEditorHtmlRef.current = previousHtml;
 
-            // iframe에 HTML 복원
-            iframeDoc.open();
-            iframeDoc.write(previousHtml);
-            iframeDoc.close();
+						// iframe에 HTML 복원
+						iframeDoc.open();
+						iframeDoc.write(previousHtml);
+						iframeDoc.close();
 
-            setSavedTranslationHtml(previousHtml);
-            setSelectedElements([]);
+						setSavedTranslationHtml(previousHtml);
+						setSelectedElements([]);
 
-            // ⭐ savedTranslationHtml 의존성 배열에 추가되어 useEffect가 자동으로 재실행됨
-            // iframe에 포커스를 주어 키보드 이벤트가 계속 작동하도록 함
-            setTimeout(() => {
-              const newIframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-              if (newIframeDoc?.body) {
-                newIframeDoc.body.setAttribute('tabindex', '-1');
-                newIframeDoc.body.focus();
-              }
-            }, 50);
-        } else {
-            console.log('⚠️ Undo stack이 비어있습니다 (TranslationWork)');
-            // ⭐ undo stack이 비어있어도 preventDefault는 이미 호출됨 (시스템 단축키 방지)
-          }
-        }
-        // Cmd+Shift+Z (Mac) 또는 Ctrl+Y (Windows) - Redo
-        else if ((e.ctrlKey || e.metaKey) && (e.key === 'y' || (e.key === 'z' && e.shiftKey))) {
-          e.preventDefault(); // ⭐ 항상 preventDefault 호출 (redo stack이 비어있어도 시스템 단축키 방지)
-          e.stopImmediatePropagation();
+						// ⭐ savedTranslationHtml 의존성 배열에 추가되어 useEffect가 자동으로 재실행됨
+						// iframe에 포커스를 주어 키보드 이벤트가 계속 작동하도록 함
+						setTimeout(() => {
+							const newIframeDoc =
+								iframe.contentDocument || iframe.contentWindow?.document;
+							if (newIframeDoc?.body) {
+								newIframeDoc.body.setAttribute("tabindex", "-1");
+								newIframeDoc.body.focus();
+							}
+						}, 50);
+					} else {
+						console.log("⚠️ Undo stack이 비어있습니다 (TranslationWork)");
+						// ⭐ undo stack이 비어있어도 preventDefault는 이미 호출됨 (시스템 단축키 방지)
+					}
+				}
+				// Cmd+Shift+Z (Mac) 또는 Ctrl+Y (Windows) - Redo
+				else if (
+					(e.ctrlKey || e.metaKey) &&
+					(e.key === "y" || (e.key === "z" && e.shiftKey))
+				) {
+					e.preventDefault(); // ⭐ 항상 preventDefault 호출 (redo stack이 비어있어도 시스템 단축키 방지)
+					e.stopImmediatePropagation();
 
-          if (redoStackRef.current.length > 0) {
-            console.log('↪️ Redo (컴포넌트 편집 TranslationWork) - stack:', redoStackRef.current.length);
+					if (redoStackRef.current.length > 0) {
+						console.log(
+							"↪️ Redo (컴포넌트 편집 TranslationWork) - stack:",
+							redoStackRef.current.length,
+						);
 
-            // 현재 상태를 undo stack에 저장
-            undoStackRef.current.push(currentEditorHtmlRef.current);
+						// 현재 상태를 undo stack에 저장
+						undoStackRef.current.push(currentEditorHtmlRef.current);
 
-            // redo stack에서 다음 상태 복원
-            const nextHtml = redoStackRef.current.pop()!;
-            currentEditorHtmlRef.current = nextHtml;
+						// redo stack에서 다음 상태 복원
+						const nextHtml = redoStackRef.current.pop()!;
+						currentEditorHtmlRef.current = nextHtml;
 
-            // iframe에 HTML 복원
-            iframeDoc.open();
-            iframeDoc.write(nextHtml);
-            iframeDoc.close();
+						// iframe에 HTML 복원
+						iframeDoc.open();
+						iframeDoc.write(nextHtml);
+						iframeDoc.close();
 
-            setSavedTranslationHtml(nextHtml);
-            setSelectedElements([]);
+						setSavedTranslationHtml(nextHtml);
+						setSelectedElements([]);
 
-            // ⭐ savedTranslationHtml 의존성 배열에 추가되어 useEffect가 자동으로 재실행됨
-            // iframe에 포커스를 주어 키보드 이벤트가 계속 작동하도록 함
-            setTimeout(() => {
-              const newIframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-              if (newIframeDoc?.body) {
-                newIframeDoc.body.setAttribute('tabindex', '-1');
-                newIframeDoc.body.focus();
-              }
-            }, 50);
-          } else {
-            console.log('⚠️ Redo stack이 비어있습니다');
-            // ⭐ redo stack이 비어있어도 preventDefault는 이미 호출됨 (시스템 단축키 방지)
-          }
-        }
-      };
+						// ⭐ savedTranslationHtml 의존성 배열에 추가되어 useEffect가 자동으로 재실행됨
+						// iframe에 포커스를 주어 키보드 이벤트가 계속 작동하도록 함
+						setTimeout(() => {
+							const newIframeDoc =
+								iframe.contentDocument || iframe.contentWindow?.document;
+							if (newIframeDoc?.body) {
+								newIframeDoc.body.setAttribute("tabindex", "-1");
+								newIframeDoc.body.focus();
+							}
+						}, 50);
+					} else {
+						console.log("⚠️ Redo stack이 비어있습니다");
+						// ⭐ redo stack이 비어있어도 preventDefault는 이미 호출됨 (시스템 단축키 방지)
+					}
+				}
+			};
 
-      // 기존 iframe 리스너 제거
-      if (iframeKeydownHandlerRef.current && iframeDoc) {
-        iframeDoc.removeEventListener('keydown', iframeKeydownHandlerRef.current, true);
-      }
-      // 새 iframe 리스너 등록 및 저장
-      iframeKeydownHandlerRef.current = handleKeydown;
-      iframeDoc.addEventListener('keydown', handleKeydown, true);
-      console.log('✅ TranslationWork 컴포넌트 모드 키보드 단축키 등록 완료 (iframe)');
+			// 기존 iframe 리스너 제거
+			if (iframeKeydownHandlerRef.current && iframeDoc) {
+				iframeDoc.removeEventListener(
+					"keydown",
+					iframeKeydownHandlerRef.current,
+					true,
+				);
+			}
+			// 새 iframe 리스너 등록 및 저장
+			iframeKeydownHandlerRef.current = handleKeydown;
+			iframeDoc.addEventListener("keydown", handleKeydown, true);
+			console.log(
+				"✅ TranslationWork 컴포넌트 모드 키보드 단축키 등록 완료 (iframe)",
+			);
 
-      // 부모 window에서도 이벤트 잡기 (iframe 포커스가 없을 때 대비)
-      const handleWindowKeydown = (e: KeyboardEvent) => {
-        console.log('🔑 TranslationWork window 키 감지:', e.key, 'ctrl:', e.ctrlKey, 'meta:', e.metaKey, 'shift:', e.shiftKey);
+			// 부모 window에서도 이벤트 잡기 (iframe 포커스가 없을 때 대비)
+			const handleWindowKeydown = (e: KeyboardEvent) => {
+				console.log(
+					"🔑 TranslationWork window 키 감지:",
+					e.key,
+					"ctrl:",
+					e.ctrlKey,
+					"meta:",
+					e.metaKey,
+					"shift:",
+					e.shiftKey,
+				);
 
-        // Ctrl+Z (되돌리기)
-        if ((e.ctrlKey || e.metaKey) && e.key === 'z' && !e.shiftKey) {
-          e.preventDefault();
-          e.stopImmediatePropagation();
+				// Ctrl+Z (되돌리기)
+				if ((e.ctrlKey || e.metaKey) && e.key === "z" && !e.shiftKey) {
+					e.preventDefault();
+					e.stopImmediatePropagation();
 
-          if (undoStackRef.current.length > 0 && iframeDoc) {
-            console.log('↩️ Undo (TranslationWork 컴포넌트 편집 - window)');
+					if (undoStackRef.current.length > 0 && iframeDoc) {
+						console.log("↩️ Undo (TranslationWork 컴포넌트 편집 - window)");
 
-            redoStackRef.current.push(currentEditorHtmlRef.current);
-            const previousHtml = undoStackRef.current.pop()!;
-            currentEditorHtmlRef.current = previousHtml;
+						redoStackRef.current.push(currentEditorHtmlRef.current);
+						const previousHtml = undoStackRef.current.pop()!;
+						currentEditorHtmlRef.current = previousHtml;
 
-            iframeDoc.open();
-            iframeDoc.write(previousHtml);
-            iframeDoc.close();
+						iframeDoc.open();
+						iframeDoc.write(previousHtml);
+						iframeDoc.close();
 
-            setSavedTranslationHtml(previousHtml);
-            setSelectedElements([]);
+						setSavedTranslationHtml(previousHtml);
+						setSelectedElements([]);
 
-            // ⭐ savedTranslationHtml 의존성 배열에 추가되어 useEffect가 자동으로 재실행됨
-            // iframe에 포커스를 주어 키보드 이벤트가 계속 작동하도록 함
-            setTimeout(() => {
-              const newIframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-              if (newIframeDoc?.body) {
-                newIframeDoc.body.setAttribute('tabindex', '-1');
-                newIframeDoc.body.focus();
-              }
-            }, 50);
-          }
-        }
-        // Ctrl+Shift+Z 또는 Ctrl+Y (다시 실행)
-        else if ((e.ctrlKey || e.metaKey) && (e.key === 'y' || (e.key === 'z' && e.shiftKey))) {
-          e.preventDefault();
-          e.stopImmediatePropagation();
+						// ⭐ savedTranslationHtml 의존성 배열에 추가되어 useEffect가 자동으로 재실행됨
+						// iframe에 포커스를 주어 키보드 이벤트가 계속 작동하도록 함
+						setTimeout(() => {
+							const newIframeDoc =
+								iframe.contentDocument || iframe.contentWindow?.document;
+							if (newIframeDoc?.body) {
+								newIframeDoc.body.setAttribute("tabindex", "-1");
+								newIframeDoc.body.focus();
+							}
+						}, 50);
+					}
+				}
+				// Ctrl+Shift+Z 또는 Ctrl+Y (다시 실행)
+				else if (
+					(e.ctrlKey || e.metaKey) &&
+					(e.key === "y" || (e.key === "z" && e.shiftKey))
+				) {
+					e.preventDefault();
+					e.stopImmediatePropagation();
 
-          if (redoStackRef.current.length > 0 && iframeDoc) {
-            console.log('↪️ Redo (TranslationWork 컴포넌트 편집 - window)');
+					if (redoStackRef.current.length > 0 && iframeDoc) {
+						console.log("↪️ Redo (TranslationWork 컴포넌트 편집 - window)");
 
-            undoStackRef.current.push(currentEditorHtmlRef.current);
-            const nextHtml = redoStackRef.current.pop()!;
-            currentEditorHtmlRef.current = nextHtml;
+						undoStackRef.current.push(currentEditorHtmlRef.current);
+						const nextHtml = redoStackRef.current.pop()!;
+						currentEditorHtmlRef.current = nextHtml;
 
-            iframeDoc.open();
-            iframeDoc.write(nextHtml);
-            iframeDoc.close();
+						iframeDoc.open();
+						iframeDoc.write(nextHtml);
+						iframeDoc.close();
 
-            setSavedTranslationHtml(nextHtml);
-            setSelectedElements([]);
+						setSavedTranslationHtml(nextHtml);
+						setSelectedElements([]);
 
-            // ⭐ savedTranslationHtml 의존성 배열에 추가되어 useEffect가 자동으로 재실행됨
-            // iframe에 포커스를 주어 키보드 이벤트가 계속 작동하도록 함
-            setTimeout(() => {
-              const newIframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-              if (newIframeDoc?.body) {
-                newIframeDoc.body.setAttribute('tabindex', '-1');
-                newIframeDoc.body.focus();
-              }
-            }, 50);
-          }
-        }
-      };
+						// ⭐ savedTranslationHtml 의존성 배열에 추가되어 useEffect가 자동으로 재실행됨
+						// iframe에 포커스를 주어 키보드 이벤트가 계속 작동하도록 함
+						setTimeout(() => {
+							const newIframeDoc =
+								iframe.contentDocument || iframe.contentWindow?.document;
+							if (newIframeDoc?.body) {
+								newIframeDoc.body.setAttribute("tabindex", "-1");
+								newIframeDoc.body.focus();
+							}
+						}, 50);
+					}
+				}
+			};
 
-      // 기존 window 리스너 제거
-      if (windowKeydownHandlerRef.current) {
-        window.removeEventListener('keydown', windowKeydownHandlerRef.current, true);
-      }
-      // 새 window 리스너 등록 및 저장
-      windowKeydownHandlerRef.current = handleWindowKeydown;
-      window.addEventListener('keydown', handleWindowKeydown, true);
-      console.log('✅ TranslationWork window 키보드 이벤트 리스너 등록 완료');
+			// 기존 window 리스너 제거
+			if (windowKeydownHandlerRef.current) {
+				window.removeEventListener(
+					"keydown",
+					windowKeydownHandlerRef.current,
+					true,
+				);
+			}
+			// 새 window 리스너 등록 및 저장
+			windowKeydownHandlerRef.current = handleWindowKeydown;
+			window.addEventListener("keydown", handleWindowKeydown, true);
+			console.log("✅ TranslationWork window 키보드 이벤트 리스너 등록 완료");
 
-      // 컴포넌트 클릭 핸들러 (다중 선택 + 토글)
-      const handleComponentClick = (e: Event) => {
-        e.stopPropagation();
-          e.preventDefault();
+			// 컴포넌트 클릭 핸들러 (다중 선택 + 토글)
+			const handleComponentClick = (e: Event) => {
+				e.stopPropagation();
+				e.preventDefault();
 
-        const target = e.target as HTMLElement;
-        if (!target || ['SCRIPT', 'STYLE', 'NOSCRIPT', 'HTML', 'HEAD', 'BODY'].includes(target.tagName)) return;
+				const target = e.target as HTMLElement;
+				if (
+					!target ||
+					["SCRIPT", "STYLE", "NOSCRIPT", "HTML", "HEAD", "BODY"].includes(
+						target.tagName,
+					)
+				)
+					return;
 
-        // ⭐ 링크 내부 요소를 클릭한 경우 가장 가까운 편집 가능한 요소 찾기
-        const editableElement = target.closest('[data-component-editable]') as HTMLElement;
-        if (!editableElement) {
-          console.log('⚠️ 편집 가능한 요소를 찾을 수 없습니다:', target.tagName);
-          return;
-        }
+				// ⭐ 링크 내부 요소를 클릭한 경우 가장 가까운 편집 가능한 요소 찾기
+				const editableElement = target.closest(
+					"[data-component-editable]",
+				) as HTMLElement;
+				if (!editableElement) {
+					console.log("⚠️ 편집 가능한 요소를 찾을 수 없습니다:", target.tagName);
+					return;
+				}
 
-        const isSelected = editableElement.classList.contains('component-selected');
+				const isSelected =
+					editableElement.classList.contains("component-selected");
 
-        if (isSelected) {
-          editableElement.classList.remove('component-selected');
-          editableElement.style.outline = '1px dashed #C0C0C0';
-          editableElement.style.boxShadow = 'none';
-          setSelectedElements(prev => prev.filter(el => el !== editableElement));
-        } else {
-          editableElement.classList.add('component-selected');
-          editableElement.style.outline = '3px solid #000000';
-          editableElement.style.boxShadow = 'none';
-          setSelectedElements(prev => [...prev, editableElement]);
-        }
-      };
+				if (isSelected) {
+					editableElement.classList.remove("component-selected");
+					editableElement.style.outline = "1px dashed #C0C0C0";
+					editableElement.style.boxShadow = "none";
+					setSelectedElements((prev) =>
+						prev.filter((el) => el !== editableElement),
+					);
+				} else {
+					editableElement.classList.add("component-selected");
+					editableElement.style.outline = "3px solid #000000";
+					editableElement.style.boxShadow = "none";
+					setSelectedElements((prev) => [...prev, editableElement]);
+				}
+			};
 
-      // ⭐ Step 5와 동일한 방식으로 이벤트 리스너 등록 (capture phase)
-      componentElements.forEach((el) => {
-        if (el.tagName && !['SCRIPT', 'STYLE', 'NOSCRIPT', 'HTML', 'HEAD', 'BODY'].includes(el.tagName)) {
-          const htmlEl = el as HTMLElement;
-          htmlEl.setAttribute('data-component-editable', 'true');
-          htmlEl.style.cursor = 'pointer';
-          htmlEl.style.outline = '1px dashed #C0C0C0';
+			// ⭐ Step 5와 동일한 방식으로 이벤트 리스너 등록 (capture phase)
+			componentElements.forEach((el) => {
+				if (
+					el.tagName &&
+					!["SCRIPT", "STYLE", "NOSCRIPT", "HTML", "HEAD", "BODY"].includes(
+						el.tagName,
+					)
+				) {
+					const htmlEl = el as HTMLElement;
+					htmlEl.setAttribute("data-component-editable", "true");
+					htmlEl.style.cursor = "pointer";
+					htmlEl.style.outline = "1px dashed #C0C0C0";
 
-          // 기존 핸들러가 있으면 제거
-          const existingHandler = componentClickHandlersRef.current.get(htmlEl);
-          if (existingHandler) {
-            htmlEl.removeEventListener('click', existingHandler, true);
-          }
+					// 기존 핸들러가 있으면 제거
+					const existingHandler = componentClickHandlersRef.current.get(htmlEl);
+					if (existingHandler) {
+						htmlEl.removeEventListener("click", existingHandler, true);
+					}
 
-          // 클릭 이벤트 리스너 추가 및 저장 (capture phase)
-          htmlEl.addEventListener('click', handleComponentClick, true);
-          componentClickHandlersRef.current.set(htmlEl, handleComponentClick);
-        }
-      });
+					// 클릭 이벤트 리스너 추가 및 저장 (capture phase)
+					htmlEl.addEventListener("click", handleComponentClick, true);
+					componentClickHandlersRef.current.set(htmlEl, handleComponentClick);
+				}
+			});
 
-      // ⭐ 링크 클릭 방지 (다른 사이트로 이동 방지)
-      const allLinks = iframeDoc.querySelectorAll('a');
-      const preventLinkNavigation = (e: Event) => {
-        e.preventDefault();
-        e.stopPropagation();
-          e.stopImmediatePropagation();
-        return false;
-      };
+			// ⭐ 링크 클릭 방지 (다른 사이트로 이동 방지)
+			const allLinks = iframeDoc.querySelectorAll("a");
+			const preventLinkNavigation = (e: Event) => {
+				e.preventDefault();
+				e.stopPropagation();
+				e.stopImmediatePropagation();
+				return false;
+			};
 
-      allLinks.forEach(link => {
-        const htmlLink = link as HTMLElement;
-        // 기존 핸들러가 있으면 제거
-        const existingLinkHandler = linkClickHandlersRef.current.get(htmlLink);
-        if (existingLinkHandler) {
-          htmlLink.removeEventListener('click', existingLinkHandler, true);
-        }
-        htmlLink.addEventListener('click', preventLinkNavigation, true);
-        linkClickHandlersRef.current.set(htmlLink, preventLinkNavigation);
-        htmlLink.style.cursor = 'pointer';
-      });
+			allLinks.forEach((link) => {
+				const htmlLink = link as HTMLElement;
+				// 기존 핸들러가 있으면 제거
+				const existingLinkHandler = linkClickHandlersRef.current.get(htmlLink);
+				if (existingLinkHandler) {
+					htmlLink.removeEventListener("click", existingLinkHandler, true);
+				}
+				htmlLink.addEventListener("click", preventLinkNavigation, true);
+				linkClickHandlersRef.current.set(htmlLink, preventLinkNavigation);
+				htmlLink.style.cursor = "pointer";
+			});
 
-      console.log('✅ TranslationWork 컴포넌트 클릭 리스너 추가 완료:', componentElements.length, '개');
-      console.log('✅ TranslationWork 링크 클릭 방지 핸들러 추가 완료:', allLinks.length, '개');
-    }
+			console.log(
+				"✅ TranslationWork 컴포넌트 클릭 리스너 추가 완료:",
+				componentElements.length,
+				"개",
+			);
+			console.log(
+				"✅ TranslationWork 링크 클릭 방지 핸들러 추가 완료:",
+				allLinks.length,
+				"개",
+			);
+		}
 
-    // ⭐ cleanup 함수: 컴포넌트 언마운트 시 window 리스너 제거
-    return () => {
-      console.log('🧹 TranslationWork cleanup: 이벤트 리스너 제거');
-      // window 리스너 제거
-      if (windowKeydownHandlerRef.current) {
-        window.removeEventListener('keydown', windowKeydownHandlerRef.current, true);
-        console.log('✅ TranslationWork window 키보드 리스너 제거');
-      }
-    };
-  }, [editorMode, isTranslationEditorInitialized, savedTranslationHtml]); // ⭐ savedTranslationHtml 추가하여 undo/redo 후 자동 재활성화
+		// ⭐ cleanup 함수: 컴포넌트 언마운트 시 window 리스너 제거
+		return () => {
+			console.log("🧹 TranslationWork cleanup: 이벤트 리스너 제거");
+			// window 리스너 제거
+			if (windowKeydownHandlerRef.current) {
+				window.removeEventListener(
+					"keydown",
+					windowKeydownHandlerRef.current,
+					true,
+				);
+				console.log("✅ TranslationWork window 키보드 리스너 제거");
+			}
+		};
+	}, [editorMode, isTranslationEditorInitialized, savedTranslationHtml]); // ⭐ savedTranslationHtml 추가하여 undo/redo 후 자동 재활성화
 
-  // 더보기 메뉴 외부 클릭 시 닫기
-  useEffect(() => {
-    if (!showMoreMenu) return;
+	// 더보기 메뉴 외부 클릭 시 닫기
+	useEffect(() => {
+		if (!showMoreMenu) return;
 
-    const handleClickOutside = (e: MouseEvent) => {
-      const target = e.target as HTMLElement;
-      if (!target.closest('[data-more-menu]')) {
-        setShowMoreMenu(false);
-      }
-    };
+		const handleClickOutside = (e: MouseEvent) => {
+			const target = e.target as HTMLElement;
+			if (!target.closest("[data-more-menu]")) {
+				setShowMoreMenu(false);
+			}
+		};
 
-    window.document.addEventListener('mousedown', handleClickOutside);
-    return () => {
-      window.document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [showMoreMenu]);
+		window.document.addEventListener("mousedown", handleClickOutside);
+		return () => {
+			window.document.removeEventListener("mousedown", handleClickOutside);
+		};
+	}, [showMoreMenu]);
 
-  // 패널 접기/펼치기
-  const togglePanel = (panelId: string) => {
-    setCollapsedPanels(prev => {
-      const newSet = new Set(prev);
-      if (newSet.has(panelId)) {
-        newSet.delete(panelId);
-      } else {
-        newSet.add(panelId);
-      }
-      return newSet;
-    });
-  };
+	// 패널 접기/펼치기
+	const togglePanel = (panelId: string) => {
+		setCollapsedPanels((prev) => {
+			const newSet = new Set(prev);
+			if (newSet.has(panelId)) {
+				newSet.delete(panelId);
+			} else {
+				newSet.add(panelId);
+			}
+			return newSet;
+		});
+	};
 
-  // 전체화면 토글
-  const toggleFullscreen = (panelId: string) => {
-    setFullscreenPanel(prev => prev === panelId ? null : panelId);
-  };
+	// 전체화면 토글
+	const toggleFullscreen = (panelId: string) => {
+		setFullscreenPanel((prev) => (prev === panelId ? null : panelId));
+	};
 
-  // 원문 iframe 렌더링 + 문단 클릭/호버 이벤트
-  useEffect(() => {
-    const iframe = originalIframeRef.current;
-    if (!iframe || !originalHtml) return;
-    
-    console.log('🚀 원문 iframe 렌더링 시작...');
-    
-    const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-    if (iframeDoc) {
-      try {
-        iframeDoc.open();
-        iframeDoc.write(originalHtml);
-        iframeDoc.close();
-        
-        // ⭐ 경계선 제거 + 원문 용어집 표시 CSS 주입
-        const style = iframeDoc.createElement('style');
-        style.textContent = `
+	// 원문 iframe 렌더링 + 문단 클릭/호버 이벤트
+	useEffect(() => {
+		const iframe = originalIframeRef.current;
+		if (!iframe || !originalHtml) return;
+
+		console.log("🚀 원문 iframe 렌더링 시작...");
+
+		const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
+		if (iframeDoc) {
+			try {
+				iframeDoc.open();
+				iframeDoc.write(originalHtml);
+				iframeDoc.close();
+
+				// ⭐ 경계선 제거 + 원문 용어집 표시 CSS 주입
+				const style = iframeDoc.createElement("style");
+				style.textContent = `
           * {
             border: none !important;
             outline: none !important;
@@ -1215,74 +1450,87 @@ export default function TranslationWork() {
             padding: 0 2px;
           }
         `;
-        iframeDoc.head.appendChild(style);
+				iframeDoc.head.appendChild(style);
 
-        if (showOriginalGlossary) {
-          highlightGlossaryInOriginalIframe(iframeDoc, originalGlossaryTerms);
-        }
-        
-        // 편집 불가능하게 설정
-        if (iframeDoc.body) {
-          iframeDoc.body.style.cursor = 'default';
-          iframeDoc.body.contentEditable = 'false';
-        }
-        
-        // ⭐ 문단 클릭/호버 이벤트 추가 (원문 ↔ AI 초벌 번역 1:1 매칭)
-        const paragraphs = iframeDoc.querySelectorAll('[data-paragraph-index]');
-        console.log(`🔍 원문: ${paragraphs.length}개 문단 발견, 이벤트 리스너 등록 시작`);
-        
-        if (paragraphs.length === 0) {
-          console.warn('⚠️ 원문에 data-paragraph-index를 가진 요소가 없습니다!');
-        }
-        
-        paragraphs.forEach((para, idx) => {
-          const element = para as HTMLElement;
-          const indexAttr = element.getAttribute('data-paragraph-index');
-          const index = parseInt(indexAttr || '0', 10);
-          
-          if (idx < 3) { // 처음 3개만 로그
-            console.log(`📝 원문 문단 ${idx}: data-paragraph-index="${indexAttr}" → ${index}`);
-          }
-          
-          // 호버 이벤트
-          element.addEventListener('mouseenter', () => {
-            console.log(`🖱️ [원문] 문단 ${index} 호버 시작`);
-            setHighlightedParagraphIndex(index);
-          });
-          
-          // 클릭 이벤트
-          element.addEventListener('click', () => {
-            console.log(`🖱️ [원문] 문단 ${index} 클릭`);
-            setHighlightedParagraphIndex(index);
-          });
-        });
-        
-        console.log(`✅ 원문 iframe 렌더링 완료 (문단 ${paragraphs.length}개, 이벤트 등록 완료)`);
-      } catch (error) {
-        console.error('❌ 원문 iframe 오류:', error);
-      }
-    } else {
-      console.error('❌ 원문 iframe document를 찾을 수 없습니다');
-    }
-  }, [originalHtml, collapsedPanels, fullscreenPanel, showOriginalGlossary, originalGlossaryTerms]);
+				if (showOriginalGlossary) {
+					highlightGlossaryInOriginalIframe(iframeDoc, originalGlossaryTerms);
+				}
 
-  // AI 초벌 번역 iframe 렌더링 + 문단 클릭/호버 이벤트
-  useEffect(() => {
-    const iframe = aiDraftIframeRef.current;
-    if (!iframe || !aiDraftHtml) return;
-    
-    console.log('🚀 AI 초벌 iframe 렌더링 시작...');
-    
-    const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-    if (iframeDoc) {
-      try {
-        iframeDoc.open();
-        iframeDoc.write(aiDraftHtml);
-        iframeDoc.close();
-        
-        // ⭐ 경계선 제거 CSS 주입
-        const style = iframeDoc.createElement('style');
-        style.textContent = `
+				// 편집 불가능하게 설정
+				if (iframeDoc.body) {
+					iframeDoc.body.style.cursor = "default";
+					iframeDoc.body.contentEditable = "false";
+				}
+
+				// ⭐ 문단 클릭/호버 이벤트 추가 (원문 ↔ AI 초벌 번역 1:1 매칭)
+				const paragraphs = iframeDoc.querySelectorAll("[data-paragraph-index]");
+				console.log(
+					`🔍 원문: ${paragraphs.length}개 문단 발견, 이벤트 리스너 등록 시작`,
+				);
+
+				if (paragraphs.length === 0) {
+					console.warn("⚠️ 원문에 data-paragraph-index를 가진 요소가 없습니다!");
+				}
+
+				paragraphs.forEach((para, idx) => {
+					const element = para as HTMLElement;
+					const indexAttr = element.getAttribute("data-paragraph-index");
+					const index = Number.parseInt(indexAttr || "0", 10);
+
+					if (idx < 3) {
+						// 처음 3개만 로그
+						console.log(
+							`📝 원문 문단 ${idx}: data-paragraph-index="${indexAttr}" → ${index}`,
+						);
+					}
+
+					// 호버 이벤트
+					element.addEventListener("mouseenter", () => {
+						console.log(`🖱️ [원문] 문단 ${index} 호버 시작`);
+						setHighlightedParagraphIndex(index);
+					});
+
+					// 클릭 이벤트
+					element.addEventListener("click", () => {
+						console.log(`🖱️ [원문] 문단 ${index} 클릭`);
+						setHighlightedParagraphIndex(index);
+					});
+				});
+
+				console.log(
+					`✅ 원문 iframe 렌더링 완료 (문단 ${paragraphs.length}개, 이벤트 등록 완료)`,
+				);
+			} catch (error) {
+				console.error("❌ 원문 iframe 오류:", error);
+			}
+		} else {
+			console.error("❌ 원문 iframe document를 찾을 수 없습니다");
+		}
+	}, [
+		originalHtml,
+		collapsedPanels,
+		fullscreenPanel,
+		showOriginalGlossary,
+		originalGlossaryTerms,
+	]);
+
+	// AI 초벌 번역 iframe 렌더링 + 문단 클릭/호버 이벤트
+	useEffect(() => {
+		const iframe = aiDraftIframeRef.current;
+		if (!iframe || !aiDraftHtml) return;
+
+		console.log("🚀 AI 초벌 iframe 렌더링 시작...");
+
+		const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
+		if (iframeDoc) {
+			try {
+				iframeDoc.open();
+				iframeDoc.write(aiDraftHtml);
+				iframeDoc.close();
+
+				// ⭐ 경계선 제거 CSS 주입
+				const style = iframeDoc.createElement("style");
+				style.textContent = `
           * {
             border: none !important;
             outline: none !important;
@@ -1291,2202 +1539,3009 @@ export default function TranslationWork() {
             cursor: default !important;
           }
         `;
-        iframeDoc.head.appendChild(style);
-        
-        // 편집 불가능하게 설정 (AI 초벌 번역은 읽기 전용)
-        if (iframeDoc.body) {
-          iframeDoc.body.style.cursor = 'default';
-          iframeDoc.body.contentEditable = 'false';
-          
-          // 모든 요소를 편집 불가능하게 설정
-          const allElements = iframeDoc.querySelectorAll('*');
-          allElements.forEach(el => {
-            (el as HTMLElement).contentEditable = 'false';
-            (el as HTMLElement).style.userSelect = 'none';
-            (el as HTMLElement).style.webkitUserSelect = 'none';
-          });
-        }
-        
-        // ⭐ 문단 클릭/호버 이벤트 추가 (원문 ↔ AI 초벌 번역 1:1 매칭)
-        const paragraphs = iframeDoc.querySelectorAll('[data-paragraph-index]');
-        console.log(`🔍 AI 초벌: ${paragraphs.length}개 문단 발견, 이벤트 리스너 등록 시작`);
-        
-        if (paragraphs.length === 0) {
-          console.warn('⚠️ AI 초벌에 data-paragraph-index를 가진 요소가 없습니다!');
-        }
-        
-        paragraphs.forEach((para, idx) => {
-          const element = para as HTMLElement;
-          const indexAttr = element.getAttribute('data-paragraph-index');
-          const index = parseInt(indexAttr || '0', 10);
-          
-          if (idx < 3) { // 처음 3개만 로그
-            console.log(`📝 AI 초벌 문단 ${idx}: data-paragraph-index="${indexAttr}" → ${index}`);
-          }
-          
-          // 호버 이벤트
-          element.addEventListener('mouseenter', () => {
-            console.log(`🖱️ [AI 초벌] 문단 ${index} 호버 시작`);
-            setHighlightedParagraphIndex(index);
-          });
-          
-          // 클릭 이벤트
-          element.addEventListener('click', () => {
-            console.log(`🖱️ [AI 초벌] 문단 ${index} 클릭`);
-            setHighlightedParagraphIndex(index);
-          });
-        });
-        
-        console.log(`✅ AI 초벌 번역 iframe 렌더링 완료 (문단 ${paragraphs.length}개, 이벤트 등록 완료)`);
-      } catch (error) {
-        console.error('❌ AI 초벌 iframe 오류:', error);
-      }
-    } else {
-      console.error('❌ AI 초벌 iframe document를 찾을 수 없습니다');
-    }
-  }, [aiDraftHtml, collapsedPanels, fullscreenPanel]);
+				iframeDoc.head.appendChild(style);
 
-  // 스크롤 동기화 (iframe용)
-  const syncScroll = useCallback((sourceIframe: HTMLIFrameElement, targetIframes: (HTMLIFrameElement | HTMLDivElement)[]) => {
-    if (isScrollingRef.current) return;
+				// 편집 불가능하게 설정 (AI 초벌 번역은 읽기 전용)
+				if (iframeDoc.body) {
+					iframeDoc.body.style.cursor = "default";
+					iframeDoc.body.contentEditable = "false";
 
-    const sourceDoc = sourceIframe.contentDocument || sourceIframe.contentWindow?.document;
-    if (!sourceDoc) return;
+					// 모든 요소를 편집 불가능하게 설정
+					const allElements = iframeDoc.querySelectorAll("*");
+					allElements.forEach((el) => {
+						(el as HTMLElement).contentEditable = "false";
+						(el as HTMLElement).style.userSelect = "none";
+						(el as HTMLElement).style.webkitUserSelect = "none";
+					});
+				}
 
-    isScrollingRef.current = true;
-    const sourceBody = sourceDoc.body || sourceDoc.documentElement;
-    const maxScroll = sourceBody.scrollHeight - sourceBody.clientHeight;
-    const scrollRatio = maxScroll > 0 ? sourceBody.scrollTop / maxScroll : 0;
+				// ⭐ 문단 클릭/호버 이벤트 추가 (원문 ↔ AI 초벌 번역 1:1 매칭)
+				const paragraphs = iframeDoc.querySelectorAll("[data-paragraph-index]");
+				console.log(
+					`🔍 AI 초벌: ${paragraphs.length}개 문단 발견, 이벤트 리스너 등록 시작`,
+				);
 
-    targetIframes.forEach((target) => {
-      if (target instanceof HTMLIFrameElement) {
-        const targetDoc = target.contentDocument || target.contentWindow?.document;
-        if (targetDoc) {
-          const targetBody = targetDoc.body || targetDoc.documentElement;
-          const targetMaxScroll = targetBody.scrollHeight - targetBody.clientHeight;
-          if (targetMaxScroll > 0) {
-            targetBody.scrollTop = scrollRatio * targetMaxScroll;
-          }
-        }
-      } else {
-        const targetMaxScroll = target.scrollHeight - target.clientHeight;
-        if (targetMaxScroll > 0) {
-          target.scrollTop = scrollRatio * targetMaxScroll;
-        }
-      }
-    });
+				if (paragraphs.length === 0) {
+					console.warn(
+						"⚠️ AI 초벌에 data-paragraph-index를 가진 요소가 없습니다!",
+					);
+				}
 
-    // 현재 스크롤 위치의 문단 찾기
-    const currentPara = getParagraphAtScrollPosition(sourceBody as HTMLElement, sourceBody.scrollTop);
-    if (currentPara) {
-      setHighlightedParagraphIndex(currentPara.index);
-    }
+				paragraphs.forEach((para, idx) => {
+					const element = para as HTMLElement;
+					const indexAttr = element.getAttribute("data-paragraph-index");
+					const index = Number.parseInt(indexAttr || "0", 10);
 
-    setTimeout(() => {
-      isScrollingRef.current = false;
-    }, 50);
-  }, []);
+					if (idx < 3) {
+						// 처음 3개만 로그
+						console.log(
+							`📝 AI 초벌 문단 ${idx}: data-paragraph-index="${indexAttr}" → ${index}`,
+						);
+					}
 
-  const handleParagraphLeave = useCallback(() => {
-    // 호버 해제 시 하이라이트 유지 (스크롤 위치 기반)
-    // 필요시 null로 설정하여 하이라이트 제거 가능
-  }, []);
+					// 호버 이벤트
+					element.addEventListener("mouseenter", () => {
+						console.log(`🖱️ [AI 초벌] 문단 ${index} 호버 시작`);
+						setHighlightedParagraphIndex(index);
+					});
 
-  // 문단 하이라이트 및 완료 상태 동기화
-  useEffect(() => {
-    console.log(`🎨 하이라이트 상태 변경: ${highlightedParagraphIndex}`);
-    
-    const applyParagraphStyles = (panel: HTMLElement | null, panelName: string, isMyTranslation: boolean = false) => {
-      if (!panel) return;
-      clearAllHighlights(panel);
-      
-      const paragraphs = getParagraphs(panel);
-      console.log(`📊 ${panelName}에서 ${paragraphs.length}개 문단 발견`);
-      
-      paragraphs.forEach((para) => {
-        const isHighlighted = para.index === highlightedParagraphIndex;
-        const isComplete = completedParagraphs.has(para.index);
-        
-        if (isHighlighted) {
-          console.log(`✨ ${panelName} 문단 ${para.index} 하이라이트 적용`);
-          highlightParagraph(para.element, true);
-        }
-        
-        if (isComplete) {
-          // 완료된 문단: 회색 배경색 적용
-          para.element.style.backgroundColor = 'rgba(211, 211, 211, 0.3)'; // lightgray 배경
-          para.element.style.opacity = '0.85';
-          para.element.style.transition = 'background-color 0.2s ease, opacity 0.2s ease';
-          // 취소선은 제거 (회색 배경만으로 충분)
-          para.element.style.textDecoration = '';
-          para.element.style.color = '';
-        } else {
-          para.element.style.backgroundColor = '';
-          para.element.style.opacity = '';
-          para.element.style.textDecoration = '';
-          para.element.style.color = '';
-        }
-      });
-    };
+					// 클릭 이벤트
+					element.addEventListener("click", () => {
+						console.log(`🖱️ [AI 초벌] 문단 ${index} 클릭`);
+						setHighlightedParagraphIndex(index);
+					});
+				});
 
-    // 원문 iframe 내부 문단 스타일 적용
-    if (originalIframeRef.current?.contentDocument?.body) {
-      applyParagraphStyles(originalIframeRef.current.contentDocument.body as HTMLElement, '원문');
-    }
-    
-    // AI 초벌 번역 iframe 내부 문단 스타일 적용
-    if (aiDraftIframeRef.current?.contentDocument?.body) {
-      applyParagraphStyles(aiDraftIframeRef.current.contentDocument.body as HTMLElement, 'AI 초벌');
-    }
-    
-    // 에디터 내부 문단 스타일 적용 (내 번역)
-    if (myTranslationIframeRef.current?.contentDocument?.body) {
-      applyParagraphStyles(myTranslationIframeRef.current.contentDocument.body as HTMLElement, '내 번역', true);
-    }
-  }, [highlightedParagraphIndex, completedParagraphs]);
+				console.log(
+					`✅ AI 초벌 번역 iframe 렌더링 완료 (문단 ${paragraphs.length}개, 이벤트 등록 완료)`,
+				);
+			} catch (error) {
+				console.error("❌ AI 초벌 iframe 오류:", error);
+			}
+		} else {
+			console.error("❌ AI 초벌 iframe document를 찾을 수 없습니다");
+		}
+	}, [aiDraftHtml, collapsedPanels, fullscreenPanel]);
 
-  // 문단 완료 체크 토글
-  const toggleParagraphComplete = useCallback((index: number) => {
-    setCompletedParagraphs((prev) => {
-      const newSet = new Set(prev);
-      if (newSet.has(index)) {
-        newSet.delete(index);
-        console.log(`❌ 문단 ${index} 완료 해제`);
-      } else {
-        newSet.add(index);
-        console.log(`✅ 문단 ${index} 완료 표시`);
-      }
-      
-      // iframe 내부 UI 즉시 업데이트
-      const iframe = myTranslationIframeRef.current;
-      if (iframe) {
-        const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-        if (iframeDoc) {
-          const paraElement = iframeDoc.querySelector(`[data-paragraph-index="${index}"]`) as HTMLElement;
-          if (paraElement) {
-            if (newSet.has(index)) {
-              paraElement.classList.add('completed');
-            } else {
-              paraElement.classList.remove('completed');
-            }
-          }
-        }
-      }
-      
-      // 진행률 업데이트 (전체 문단 수 대비 완료된 문단 수)
-      const completedCount = newSet.size;
-      setProgress((p) => {
-        const newProgress = { ...p, completed: completedCount };
-        const percentage = p.total > 0 ? Math.round((completedCount / p.total) * 100) : 0;
-        console.log(`📊 진행률 업데이트: ${completedCount}/${p.total} (${percentage}%)`);
-        return newProgress;
-      });
-      
-      return newSet;
-    });
-  }, []);
+	// 스크롤 동기화 (iframe용)
+	const syncScroll = useCallback(
+		(
+			sourceIframe: HTMLIFrameElement,
+			targetIframes: (HTMLIFrameElement | HTMLDivElement)[],
+		) => {
+			if (isScrollingRef.current) return;
 
-  // 진행률 업데이트
-  useEffect(() => {
-    setProgress((prev) => ({ ...prev, completed: completedParagraphs.size }));
-  }, [completedParagraphs]);
+			const sourceDoc =
+				sourceIframe.contentDocument || sourceIframe.contentWindow?.document;
+			if (!sourceDoc) return;
 
-  // completedParagraphs 변경 시 iframe 내부 완료 상태 동기화
-  useEffect(() => {
-    const iframe = myTranslationIframeRef.current;
-    if (!iframe) return;
+			isScrollingRef.current = true;
+			const sourceBody = sourceDoc.body || sourceDoc.documentElement;
+			const maxScroll = sourceBody.scrollHeight - sourceBody.clientHeight;
+			const scrollRatio = maxScroll > 0 ? sourceBody.scrollTop / maxScroll : 0;
 
-    const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-    if (!iframeDoc) return;
+			targetIframes.forEach((target) => {
+				if (target instanceof HTMLIFrameElement) {
+					const targetDoc =
+						target.contentDocument || target.contentWindow?.document;
+					if (targetDoc) {
+						const targetBody = targetDoc.body || targetDoc.documentElement;
+						const targetMaxScroll =
+							targetBody.scrollHeight - targetBody.clientHeight;
+						if (targetMaxScroll > 0) {
+							targetBody.scrollTop = scrollRatio * targetMaxScroll;
+						}
+					}
+				} else {
+					const targetMaxScroll = target.scrollHeight - target.clientHeight;
+					if (targetMaxScroll > 0) {
+						target.scrollTop = scrollRatio * targetMaxScroll;
+					}
+				}
+			});
 
-    const paragraphs = iframeDoc.querySelectorAll('[data-paragraph-index]');
-    paragraphs.forEach((para) => {
-      const paraElement = para as HTMLElement;
-      const index = parseInt(paraElement.getAttribute('data-paragraph-index') || '0', 10);
-      
-      if (completedParagraphs.has(index)) {
-        paraElement.classList.add('completed');
-      } else {
-        paraElement.classList.remove('completed');
-      }
-    });
-  }, [completedParagraphs]);
+			// 현재 스크롤 위치의 문단 찾기
+			const currentPara = getParagraphAtScrollPosition(
+				sourceBody as HTMLElement,
+				sourceBody.scrollTop,
+			);
+			if (currentPara) {
+				setHighlightedParagraphIndex(currentPara.index);
+			}
 
+			setTimeout(() => {
+				isScrollingRef.current = false;
+			}, 50);
+		},
+		[],
+	);
 
+	const handleParagraphLeave = useCallback(() => {
+		// 호버 해제 시 하이라이트 유지 (스크롤 위치 기반)
+		// 필요시 null로 설정하여 하이라이트 제거 가능
+	}, []);
 
-  const handleHandover = () => {
-    setShowHandoverModal(true);
-  };
+	// 문단 하이라이트 및 완료 상태 동기화
+	useEffect(() => {
+		console.log(`🎨 하이라이트 상태 변경: ${highlightedParagraphIndex}`);
 
-  const confirmHandover = async () => {
-    if (!documentId || !handoverMemo.trim()) {
-      alert('남은 작업 메모를 입력해주세요.');
-      return;
-    }
-    if (!savedTranslationHtml) {
-      alert('저장할 번역 내용이 없습니다.');
-      return;
-    }
+		const applyParagraphStyles = (
+			panel: HTMLElement | null,
+			panelName: string,
+			isMyTranslation = false,
+		) => {
+			if (!panel) return;
+			clearAllHighlights(panel);
 
-    try {
-      setHandoverSubmitting(true);
-      try {
-        await translationWorkApi.saveTranslation(documentId, {
-          content: savedTranslationHtml,
-          completedParagraphs: Array.from(completedParagraphs),
-        });
-      } catch (saveErr: any) {
-        const msg = (saveErr as any).response?.data?.message ?? (saveErr as any).message ?? (saveErr as any).response?.statusText ?? '서버 오류';
-        alert('저장 실패: ' + msg);
-        return;
-      }
-      try {
-        await translationWorkApi.handover(documentId, {
-          memo: handoverMemo.trim(),
-          terms: handoverTerms.trim() || undefined,
-        });
-      } catch (handoverErr: any) {
-        const msg = (handoverErr as any).response?.data?.message ?? (handoverErr as any).message ?? (handoverErr as any).response?.statusText ?? '서버 오류';
-        alert('인계 요청 실패: ' + msg);
-        return;
-      }
-      alert('인계가 완료되었습니다.');
-      navigate(fromPath);
-    } finally {
-      setHandoverSubmitting(false);
-    }
-  };
+			const paragraphs = getParagraphs(panel);
+			console.log(`📊 ${panelName}에서 ${paragraphs.length}개 문단 발견`);
 
-  const handleComplete = async () => {
-    if (!documentId || !savedTranslationHtml) return;
+			paragraphs.forEach((para) => {
+				const isHighlighted = para.index === highlightedParagraphIndex;
+				const isComplete = completedParagraphs.has(para.index);
 
-    if (!window.confirm('번역을 완료하시겠습니까? 완료 후 검토 대기 상태로 변경됩니다.')) {
-      return;
-    }
+				if (isHighlighted) {
+					console.log(`✨ ${panelName} 문단 ${para.index} 하이라이트 적용`);
+					highlightParagraph(para.element, true);
+				}
 
-    try {
-      await translationWorkApi.completeTranslation(documentId, {
-        content: savedTranslationHtml,
-        completedParagraphs: Array.from(completedParagraphs),
-      });
-      alert('번역이 완료되었습니다!');
-      navigate(fromPath);
-    } catch (error: any) {
-      alert('완료 처리 실패: ' + (error.response?.data?.message || error.message));
-    }
-  };
+				if (isComplete) {
+					// 완료된 문단: 회색 배경색 적용
+					para.element.style.backgroundColor = "rgba(211, 211, 211, 0.3)"; // lightgray 배경
+					para.element.style.opacity = "0.85";
+					para.element.style.transition =
+						"background-color 0.2s ease, opacity 0.2s ease";
+					// 취소선은 제거 (회색 배경만으로 충분)
+					para.element.style.textDecoration = "";
+					para.element.style.color = "";
+				} else {
+					para.element.style.backgroundColor = "";
+					para.element.style.opacity = "";
+					para.element.style.textDecoration = "";
+					para.element.style.color = "";
+				}
+			});
+		};
 
-  if (loading) {
-    return (
-      <div style={{ padding: '48px', textAlign: 'center', color: colors.primaryText }}>
-        로딩 중...
-      </div>
-    );
-  }
+		// 원문 iframe 내부 문단 스타일 적용
+		if (originalIframeRef.current?.contentDocument?.body) {
+			applyParagraphStyles(
+				originalIframeRef.current.contentDocument.body as HTMLElement,
+				"원문",
+			);
+		}
 
-  // 에러가 있거나, 필수 데이터가 없으면 에러 화면 표시
-  if (error || !document) {
-    return (
-      <div style={{ padding: '48px' }}>
-        <div
-          style={{
-            padding: '16px',
-            backgroundColor: '#F5F5F5',
-            border: `1px solid ${colors.border}`,
-            borderRadius: '8px',
-            color: colors.primaryText,
-            marginBottom: '16px',
-          }}
-        >
-          ⚠️ {error || '문서를 불러올 수 없습니다.'}
-        </div>
-        <div>
-          <Button variant="secondary" onClick={() => navigate(fromPath)}>
-            목록으로 돌아가기
-          </Button>
-        </div>
-      </div>
-    );
-  }
+		// AI 초벌 번역 iframe 내부 문단 스타일 적용
+		if (aiDraftIframeRef.current?.contentDocument?.body) {
+			applyParagraphStyles(
+				aiDraftIframeRef.current.contentDocument.body as HTMLElement,
+				"AI 초벌",
+			);
+		}
 
-  const adminSessionOwnerId = document.adminSessionUser?.id;
-  const isAdminSessionOwner =
-    adminSessionOwnerId != null && user != null && Number(adminSessionOwnerId) === Number(user.id);
-  const isCompletedOrReview = ['PENDING_REVIEW', 'APPROVED', 'PUBLISHED'].includes(document.status);
-  const adminSessionBlocking =
-    !!document.adminTranslationSessionActive && document.sourceDocumentId != null;
-  const translationLocked = isCompletedOrReview || (adminSessionBlocking && !isAdminSessionOwner);
+		// 에디터 내부 문단 스타일 적용 (내 번역)
+		if (myTranslationIframeRef.current?.contentDocument?.body) {
+			applyParagraphStyles(
+				myTranslationIframeRef.current.contentDocument.body as HTMLElement,
+				"내 번역",
+				true,
+			);
+		}
+	}, [highlightedParagraphIndex, completedParagraphs]);
 
-  const toggleAllPanels = () => {
-    if (allPanelsCollapsed) {
-      // 모든 패널 펼치기
-      setCollapsedPanels(new Set());
-    } else {
-      // 모든 패널 접기
-      setCollapsedPanels(new Set(['original', 'aiDraft', 'myTranslation']));
-    }
-    setAllPanelsCollapsed(!allPanelsCollapsed);
-  };
+	// 문단 완료 체크 토글
+	const toggleParagraphComplete = useCallback((index: number) => {
+		setCompletedParagraphs((prev) => {
+			const newSet = new Set(prev);
+			if (newSet.has(index)) {
+				newSet.delete(index);
+				console.log(`❌ 문단 ${index} 완료 해제`);
+			} else {
+				newSet.add(index);
+				console.log(`✅ 문단 ${index} 완료 표시`);
+			}
 
-  // 상태 텍스트 변환
-  const getStatusText = (status: string) => {
-    const statusMap: Record<string, string> = {
-      'DRAFT': '초안',
-      'PENDING_TRANSLATION': '번역 대기',
-      'IN_TRANSLATION': '번역 중',
-      'PENDING_REVIEW': '검토 대기',
-      'APPROVED': '승인됨',
-      'PUBLISHED': '공개됨',
-    };
-    return statusMap[status] || status;
-  };
+			// iframe 내부 UI 즉시 업데이트
+			const iframe = myTranslationIframeRef.current;
+			if (iframe) {
+				const iframeDoc =
+					iframe.contentDocument || iframe.contentWindow?.document;
+				if (iframeDoc) {
+					const paraElement = iframeDoc.querySelector(
+						`[data-paragraph-index="${index}"]`,
+					) as HTMLElement;
+					if (paraElement) {
+						if (newSet.has(index)) {
+							paraElement.classList.add("completed");
+						} else {
+							paraElement.classList.remove("completed");
+						}
+					}
+				}
+			}
 
-  return (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        height: '100vh',
-        backgroundColor: colors.primaryBackground,
-      }}
-    >
-      {translationLocked && adminSessionBlocking && !isCompletedOrReview && (
-        <div
-          style={{
-            padding: '10px 24px',
-            backgroundColor: '#FFF3E0',
-            borderBottom: '1px solid #FFB74D',
-            fontSize: '13px',
-            color: '#5D4037',
-          }}
-        >
-          {document.adminSessionUser?.name
-            ? `${document.adminSessionUser.name} 관리자`
-            : '관리자'}
-          가 이 원문 번역을 진행 중입니다. 임시 저장·번역 완료·인계는 관리자 작업이 끝난 뒤 가능합니다.
-        </div>
-      )}
-      {isCompletedOrReview && (
-        <div
-          style={{
-            padding: '10px 24px',
-            backgroundColor: '#E8F5E9',
-            borderBottom: '1px solid #A5D6A7',
-            fontSize: '13px',
-            color: '#2E7D32',
-          }}
-        >
-          이 문서는 {getStatusText(document.status)} 상태입니다. 조회만 가능합니다.
-        </div>
-      )}
-      {/* 상단 고정 바 */}
-      <div
-        style={{
-          padding: '12px 24px',
-          backgroundColor: colors.surface,
-          borderBottom: `1px solid ${colors.border}`,
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          gap: '16px',
-        }}
-      >
-        {/* 왼쪽: 뒤로가기 + 문서 정보 */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: '16px', flex: 1 }}>
-          <Button 
-            variant="secondary" 
-            onClick={() => {
-              const hasUnsavedChanges = savedTranslationHtml !== lastSavedHtml;
-              if (hasUnsavedChanges) {
-                const confirmed = window.confirm('저장하지 않으면 변경사항이 사라집니다. 나가시겠습니까?');
-                if (!confirmed) return;
-              }
-              navigate(fromPath);
-            }} 
-            style={{ fontSize: '12px', padding: '6px 12px' }}
-          >
-            ← 뒤로가기
-          </Button>
-          
-          {document && (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
-              <div style={{ fontSize: '14px', fontWeight: 600, color: '#000000' }}>
-                {document.title}
-              </div>
-              <div style={{ display: 'flex', gap: '12px', alignItems: 'center' }}>
-                <span style={{ fontSize: '11px', color: colors.secondaryText }}>
-                  {document.categoryId ? `카테고리 ${document.categoryId}` : '미분류'} · {getStatusText(document.status)}
-                </span>
-                {lockStatus?.lockedBy && (
-                  <span style={{ fontSize: '11px', color: colors.secondaryText }}>
-                    작업자: {lockStatus.lockedBy.name}
-                  </span>
-                )}
-              </div>
-            </div>
-          )}
-        </div>
-        
-        {/* 인계 메모 확인 버튼 (인계 정보가 있을 때만) */}
-        {document?.latestHandover && (
-          <Button
-            variant="secondary"
-            onClick={() => setShowHandoverInfoModal(true)}
-            style={{ fontSize: '12px', padding: '6px 14px', color: '#FF6B00', borderColor: '#FF6B00', whiteSpace: 'nowrap' }}
-          >
-            📋 인계 메모 확인
-          </Button>
-        )}
+			// 진행률 업데이트 (전체 문단 수 대비 완료된 문단 수)
+			const completedCount = newSet.size;
+			setProgress((p) => {
+				const newProgress = { ...p, completed: completedCount };
+				const percentage =
+					p.total > 0 ? Math.round((completedCount / p.total) * 100) : 0;
+				console.log(
+					`📊 진행률 업데이트: ${completedCount}/${p.total} (${percentage}%)`,
+				);
+				return newProgress;
+			});
 
-        {/* 중앙: 문서 보기 옵션 (체크박스로 각 버전 표시/숨김) */}
-        <div style={{ 
-          display: 'flex', 
-          alignItems: 'center', 
-          gap: '24px',
-          padding: '6px 16px',
-          backgroundColor: '#F8F9FA',
-          borderRadius: '6px',
-          border: '1px solid #D3D3D3',
-        }}>
-          <span style={{ fontSize: '12px', fontWeight: 600, color: colors.primaryText }}>문서 보기:</span>
-          <label style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: '8px',
-            fontSize: '13px',
-            cursor: 'pointer',
-            fontWeight: 500,
-            color: '#7a4b00',
-          }}>
-            <input
-              type="checkbox"
-              checked={showOriginalGlossary}
-              onChange={(e) => setShowOriginalGlossary(e.target.checked)}
-              style={{ cursor: 'pointer', width: '16px', height: '16px' }}
-            />
-            <span>Version 0 용어집 적용 구간 보기</span>
-          </label>
-          <label style={{ 
-            display: 'flex', 
-            alignItems: 'center', 
-            gap: '8px', 
-            fontSize: '13px', 
-            cursor: 'pointer',
-            fontWeight: 500,
-          }}>
-            <input
-              type="checkbox"
-              checked={!collapsedPanels.has('original')}
-              onChange={() => togglePanel('original')}
-              style={{
-                cursor: 'pointer',
-                width: '16px',
-                height: '16px',
-              }}
-            />
-            <span>원문 (Version 0)</span>
-          </label>
-          <label style={{ 
-            display: 'flex', 
-            alignItems: 'center', 
-            gap: '8px', 
-            fontSize: '13px', 
-            cursor: 'pointer',
-                fontWeight: 500,
-          }}>
-            <input
-              type="checkbox"
-              checked={!collapsedPanels.has('aiDraft')}
-              onChange={() => togglePanel('aiDraft')}
-              style={{ 
-                cursor: 'pointer',
-                width: '16px',
-                height: '16px',
-              }}
-            />
-            <span>AI 초벌 번역 (Version 1)</span>
-          </label>
-          <label style={{ 
-            display: 'flex', 
-            alignItems: 'center', 
-            gap: '8px', 
-            fontSize: '13px', 
-            cursor: 'pointer',
-            fontWeight: 500,
-          }}>
-            <input
-              type="checkbox"
-              checked={!collapsedPanels.has('myTranslation')}
-              onChange={() => togglePanel('myTranslation')}
-              style={{ 
-                cursor: 'pointer',
-                width: '16px',
-                height: '16px',
-              }}
-            />
-            <span>내 번역 (작업 중)</span>
-          </label>
-          </div>
+			return newSet;
+		});
+	}, []);
 
-        {/* 오른쪽: 채팅 토글 + 저장/완료 버튼 */}
-        <div style={{ display: 'flex', gap: '8px' }}>
-          {/* 소통 채팅 토글 */}
-          <button
-            onClick={() => setShowChat(prev => !prev)}
-            title="소통 채팅"
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: '5px',
-              padding: '6px 12px',
-              fontSize: '12px',
-              fontWeight: 500,
-              border: `1px solid ${showChat ? '#3B82F6' : '#D1D5DB'}`,
-              borderRadius: '6px',
-              backgroundColor: showChat ? '#EFF6FF' : '#FFFFFF',
-              color: showChat ? '#3B82F6' : '#374151',
-              cursor: 'pointer',
-              whiteSpace: 'nowrap',
-            }}
-          >
-            💬 채팅
-          </button>
-          <Button 
-            variant={translationLocked ? 'disabled' : 'secondary'}
-            onClick={async () => {
-              if (translationLocked) return;
-              if (!documentId) {
-                alert('⚠️ 문서 ID가 없습니다.');
-                return;
-              }
-              
-              try {
-                // iframe에서 최신 HTML 가져오기
-                const iframe = myTranslationIframeRef.current;
-                let contentToSave = savedTranslationHtml;
-                
-                if (iframe) {
-                  const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-                  if (iframeDoc && iframeDoc.documentElement) {
-                    contentToSave = iframeDoc.documentElement.outerHTML;
-                    console.log('💾 iframe에서 최신 HTML 추출:', contentToSave.substring(0, 100) + '...');
-                  }
-                }
-                
-                // 서버에 저장
-                await translationWorkApi.saveTranslation(
-                  documentId,
-                  {
-                    content: contentToSave,
-                    completedParagraphs: Array.from(completedParagraphs)
-                  }
-                );
-                
-                // 저장 후 상태 업데이트
-                setSavedTranslationHtml(contentToSave);
-                setLastSavedHtml(contentToSave);
-                currentEditorHtmlRef.current = contentToSave;
-                
-                alert('✅ 저장되었습니다.');
-              } catch (error) {
-                console.error('저장 실패:', error);
-                alert('⚠️ 저장에 실패했습니다.');
-              }
-            }} 
-            style={{ fontSize: '12px' }}
-          >
-            💾 저장하기
-          </Button>
-          <Button
-            variant={translationLocked ? 'disabled' : 'secondary'}
-            onClick={() => {
-              if (!translationLocked) handleHandover();
-            }}
-            style={{ fontSize: '12px' }}
-          >
-            인계 요청
-          </Button>
-          <Button
-            variant={translationLocked ? 'disabled' : 'primary'}
-            onClick={() => {
-              if (!translationLocked) handleComplete();
-            }}
-            style={{ fontSize: '12px' }}
-          >
-            번역 완료
-          </Button>
-        </div>
-      </div>
+	// 진행률 업데이트
+	useEffect(() => {
+		setProgress((prev) => ({ ...prev, completed: completedParagraphs.size }));
+	}, [completedParagraphs]);
 
-      {/* 3단 레이아웃 + 채팅 사이드바 */}
-      <div style={{ display: 'flex', height: '100%', overflow: 'hidden' }}>
+	// completedParagraphs 변경 시 iframe 내부 완료 상태 동기화
+	useEffect(() => {
+		const iframe = myTranslationIframeRef.current;
+		if (!iframe) return;
 
-        {/* 문서 패널 영역 */}
-        <div style={{ flex: 1, display: 'flex', gap: '4px', padding: '4px', overflow: 'hidden' }}>
-        {[
-          { id: 'original', title: '원문', ref: originalIframeRef, editable: false, html: originalHtml },
-          { id: 'aiDraft', title: 'AI 초벌 번역', ref: aiDraftIframeRef, editable: false, html: aiDraftHtml },
-          { id: 'myTranslation', title: '내 번역', ref: myTranslationIframeRef, editable: true, html: savedTranslationHtml },
-        ].map(panel => {
-          const isCollapsed = collapsedPanels.has(panel.id);
-          const isFullscreen = fullscreenPanel === panel.id;
-          const visiblePanels = ['original', 'aiDraft', 'myTranslation'].filter(id => !collapsedPanels.has(id));
-          const hasFullscreen = fullscreenPanel !== null;
-          const isHidden = hasFullscreen && !isFullscreen;
+		const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
+		if (!iframeDoc) return;
 
-          if (isHidden) return null;
+		const paragraphs = iframeDoc.querySelectorAll("[data-paragraph-index]");
+		paragraphs.forEach((para) => {
+			const paraElement = para as HTMLElement;
+			const index = Number.parseInt(
+				paraElement.getAttribute("data-paragraph-index") || "0",
+				10,
+			);
 
-          return (
-            <div
-              key={panel.id}
-              style={{
-                flex: isCollapsed ? '0 0 0' : isFullscreen ? '1' : `1 1 ${100 / visiblePanels.length}%`,
-                display: isCollapsed ? 'none' : 'flex',
-                flexDirection: 'column',
-                transition: 'flex 0.2s ease',
-                minWidth: isCollapsed ? '0' : '200px',
-              }}
-            >
-              {/* 패널 헤더 */}
-              <div
-                style={{
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  alignItems: 'center',
-                  padding: '8px 12px',
-                  backgroundColor: '#D3D3D3',
-                  borderRadius: '4px 4px 0 0',
-                  cursor: 'default',
-                  height: '36px',
-                }}
-              >
-                    <span style={{ fontSize: '12px', fontWeight: 600, color: '#000000' }}>
-                      {panel.title}
-                    </span>
-                <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                      <button
-                    onClick={() => toggleFullscreen(panel.id)}
-                        style={{
-                          padding: '4px 8px',
-                          fontSize: '11px',
-                          border: '1px solid #A9A9A9',
-                          borderRadius: '3px',
-                          backgroundColor: '#FFFFFF',
-                          color: '#000000',
-                          cursor: 'pointer',
-                          fontWeight: 500,
-                        }}
-                    title={isFullscreen ? '확대 해제' : '전체화면 확대'}
-                      >
-                    {isFullscreen ? '축소' : '확대'}
-                      </button>
-                    </div>
-              </div>
+			if (completedParagraphs.has(index)) {
+				paraElement.classList.add("completed");
+			} else {
+				paraElement.classList.remove("completed");
+			}
+		});
+	}, [completedParagraphs]);
 
-              {/* 패널 내용 */}
-              {(
-                <div
-                  style={{
-                    flex: 1,
-                    border: '1px solid #C0C0C0',
-                    borderTop: 'none',
-                    borderRadius: '0 0 4px 4px',
-                    overflow: 'hidden',
-                    backgroundColor: '#FFFFFF',
-                    display: 'flex',
-                    flexDirection: 'column',
-                    position: 'relative', // 오버레이를 위한 relative positioning
-                  }}
-                >
-                  {panel.id === 'myTranslation' ? (
-                    // 내 번역 패널 (iframe 기반 에디터 - HTML 구조 보존)
-                    <>
-                      {translationLocked && (
-                        <div
-                          style={{
-                            position: 'absolute',
-                            inset: 0,
-                            zIndex: 50,
-                            backgroundColor: 'rgba(255,255,255,0.82)',
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            fontSize: '13px',
-                            color: '#555',
-                            textAlign: 'center',
-                            padding: '16px',
-                          }}
-                        >
-                          조회 전용 (편집 불가)
-                        </div>
-                      )}
-                      {/* 편집 툴바 */}
-                      <div style={{ padding: '8px 12px', borderBottom: '1px solid #C0C0C0', display: 'flex', justifyContent: 'flex-start', alignItems: 'center', backgroundColor: '#F8F9FA', flexWrap: 'wrap', gap: '8px' }}>
-                        <div style={{ display: 'flex', gap: '4px', alignItems: 'center', flexWrap: 'wrap' }}>
-                          {/* 모드 선택 */}
-                          <Button
-                            variant={editorMode === 'text' ? 'primary' : 'secondary'}
-                            onClick={() => setEditorMode('text')}
-                            style={{ fontSize: '11px', padding: '4px 8px' }}
-                          >
-                            텍스트 편집
-                          </Button>
-                          <Button
-                            variant={editorMode === 'component' ? 'primary' : 'secondary'}
-                            onClick={() => setEditorMode('component')}
-                            style={{ fontSize: '11px', padding: '4px 8px' }}
-                          >
-                            컴포넌트 편집
-                          </Button>
-                          
-                          
-                          {/* Rich Text 기능 (텍스트 모드일 때만) */}
-                          {editorMode === 'text' && (
-                            <>
-                              <div style={{ width: '1px', height: '20px', backgroundColor: '#C0C0C0', margin: '0 4px' }} />
-                              <button
-                                onClick={() => {
-                                  const iframeDoc = myTranslationIframeRef.current?.contentDocument;
-                                  if (iframeDoc) iframeDoc.execCommand('bold', false);
-                                }}
-                                style={{
-                                  padding: '4px 8px',
-                                  fontSize: '11px',
-                                  fontWeight: 'bold',
-                                  border: '1px solid #A9A9A9',
-                                  borderRadius: '3px',
-                                  backgroundColor: '#FFFFFF',
-                                  color: '#000000',
-                                  cursor: 'pointer',
-                                }}
-                                title="굵게 (Ctrl+B)"
-                              >
-                                B
-                              </button>
-                              <button
-                                onClick={() => {
-                                  const iframeDoc = myTranslationIframeRef.current?.contentDocument;
-                                  if (iframeDoc) iframeDoc.execCommand('italic', false);
-                                }}
-                                style={{
-                                  padding: '4px 8px',
-                                  fontSize: '11px',
-                                  fontStyle: 'italic',
-                                  border: '1px solid #A9A9A9',
-                                  borderRadius: '3px',
-                                  backgroundColor: '#FFFFFF',
-                                  color: '#000000',
-                                  cursor: 'pointer',
-                                }}
-                                title="기울임 (Ctrl+I)"
-                              >
-                                I
-                              </button>
-                              <button
-                                onClick={() => {
-                                  const iframeDoc = myTranslationIframeRef.current?.contentDocument;
-                                  if (iframeDoc) iframeDoc.execCommand('underline', false);
-                                }}
-                                style={{
-                                  padding: '4px 8px',
-                                  fontSize: '11px',
-                                  textDecoration: 'underline',
-                                  border: '1px solid #A9A9A9',
-                                  borderRadius: '3px',
-                                  backgroundColor: '#FFFFFF',
-                                  color: '#000000',
-                                  cursor: 'pointer',
-                                }}
-                                title="밑줄 (Ctrl+U)"
-                              >
-                                U
-                              </button>
-                              <button
-                                onClick={() => {
-                                  const iframeDoc = myTranslationIframeRef.current?.contentDocument;
-                                  if (iframeDoc) iframeDoc.execCommand('strikeThrough', false);
-                                }}
-                                style={{
-                                  padding: '4px 8px',
-                                  fontSize: '11px',
-                                  textDecoration: 'line-through',
-                                  border: '1px solid #A9A9A9',
-                                  borderRadius: '3px',
-                                  backgroundColor: '#FFFFFF',
-                                  color: '#000000',
-                                  cursor: 'pointer',
-                                }}
-                                title="취소선"
-                              >
-                                S
-                              </button>
+	const handleHandover = () => {
+		setShowHandoverModal(true);
+	};
 
-                              <button
-                                onClick={() => {
-                                  const iframeDoc = myTranslationIframeRef.current?.contentDocument;
-                                  if (!iframeDoc) return;
-                                  iframeDoc.execCommand('removeFormat', false);
-                                  // removeFormat이 border-style:solid 만 남기는 문제 수정
-                                  setTimeout(() => {
-                                    iframeDoc.querySelectorAll('*').forEach((el) => {
-                                      const htmlEl = el as HTMLElement;
-                                      if (htmlEl.style && htmlEl.style.borderStyle === 'solid' && !htmlEl.style.borderWidth) {
-                                        htmlEl.style.borderWidth = '0';
-                                      }
-                                    });
-                                  }, 0);
-                                }}
-                                style={{
-                                  padding: '4px 8px',
-                                  fontSize: '11px',
-                                  fontWeight: 600,
-                                  border: '1px solid #A9A9A9',
-                                  borderRadius: '3px',
-                                  backgroundColor: '#FFFFFF',
-                                  color: '#000000',
-                                  cursor: 'pointer',
-                                }}
-                                title="서식 지우기 (선택 영역)"
-                              >
-                                서식 지우기
-                              </button>
+	const confirmHandover = async () => {
+		if (!documentId || !handoverMemo.trim()) {
+			alert("남은 작업 메모를 입력해주세요.");
+			return;
+		}
+		if (!savedTranslationHtml) {
+			alert("저장할 번역 내용이 없습니다.");
+			return;
+		}
 
-                              <div style={{ width: '1px', height: '20px', backgroundColor: '#C0C0C0', margin: '0 4px' }} />
-                              <select
-                                onChange={(e) => {
-                                  const iframeDoc = myTranslationIframeRef.current?.contentDocument;
-                                  if (iframeDoc && e.target.value) {
-                                    const fontSize = e.target.value;
-                                    const selection = iframeDoc.getSelection();
-                                    
-                                    // 선택된 텍스트가 있는지 확인
-                                    if (selection && selection.rangeCount > 0 && !selection.getRangeAt(0).collapsed) {
-                                      const range = selection.getRangeAt(0);
-                                      const selectedText = range.toString();
-                                      
-                                      // execCommand('insertHTML')을 사용하여 undo 스택에 기록
-                                      // 이 방법이 가장 안정적으로 undo/redo를 지원함
-                                      const spanHtml = `<span style="font-size: ${fontSize}pt;">${selectedText}</span>`;
-                                      
-                                      try {
-                                        // insertHTML이 지원되는 브라우저
-                                        iframeDoc.execCommand('insertHTML', false, spanHtml);
-                                      } catch (err) {
-                                        // insertHTML이 지원되지 않으면 수동으로 삽입
-                                        // 하지만 이 경우 undo 스택에 기록되지 않을 수 있음
-                                        range.deleteContents();
-                                        const tempDiv = iframeDoc.createElement('div');
-                                        tempDiv.innerHTML = spanHtml;
-                                        const fragment = iframeDoc.createDocumentFragment();
-                                        while (tempDiv.firstChild) {
-                                          fragment.appendChild(tempDiv.firstChild);
-                                        }
-                                        range.insertNode(fragment);
-                                        
-                                        // 선택 영역을 새로 삽입된 span으로 이동
-                                        range.setStartAfter(fragment.lastChild || range.startContainer);
-                                        range.collapse(false);
-                                        selection.removeAllRanges();
-                                        selection.addRange(range);
-                                      }
-                                    } else {
-                                      // 선택된 텍스트가 없으면 execCommand('fontSize') 사용
-                                      // 다음 입력에 적용될 스타일 설정
-                                      iframeDoc.execCommand('fontSize', false, '3');
-                                      
-                                      // 생성된 <font> 태그를 찾아서 변환
-                                      setTimeout(() => {
-                                        const fontSizeElements = iframeDoc.querySelectorAll('font[size="3"]');
-                                        if (fontSizeElements.length > 0) {
-                                          const lastElement = fontSizeElements[fontSizeElements.length - 1] as HTMLElement;
-                                          lastElement.style.fontSize = `${fontSize}pt`;
-                                          lastElement.removeAttribute('size');
-                                          
-                                          // <font>를 <span>으로 교체
-                                          const span = iframeDoc.createElement('span');
-                                          span.style.fontSize = `${fontSize}pt`;
-                                          span.innerHTML = lastElement.innerHTML;
-                                          
-                                          if (lastElement.parentNode) {
-                                            lastElement.parentNode.replaceChild(span, lastElement);
-                                          }
-                                        }
-                                      }, 0);
-                                    }
-                                    
-                                    e.target.value = ''; // 리셋
-                                  }
-                                }}
-                                style={{
-                                  fontSize: '11px',
-                                  padding: '4px 8px',
-                                  border: '1px solid #A9A9A9',
-                                  borderRadius: '3px',
-                                  backgroundColor: '#FFFFFF',
-                                  color: '#000000',
-                                  cursor: 'pointer',
-                                }}
-                                title="글자 크기 (pt)"
-                              >
-                                <option value="">크기</option>
-                                <option value="8">8pt</option>
-                                <option value="9">9pt</option>
-                                <option value="10">10pt</option>
-                                <option value="11">11pt</option>
-                                <option value="12">12pt</option>
-                                <option value="14">14pt</option>
-                                <option value="16">16pt</option>
-                                <option value="18">18pt</option>
-                                <option value="20">20pt</option>
-                                <option value="24">24pt</option>
-                                <option value="28">28pt</option>
-                                <option value="32">32pt</option>
-                                <option value="36">36pt</option>
-                                <option value="48">48pt</option>
-                                <option value="72">72pt</option>
-                              </select>
-                              <select
-                                onChange={(e) => {
-                                  const iframeDoc = myTranslationIframeRef.current?.contentDocument;
-                                  if (iframeDoc && e.target.value) {
-                                    const lineHeight = e.target.value;
-                                    const selection = iframeDoc.getSelection();
-                                    
-                                    if (selection && selection.rangeCount > 0) {
-                                      const range = selection.getRangeAt(0);
-                                      
-                                      // 블록 요소 찾기 (p, div, h1-h6, li 등)
-                                      let blockElement: HTMLElement | null = null;
-                                      
-                                      if (range.commonAncestorContainer.nodeType === 1) {
-                                        // Element 노드인 경우
-                                        blockElement = (range.commonAncestorContainer as HTMLElement).closest('p, div, h1, h2, h3, h4, h5, h6, li, blockquote, pre');
-                                      } else {
-                                        // Text 노드인 경우 부모 요소에서 찾기
-                                        blockElement = range.commonAncestorContainer.parentElement?.closest('p, div, h1, h2, h3, h4, h5, h6, li, blockquote, pre') || null;
-                                      }
-                                      
-                                      if (blockElement) {
-                                        // 블록 요소에 직접 line-height 스타일 적용
-                                        // execCommand를 사용하여 undo 스택에 기록하기 위해
-                                        // 블록 요소 전체를 선택하고 insertHTML로 교체
-                                        try {
-                                          // 선택 영역을 블록 요소 전체로 확장
-                                          const blockRange = iframeDoc.createRange();
-                                          blockRange.selectNodeContents(blockElement);
-                                          selection.removeAllRanges();
-                                          selection.addRange(blockRange);
-                                          
-                                          // 블록 요소의 HTML을 복사하여 line-height 적용
-                                          const originalHtml = blockElement.innerHTML;
-                                          const tagName = blockElement.tagName.toLowerCase();
-                                          const newHtml = `<${tagName} style="line-height: ${lineHeight};">${originalHtml}</${tagName}>`;
-                                          
-                                          // insertHTML로 교체 (undo 스택에 기록됨)
-                                          iframeDoc.execCommand('insertHTML', false, newHtml);
-                                        } catch (err) {
-                                          // insertHTML이 실패하면 직접 스타일 적용
-                                          blockElement.style.lineHeight = lineHeight;
-                                        }
-                                      } else {
-                                        // 블록 요소를 찾지 못한 경우, 현재 위치에 div 삽입
-                                        const div = iframeDoc.createElement('div');
-                                        div.style.lineHeight = lineHeight;
-                                        div.innerHTML = '&nbsp;';
-                                        
-                                        try {
-                                          iframeDoc.execCommand('insertHTML', false, div.outerHTML);
-                                        } catch (err) {
-                                          range.insertNode(div);
-                                        }
-                                      }
-                                    }
-                                    
-                                    e.target.value = ''; // 리셋
-                                  }
-                                }}
-                                style={{
-                                  fontSize: '11px',
-                                  padding: '4px 8px',
-                                  border: '1px solid #A9A9A9',
-                                  borderRadius: '3px',
-                                  backgroundColor: '#FFFFFF',
-                                  color: '#000000',
-                                  cursor: 'pointer',
-                                  marginLeft: '4px',
-                                }}
-                                title="줄간격"
-                              >
-                                <option value="">줄간격</option>
-                                <option value="1.0">1.0 (단일)</option>
-                                <option value="1.15">1.15</option>
-                                <option value="1.5">1.5 (기본)</option>
-                                <option value="1.75">1.75</option>
-                                <option value="2.0">2.0 (2배)</option>
-                                <option value="2.5">2.5</option>
-                                <option value="3.0">3.0</option>
-                              </select>
-                              <div style={{ position: 'relative', display: 'inline-block', width: '30px', height: '26px' }}>
-                              <input
-                                type="color"
-                                onChange={(e) => {
-                                  const iframeDoc = myTranslationIframeRef.current?.contentDocument;
-                                  if (iframeDoc) iframeDoc.execCommand('foreColor', false, e.target.value);
-                                }}
-                                style={{
-                                    position: 'absolute',
-                                    width: '100%',
-                                    height: '100%',
-                                    opacity: 0,
-                                    cursor: 'pointer',
-                                    zIndex: 2,
-                                  }}
-                                  title="글자 색상"
-                                />
-                                <button
-                                  style={{
-                                    position: 'absolute',
-                                    width: '100%',
-                                    height: '100%',
-                                  border: '1px solid #A9A9A9',
-                                  borderRadius: '3px',
-                                    backgroundColor: '#FFFFFF',
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    justifyContent: 'center',
-                                  cursor: 'pointer',
-                                    padding: 0,
-                                    pointerEvents: 'none',
-                                }}
-                                title="글자 색상"
-                                  disabled
-                                >
-                                  <Palette size={16} color="#000000" />
-                                </button>
-                              </div>
-                              <div style={{ position: 'relative', display: 'inline-block', width: '30px', height: '26px', marginLeft: '4px' }}>
-                                <input
-                                  type="color"
-                                  onChange={(e) => {
-                                    const iframeDoc = myTranslationIframeRef.current?.contentDocument;
-                                    if (iframeDoc) iframeDoc.execCommand('backColor', false, e.target.value);
-                                  }}
-                                  style={{
-                                    position: 'absolute',
-                                    width: '100%',
-                                    height: '100%',
-                                    opacity: 0,
-                                    cursor: 'pointer',
-                                    zIndex: 2,
-                                  }}
-                                  title="배경 색상"
-                                />
-                                <button
-                                  style={{
-                                    position: 'absolute',
-                                    width: '100%',
-                                    height: '100%',
-                                    border: '1px solid #A9A9A9',
-                                    borderRadius: '3px',
-                                    backgroundColor: '#FFFFFF',
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    justifyContent: 'center',
-                                    cursor: 'pointer',
-                                    padding: 0,
-                                    pointerEvents: 'none',
-                                  }}
-                                  title="배경 색상"
-                                  disabled
-                                >
-                                  <Highlighter size={16} color="#000000" />
-                                </button>
-                              </div>
-                              <div style={{ width: '1px', height: '20px', backgroundColor: '#C0C0C0', margin: '0 4px' }} />
-                              <button
-                                onClick={() => {
-                                  const iframeDoc = myTranslationIframeRef.current?.contentDocument;
-                                  if (iframeDoc) iframeDoc.execCommand('justifyLeft', false);
-                                }}
-                                style={{
-                                  padding: '4px 8px',
-                                  fontSize: '11px',
-                                  border: '1px solid #A9A9A9',
-                                  borderRadius: '3px',
-                                  backgroundColor: '#FFFFFF',
-                                  color: '#000000',
-                                  cursor: 'pointer',
-                                  display: 'flex',
-                                  alignItems: 'center',
-                                  justifyContent: 'center',
-                                }}
-                                title="왼쪽 정렬"
-                              >
-                                <AlignLeft size={16} />
-                              </button>
-                              <button
-                                onClick={() => {
-                                  const iframeDoc = myTranslationIframeRef.current?.contentDocument;
-                                  if (iframeDoc) iframeDoc.execCommand('justifyCenter', false);
-                                }}
-                                style={{
-                                  padding: '4px 8px',
-                                  fontSize: '11px',
-                                  border: '1px solid #A9A9A9',
-                                  borderRadius: '3px',
-                                  backgroundColor: '#FFFFFF',
-                                  color: '#000000',
-                                  cursor: 'pointer',
-                                  display: 'flex',
-                                  alignItems: 'center',
-                                  justifyContent: 'center',
-                                }}
-                                title="가운데 정렬"
-                              >
-                                <AlignCenter size={16} />
-                              </button>
-                              <button
-                                onClick={() => {
-                                  const iframeDoc = myTranslationIframeRef.current?.contentDocument;
-                                  if (iframeDoc) iframeDoc.execCommand('justifyRight', false);
-                                }}
-                                style={{
-                                  padding: '4px 8px',
-                                  fontSize: '11px',
-                                  border: '1px solid #A9A9A9',
-                                  borderRadius: '3px',
-                                  backgroundColor: '#FFFFFF',
-                                  color: '#000000',
-                                  cursor: 'pointer',
-                                  display: 'flex',
-                                  alignItems: 'center',
-                                  justifyContent: 'center',
-                                }}
-                                title="오른쪽 정렬"
-                              >
-                                <AlignRight size={16} />
-                              </button>
+		try {
+			setHandoverSubmitting(true);
+			try {
+				await translationWorkApi.saveTranslation(documentId, {
+					content: savedTranslationHtml,
+					completedParagraphs: Array.from(completedParagraphs),
+				});
+			} catch (saveErr: any) {
+				const msg =
+					(saveErr as any).response?.data?.message ??
+					(saveErr as any).message ??
+					(saveErr as any).response?.statusText ??
+					"서버 오류";
+				alert("저장 실패: " + msg);
+				return;
+			}
+			try {
+				await translationWorkApi.handover(documentId, {
+					memo: handoverMemo.trim(),
+					terms: handoverTerms.trim() || undefined,
+				});
+			} catch (handoverErr: any) {
+				const msg =
+					(handoverErr as any).response?.data?.message ??
+					(handoverErr as any).message ??
+					(handoverErr as any).response?.statusText ??
+					"서버 오류";
+				alert("인계 요청 실패: " + msg);
+				return;
+			}
+			alert("인계가 완료되었습니다.");
+			navigate(fromPath);
+		} finally {
+			setHandoverSubmitting(false);
+		}
+	};
 
-                              <button
-                                onClick={() => {
-                                  const iframeDoc = myTranslationIframeRef.current?.contentDocument;
-                                  if (iframeDoc) iframeDoc.execCommand('justifyFull', false);
-                                }}
-                                style={{
-                                  padding: '4px 8px',
-                                  fontSize: '11px',
-                                  border: '1px solid #A9A9A9',
-                                  borderRadius: '3px',
-                                  backgroundColor: '#FFFFFF',
-                                  color: '#000000',
-                                  cursor: 'pointer',
-                                  display: 'flex',
-                                  alignItems: 'center',
-                                  justifyContent: 'center',
-                                }}
-                                title="양쪽 정렬"
-                              >
-                                <AlignJustify size={16} />
-                              </button>
+	const handleComplete = async () => {
+		if (!documentId || !savedTranslationHtml) return;
 
-                              <div style={{ width: '1px', height: '20px', backgroundColor: '#C0C0C0', margin: '0 4px' }} />
-                              <button
-                                onClick={() => {
-                                  const iframeDoc = myTranslationIframeRef.current?.contentDocument;
-                                  if (iframeDoc) iframeDoc.execCommand('insertUnorderedList', false);
-                                }}
-                                style={{
-                                  padding: '4px 8px',
-                                  fontSize: '11px',
-                                  border: '1px solid #A9A9A9',
-                                  borderRadius: '3px',
-                                  backgroundColor: '#FFFFFF',
-                                  color: '#000000',
-                                  cursor: 'pointer',
-                                  display: 'flex',
-                                  alignItems: 'center',
-                                  justifyContent: 'center',
-                                }}
-                                title="글머리 기호 목록"
-                              >
-                                <List size={16} />
-                              </button>
-                              <button
-                                onClick={() => {
-                                  const iframeDoc = myTranslationIframeRef.current?.contentDocument;
-                                  if (iframeDoc) iframeDoc.execCommand('insertOrderedList', false);
-                                }}
-                                style={{
-                                  padding: '4px 8px',
-                                  fontSize: '11px',
-                                  border: '1px solid #A9A9A9',
-                                  borderRadius: '3px',
-                                  backgroundColor: '#FFFFFF',
-                                  color: '#000000',
-                                  cursor: 'pointer',
-                                  display: 'flex',
-                                  alignItems: 'center',
-                                  justifyContent: 'center',
-                                }}
-                                title="번호 매기기 목록"
-                              >
-                                <ListOrdered size={16} />
-                              </button>
-                              <button
-                                onClick={() => {
-                                  const iframeDoc = myTranslationIframeRef.current?.contentDocument;
-                                  if (iframeDoc) {
-                                    const url = prompt('링크 URL을 입력하세요:');
-                                    if (url) iframeDoc.execCommand('createLink', false, url);
-                                  }
-                                }}
-                                style={{
-                                  padding: '4px 8px',
-                                  fontSize: '11px',
-                                  border: '1px solid #A9A9A9',
-                                  borderRadius: '3px',
-                                  backgroundColor: '#FFFFFF',
-                                  color: '#000000',
-                                  cursor: 'pointer',
-                                  display: 'flex',
-                                  alignItems: 'center',
-                                  justifyContent: 'center',
-                                }}
-                                title="링크 삽입"
-                              >
-                                <Link2 size={16} />
-                              </button>
-                              <div style={{ width: '1px', height: '20px', backgroundColor: '#C0C0C0', margin: '0 4px' }} />
-                              <div style={{ position: 'relative', display: 'inline-block' }}>
-                                <input
-                                  type="file"
-                                  accept="image/*"
-                                  onChange={(e) => {
-                                    const file = e.target.files?.[0];
-                                    if (file) {
-                                      const reader = new FileReader();
-                                      reader.onload = (event) => {
-                                        const imageUrl = event.target?.result as string;
-                                        const iframeDoc = myTranslationIframeRef.current?.contentDocument;
-                                        if (iframeDoc && imageUrl) {
-                                          try {
-                                            iframeDoc.execCommand('insertHTML', false, `<img src="${imageUrl}" alt="" style="max-width: 100%; height: auto;" />`);
-                                          } catch (err) {
-                                            const selection = iframeDoc.getSelection();
-                                            if (selection && selection.rangeCount > 0) {
-                                              const range = selection.getRangeAt(0);
-                                              const img = iframeDoc.createElement('img');
-                                              img.src = imageUrl;
-                                              img.alt = '';
-                                              img.style.maxWidth = '100%';
-                                              img.style.height = 'auto';
-                                              range.insertNode(img);
-                                            }
-                                          }
-                                        }
-                                      };
-                                      reader.readAsDataURL(file);
-                                    }
-                                    // 같은 파일을 다시 선택할 수 있도록 리셋
-                                    e.target.value = '';
-                                  }}
-                                  style={{
-                                    position: 'absolute',
-                                    width: '100%',
-                                    height: '100%',
-                                    opacity: 0,
-                                    cursor: 'pointer',
-                                    zIndex: 2,
-                                  }}
-                                  title="이미지 삽입"
-                                />
-                                <button
-                                  style={{
-                                    padding: '4px 8px',
-                                    fontSize: '11px',
-                                    border: '1px solid #A9A9A9',
-                                    borderRadius: '3px',
-                                    backgroundColor: '#FFFFFF',
-                                    color: '#000000',
-                                    cursor: 'pointer',
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    justifyContent: 'center',
-                                    pointerEvents: 'none',
-                                  }}
-                                  title="이미지 삽입"
-                                  disabled
-                                >
-                                  <Image size={16} />
-                                </button>
-                              </div>
-                              <button
-                              onClick={() => {
-                                  const iframeDoc = myTranslationIframeRef.current?.contentDocument;
-                                  if (iframeDoc) {
-                                    // 코드 블록 삽입
-                                    try {
-                                      iframeDoc.execCommand('insertHTML', false, '<pre style="background-color: #f4f4f4; padding: 10px; border-radius: 4px; overflow-x: auto;"><code></code></pre>');
-                                    } catch (err) {
-                                      // insertHTML이 지원되지 않으면 formatBlock 사용
-                                      iframeDoc.execCommand('formatBlock', false, 'pre');
-                                      const selection = iframeDoc.getSelection();
-                                      if (selection && selection.rangeCount > 0) {
-                                        const range = selection.getRangeAt(0);
-                                        const preElement = range.commonAncestorContainer.nodeType === 1 
-                                          ? range.commonAncestorContainer as HTMLElement
-                                          : (range.commonAncestorContainer.parentElement as HTMLElement);
-                                        if (preElement && preElement.tagName === 'PRE') {
-                                          preElement.style.backgroundColor = '#f4f4f4';
-                                          preElement.style.padding = '10px';
-                                          preElement.style.borderRadius = '4px';
-                                          preElement.style.overflowX = 'auto';
-                                        }
-                                      }
-                                    }
-                                  }
-                                }}
-                                style={{
-                                  padding: '4px 8px',
-                                  fontSize: '11px',
-                                  border: '1px solid #A9A9A9',
-                                  borderRadius: '3px',
-                                  backgroundColor: '#FFFFFF',
-                                  color: '#000000',
-                                  cursor: 'pointer',
-                                  display: 'flex',
-                                  alignItems: 'center',
-                                  justifyContent: 'center',
-                                }}
-                                title="코드 블록"
-                              >
-                                <Code size={16} />
-                              </button>
-                              <div style={{ position: 'relative', display: 'inline-block' }} data-more-menu>
-                                <button
-                                  onClick={() => setShowMoreMenu(!showMoreMenu)}
-                                  style={{
-                                    padding: '4px 8px',
-                                    fontSize: '11px',
-                                    border: '1px solid #A9A9A9',
-                                    borderRadius: '3px',
-                                    backgroundColor: showMoreMenu ? '#E0E0E0' : '#FFFFFF',
-                                    color: '#000000',
-                                    cursor: 'pointer',
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    justifyContent: 'center',
-                                  }}
-                                  title="더보기"
-                                >
-                                  <MoreVertical size={16} />
-                                </button>
-                                {showMoreMenu && (
-                                  <div
-                                    style={{
-                                      position: 'absolute',
-                                      top: '100%',
-                                      right: 0,
-                                      marginTop: '4px',
-                                      backgroundColor: '#FFFFFF',
-                                      border: '1px solid #A9A9A9',
-                                      borderRadius: '4px',
-                                      boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
-                                      zIndex: 1000,
-                                      display: 'flex',
-                                      flexDirection: 'row',
-                                      gap: '4px',
-                                      padding: '4px',
-                                    }}
-                                    onClick={(e) => e.stopPropagation()}
-                                    data-more-menu
-                                  >
-                                    <button
-                                      onClick={() => {
-                                        const iframeDoc = myTranslationIframeRef.current?.contentDocument;
-                                        if (iframeDoc) {
-                                          iframeDoc.execCommand('formatBlock', false, 'blockquote');
-                                        }
-                                        setShowMoreMenu(false);
-                                      }}
-                                      style={{
-                                        padding: '4px 8px',
-                                        fontSize: '11px',
-                                        border: '1px solid #A9A9A9',
-                                        borderRadius: '3px',
-                                        backgroundColor: '#FFFFFF',
-                                        color: '#000000',
-                                        cursor: 'pointer',
-                                        display: 'flex',
-                                        alignItems: 'center',
-                                        justifyContent: 'center',
-                                      }}
-                                      title="인용문"
-                                    >
-                                      <Quote size={16} />
-                                    </button>
-                                    <button
-                                      onClick={() => {
-                                        const iframeDoc = myTranslationIframeRef.current?.contentDocument;
-                                        if (iframeDoc) {
-                                          iframeDoc.execCommand('insertHorizontalRule', false);
-                                        }
-                                        setShowMoreMenu(false);
-                                      }}
-                                      style={{
-                                        padding: '4px 8px',
-                                        fontSize: '11px',
-                                        border: '1px solid #A9A9A9',
-                                        borderRadius: '3px',
-                                        backgroundColor: '#FFFFFF',
-                                        color: '#000000',
-                                        cursor: 'pointer',
-                                        display: 'flex',
-                                        alignItems: 'center',
-                                        justifyContent: 'center',
-                                      }}
-                                      title="구분선"
-                                    >
-                                      <Minus size={16} />
-                                    </button>
-                                    <button
-                                      onClick={() => {
-                                        const iframeDoc = myTranslationIframeRef.current?.contentDocument;
-                                        if (iframeDoc) {
-                                          const rows = prompt('행 수를 입력하세요 (기본값: 3):', '3');
-                                          const cols = prompt('열 수를 입력하세요 (기본값: 3):', '3');
-                                          const rowCount = parseInt(rows || '3', 10);
-                                          const colCount = parseInt(cols || '3', 10);
-                                          
-                                          if (rowCount > 0 && colCount > 0) {
-                                            let tableHtml = '<table border="1" style="border-collapse: collapse; width: 100%;">';
-                                            for (let i = 0; i < rowCount; i++) {
-                                              tableHtml += '<tr>';
-                                              for (let j = 0; j < colCount; j++) {
-                                                tableHtml += '<td style="padding: 8px; border: 1px solid #000;">&nbsp;</td>';
-                                              }
-                                              tableHtml += '</tr>';
-                                            }
-                                            tableHtml += '</table>';
-                                            
-                                            try {
-                                              iframeDoc.execCommand('insertHTML', false, tableHtml);
-                                            } catch (err) {
-                                              const selection = iframeDoc.getSelection();
-                                              if (selection && selection.rangeCount > 0) {
-                                                const range = selection.getRangeAt(0);
-                                                const tempDiv = iframeDoc.createElement('div');
-                                                tempDiv.innerHTML = tableHtml;
-                                                const fragment = iframeDoc.createDocumentFragment();
-                                                while (tempDiv.firstChild) {
-                                                  fragment.appendChild(tempDiv.firstChild);
-                                                }
-                                                range.insertNode(fragment);
-                                              }
-                                            }
-                                          }
-                                        }
-                                        setShowMoreMenu(false);
-                                      }}
-                                      style={{
-                                        padding: '4px 8px',
-                                        fontSize: '11px',
-                                        border: '1px solid #A9A9A9',
-                                        borderRadius: '3px',
-                                        backgroundColor: '#FFFFFF',
-                                        color: '#000000',
-                                        cursor: 'pointer',
-                                        display: 'flex',
-                                        alignItems: 'center',
-                                        justifyContent: 'center',
-                                      }}
-                                      title="표"
-                                    >
-                                      <Table size={16} />
-                                    </button>
-                                    <button
-                                      onClick={() => {
-                                        const iframeDoc = myTranslationIframeRef.current?.contentDocument;
-                                        if (iframeDoc) {
-                                          const selection = iframeDoc.getSelection();
-                                          if (selection && selection.rangeCount > 0 && !selection.getRangeAt(0).collapsed) {
-                                            const range = selection.getRangeAt(0);
-                                            const selectedText = range.toString();
-                                            
-                                            try {
-                                              iframeDoc.execCommand('insertHTML', false, `<sup>${selectedText}</sup>`);
-                                            } catch (err) {
-                                              const sup = iframeDoc.createElement('sup');
-                                              sup.textContent = selectedText;
-                                              range.deleteContents();
-                                              range.insertNode(sup);
-                                            }
-                                          } else {
-                                            try {
-                                              iframeDoc.execCommand('insertHTML', false, '<sup></sup>');
-                                            } catch (err) {
-                                              const selection = iframeDoc.getSelection();
-                                              if (selection && selection.rangeCount > 0) {
-                                                const range = selection.getRangeAt(0);
-                                                const sup = iframeDoc.createElement('sup');
-                                                sup.innerHTML = '&nbsp;';
-                                                range.insertNode(sup);
-                                              }
-                                            }
-                                          }
-                                        }
-                                        setShowMoreMenu(false);
-                                      }}
-                                      style={{
-                                        padding: '4px 8px',
-                                        fontSize: '11px',
-                                        border: '1px solid #A9A9A9',
-                                        borderRadius: '3px',
-                                        backgroundColor: '#FFFFFF',
-                                        color: '#000000',
-                                        cursor: 'pointer',
-                                        display: 'flex',
-                                        alignItems: 'center',
-                                        justifyContent: 'center',
-                                      }}
-                                      title="위 첨자"
-                                    >
-                                      <Superscript size={16} />
-                                    </button>
-                                    <button
-                                      onClick={() => {
-                                        const iframeDoc = myTranslationIframeRef.current?.contentDocument;
-                                        if (iframeDoc) {
-                                          const selection = iframeDoc.getSelection();
-                                          if (selection && selection.rangeCount > 0 && !selection.getRangeAt(0).collapsed) {
-                                            const range = selection.getRangeAt(0);
-                                            const selectedText = range.toString();
-                                            
-                                            try {
-                                              iframeDoc.execCommand('insertHTML', false, `<sub>${selectedText}</sub>`);
-                                            } catch (err) {
-                                              const sub = iframeDoc.createElement('sub');
-                                              sub.textContent = selectedText;
-                                              range.deleteContents();
-                                              range.insertNode(sub);
-                                            }
-                                          } else {
-                                            try {
-                                              iframeDoc.execCommand('insertHTML', false, '<sub></sub>');
-                                            } catch (err) {
-                                              const selection = iframeDoc.getSelection();
-                                              if (selection && selection.rangeCount > 0) {
-                                                const range = selection.getRangeAt(0);
-                                                const sub = iframeDoc.createElement('sub');
-                                                sub.innerHTML = '&nbsp;';
-                                                range.insertNode(sub);
-                                              }
-                                            }
-                                          }
-                                        }
-                                        setShowMoreMenu(false);
-                                      }}
-                                      style={{
-                                        padding: '4px 8px',
-                                        fontSize: '11px',
-                                        border: '1px solid #A9A9A9',
-                                        borderRadius: '3px',
-                                        backgroundColor: '#FFFFFF',
-                                        color: '#000000',
-                                        cursor: 'pointer',
-                                        display: 'flex',
-                                        alignItems: 'center',
-                                        justifyContent: 'center',
-                                      }}
-                                      title="아래 첨자"
-                                    >
-                                      <Subscript size={16} />
-                                    </button>
-                                  </div>
-                          )}
-                        </div>
-                              <div style={{ width: '1px', height: '20px', backgroundColor: '#C0C0C0', margin: '0 4px' }} />
-                          <button
-                            onClick={() => {
-                              if (!myTranslationIframeRef.current) return;
-                              const iframeDoc = myTranslationIframeRef.current.contentDocument;
-                              if (!iframeDoc) return;
-                              
-                              if (editorMode === 'text') {
-                                // ⭐ 버튼 클릭 시 focus를 iframe body로 이동 (execCommand가 작동하려면 필요)
-                                iframeDoc.body.setAttribute('tabindex', '-1');
-                                iframeDoc.body.focus();
-                                
-                                iframeDoc.execCommand('undo', false);
-                                const updatedHtml = iframeDoc.documentElement.outerHTML;
-                                currentEditorHtmlRef.current = updatedHtml;
-                                // ⭐ setSavedTranslationHtml 제거 - Step 5와 동일하게 useEffect 재트리거 방지
-                                console.log('↩️ Undo (TranslationWork 텍스트 - 버튼)');
-                              } else {
-                                if (undoStackRef.current.length > 0) {
-                                  const previousHtml = undoStackRef.current.pop()!;
-                                  redoStackRef.current.push(currentEditorHtmlRef.current);
-                                  currentEditorHtmlRef.current = previousHtml;
-                                  iframeDoc.open();
-                                  iframeDoc.write(previousHtml);
-                                  iframeDoc.close();
-                                  setSavedTranslationHtml(previousHtml);
-                                  
-                                  // ⭐ savedTranslationHtml 의존성 배열에 추가되어 useEffect가 자동으로 재실행됨
-                                  // iframe에 포커스를 주어 키보드 이벤트가 계속 작동하도록 함
-                                  setTimeout(() => {
-                                    const newIframeDoc = myTranslationIframeRef.current?.contentDocument || myTranslationIframeRef.current?.contentWindow?.document;
-                                    if (newIframeDoc?.body) {
-                                      newIframeDoc.body.setAttribute('tabindex', '-1');
-                                      newIframeDoc.body.focus();
-                                    }
-                                  }, 50);
-                                }
-                              }
-                            }}
-                            style={{
-                              padding: '4px 8px',
-                              fontSize: '11px',
-                              border: '1px solid #A9A9A9',
-                              borderRadius: '3px',
-                              backgroundColor: '#FFFFFF',
-                              color: '#000000',
-                              cursor: 'pointer',
-                                  display: 'flex',
-                                  alignItems: 'center',
-                                  justifyContent: 'center',
-                            }}
-                                title="실행 취소 (Ctrl/Cmd+Z)"
-                          >
-                                <Undo2 size={16} color="#000000" />
-                          </button>
-                          <button
-                            onClick={() => {
-                              if (!myTranslationIframeRef.current) return;
-                              const iframeDoc = myTranslationIframeRef.current.contentDocument;
-                              if (!iframeDoc) return;
-                              
-                              if (editorMode === 'text') {
-                                // ⭐ 버튼 클릭 시 focus를 iframe body로 이동 (execCommand가 작동하려면 필요)
-                                iframeDoc.body.setAttribute('tabindex', '-1');
-                                iframeDoc.body.focus();
-                                
-                                iframeDoc.execCommand('redo', false);
-                                const updatedHtml = iframeDoc.documentElement.outerHTML;
-                                currentEditorHtmlRef.current = updatedHtml;
-                                // ⭐ setSavedTranslationHtml 제거 - Step 5와 동일하게 useEffect 재트리거 방지
-                                console.log('↪️ Redo (TranslationWork 텍스트 - 버튼)');
-                              } else {
-                                if (redoStackRef.current.length > 0) {
-                                  const nextHtml = redoStackRef.current.pop()!;
-                                  undoStackRef.current.push(currentEditorHtmlRef.current);
-                                  currentEditorHtmlRef.current = nextHtml;
-                                  iframeDoc.open();
-                                  iframeDoc.write(nextHtml);
-                                  iframeDoc.close();
-                                  setSavedTranslationHtml(nextHtml);
-                                  
-                                  // ⭐ savedTranslationHtml 의존성 배열에 추가되어 useEffect가 자동으로 재실행됨
-                                  // iframe에 포커스를 주어 키보드 이벤트가 계속 작동하도록 함
-                                  setTimeout(() => {
-                                    const newIframeDoc = myTranslationIframeRef.current?.contentDocument || myTranslationIframeRef.current?.contentWindow?.document;
-                                    if (newIframeDoc?.body) {
-                                      newIframeDoc.body.setAttribute('tabindex', '-1');
-                                      newIframeDoc.body.focus();
-                                    }
-                                  }, 50);
-                                }
-                              }
-                            }}
-                            style={{
-                              padding: '4px 8px',
-                              fontSize: '11px',
-                              border: '1px solid #A9A9A9',
-                              borderRadius: '3px',
-                              backgroundColor: '#FFFFFF',
-                              color: '#000000',
-                              cursor: 'pointer',
-                                  display: 'flex',
-                                  alignItems: 'center',
-                                  justifyContent: 'center',
-                            }}
-                                title="다시 실행 (Ctrl/Cmd+Y)"
-                          >
-                                <Redo2 size={16} color="#000000" />
-                          </button>
-                            </>
-                          )}
-                          
-                          {/* 컴포넌트 편집 모드 */}
-                          {editorMode === 'component' && selectedElements.length > 0 && (
-                            <>
-                              <span style={{ fontSize: '11px', color: '#696969', marginRight: '4px' }}>
-                                {selectedElements.length}개 선택됨
-                              </span>
-                              <Button
-                                variant="secondary"
-                                onClick={() => {
-                                  if (!myTranslationIframeRef.current) return;
-                                  const iframeDoc = myTranslationIframeRef.current.contentDocument;
-                                  if (!iframeDoc) return;
+		if (
+			!window.confirm(
+				"번역을 완료하시겠습니까? 완료 후 검토 대기 상태로 변경됩니다.",
+			)
+		) {
+			return;
+		}
 
-                                  // 선택된 요소들의 선택 상태 제거
-                                  selectedElements.forEach(el => {
-                                    el.classList.remove('component-selected');
-                                    el.style.outline = '';
-                                    el.style.boxShadow = '';
-                                    el.style.backgroundColor = '';
-                                    el.style.outlineOffset = '';
-                                  });
-                                  setSelectedElements([]);
-                                  console.log('🔄 전체 선택 취소:', selectedElements.length, '개');
-                                }}
-                                style={{ fontSize: '11px', padding: '4px 8px' }}
-                              >
-                                선택 취소
-                              </Button>
-                              <Button
-                                variant="primary"
-                                onClick={() => {
-                                  if (!myTranslationIframeRef.current) return;
-                                  const iframeDoc = myTranslationIframeRef.current.contentDocument;
-                                  if (!iframeDoc) return;
+		try {
+			await translationWorkApi.completeTranslation(documentId, {
+				content: savedTranslationHtml,
+				completedParagraphs: Array.from(completedParagraphs),
+			});
+			alert("번역이 완료되었습니다!");
+			navigate(fromPath);
+		} catch (error: any) {
+			alert(
+				"완료 처리 실패: " + (error.response?.data?.message || error.message),
+			);
+		}
+	};
 
-                                  // Undo Stack에 현재 상태 저장
-                                  undoStackRef.current.push(currentEditorHtmlRef.current);
-                                  redoStackRef.current = [];
+	if (loading) {
+		return (
+			<div
+				style={{
+					padding: "48px",
+					textAlign: "center",
+					color: colors.primaryText,
+				}}
+			>
+				로딩 중...
+			</div>
+		);
+	}
 
-                                  // 선택된 요소 삭제
-                                  selectedElements.forEach(el => el.remove());
-                                  setSelectedElements([]);
+	// 에러가 있거나, 필수 데이터가 없으면 에러 화면 표시
+	if (error || !document) {
+		return (
+			<div style={{ padding: "48px" }}>
+				<div
+					style={{
+						padding: "16px",
+						backgroundColor: "#F5F5F5",
+						border: `1px solid ${colors.border}`,
+						borderRadius: "8px",
+						color: colors.primaryText,
+						marginBottom: "16px",
+					}}
+				>
+					⚠️ {error || "문서를 불러올 수 없습니다."}
+				</div>
+				<div>
+					<Button variant="secondary" onClick={() => navigate(fromPath)}>
+						목록으로 돌아가기
+					</Button>
+				</div>
+			</div>
+		);
+	}
 
-                                  // 변경된 HTML 저장
-                                  const updatedHtml = iframeDoc.documentElement.outerHTML;
-                                  currentEditorHtmlRef.current = updatedHtml;
-                                  setSavedTranslationHtml(updatedHtml);
-                                  console.log('🗑️ 선택된 요소 삭제:', selectedElements.length, '개');
-                                  
-                                  // ⭐ 삭제 후 iframe에 포커스를 주어 키보드 단축키가 바로 작동하도록 함
-                                  setTimeout(() => {
-                                    // body에 tabIndex 설정하여 포커스 가능하게 만들기
-                                    if (iframeDoc.body) {
-                                      iframeDoc.body.setAttribute('tabindex', '-1');
-                                      iframeDoc.body.focus();
-                                    }
-                                    if (myTranslationIframeRef.current?.contentWindow) {
-                                      myTranslationIframeRef.current.contentWindow.focus();
-                                    }
-                                    myTranslationIframeRef.current?.focus();
-                                    console.log('🎯 TranslationWork iframe에 포커스 설정');
-                                  }, 100);
-                                }}
-                                style={{ fontSize: '11px', padding: '4px 8px' }}
-                              >
-                                삭제
-                              </Button>
-                            </>
-                          )}
-                        </div>
-                      </div>
-                      {/* iframe 에디터 */}
-                      <iframe
-                        ref={myTranslationIframeRef}
-                        srcDoc={savedTranslationHtml}
-                        style={{
-                          flex: 1,
-                          width: '100%',
-                          border: 'none',
-                          backgroundColor: '#FFFFFF',
-                        }}
-                        title="내 번역 에디터"
-                        onLoad={() => {
-                          const iframe = myTranslationIframeRef.current;
-                          if (!iframe) return;
-                          
-                          const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-                          if (!iframeDoc || !iframeDoc.body) return;
+	const adminSessionOwnerId = document.adminSessionUser?.id;
+	const isAdminSessionOwner =
+		adminSessionOwnerId != null &&
+		user != null &&
+		Number(adminSessionOwnerId) === Number(user.id);
+	const isCompletedOrReview = [
+		"PENDING_REVIEW",
+		"APPROVED",
+		"PUBLISHED",
+	].includes(document.status);
+	const adminSessionBlocking =
+		!!document.adminTranslationSessionActive &&
+		document.sourceDocumentId != null;
+	const translationLocked =
+		isCompletedOrReview || (adminSessionBlocking && !isAdminSessionOwner);
 
-                          try {
-                            // body를 편집 가능하게 설정
-                            iframeDoc.body.contentEditable = 'true';
-                            iframeDoc.body.style.padding = '16px';
-                            iframeDoc.body.style.wordWrap = 'break-word';
-                            
-                            // 편집 시 자동 저장 (debounce)
-                            let saveTimeout: NodeJS.Timeout;
-                            const handleInput = () => {
-                              clearTimeout(saveTimeout);
-                              saveTimeout = setTimeout(() => {
-                                if (iframeDoc.documentElement) {
-                                  const updatedHtml = iframeDoc.documentElement.outerHTML;
-                                  currentEditorHtmlRef.current = updatedHtml;
-                                  console.log('📝 편집 내용 임시 저장됨 (메모리)');
-                                }
-                              }, 500);
-                            };
-                            
-                            iframeDoc.body.addEventListener('input', handleInput);
-                            
-                            if (!hasRenderedMyTranslation.current) {
-                              hasRenderedMyTranslation.current = true;
-                              setIsTranslationEditorInitialized(true);
-                            }
-                            
-                            console.log(`✅ 내 번역 iframe 설정 완료 (문단 ${paragraphs.length}개, 완료 표시 기능 활성화)`);
-                          } catch (error) {
-                            console.error('내 번역 iframe 설정 실패:', error);
-                          }
-                        }}
-                      />
-                    </>
-                  ) : (
-                    // 원문 / AI 초벌 번역 패널 (iframe)
-                    panel.html ? (
-                      <iframe
-                        ref={panel.ref as React.RefObject<HTMLIFrameElement>}
-                        srcDoc={panel.html}
-                        style={{
-                          width: '100%',
-                          height: '100%',
-                          border: 'none',
-                          backgroundColor: '#FFFFFF',
-                        }}
-                        title={panel.title}
-                      />
-                    ) : (
-                      <div style={{ 
-                        display: 'flex', 
-                        alignItems: 'center', 
-                        justifyContent: 'center', 
-                        height: '100%',
-                        color: colors.secondaryText,
-                        fontSize: '13px'
-                      }}>
-                        {panel.id === 'original' ? '원문이 없습니다.' : 'AI 초벌 번역이 없습니다.'}
-                      </div>
-                    )
-                  )}
-                </div>
-              )}
-            </div>
-          );
-        })}
-        </div>
+	const toggleAllPanels = () => {
+		if (allPanelsCollapsed) {
+			// 모든 패널 펼치기
+			setCollapsedPanels(new Set());
+		} else {
+			// 모든 패널 접기
+			setCollapsedPanels(new Set(["original", "aiDraft", "myTranslation"]));
+		}
+		setAllPanelsCollapsed(!allPanelsCollapsed);
+	};
 
-        {/* 소통 채팅 사이드바 */}
-        {showChat && documentId && (
-          <div
-            style={{
-              width: '300px',
-              flexShrink: 0,
-              padding: '4px 4px 4px 0',
-              display: 'flex',
-              flexDirection: 'column',
-            }}
-          >
-            <DocumentChat documentId={documentId} height="100%" />
-          </div>
-        )}
-      </div>
+	// 상태 텍스트 변환
+	const getStatusText = (status: string) => {
+		const statusMap: Record<string, string> = {
+			DRAFT: "초안",
+			PENDING_TRANSLATION: "번역 대기",
+			IN_TRANSLATION: "번역 중",
+			PENDING_REVIEW: "검토 대기",
+			APPROVED: "승인됨",
+			PUBLISHED: "공개됨",
+		};
+		return statusMap[status] || status;
+	};
 
-      {/* 인계 메모 확인 모달 */}
-      {showHandoverInfoModal && document?.latestHandover && (() => {
-        const h = document.latestHandover!;
-        return (
-          <div
-            style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0, backgroundColor: 'rgba(0,0,0,0.5)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1100 }}
-            onClick={() => setShowHandoverInfoModal(false)}
-          >
-            <div
-              style={{ backgroundColor: colors.surface, padding: '24px', borderRadius: '8px', width: '500px', maxWidth: '90vw', border: `1px solid ${colors.border}`, maxHeight: '80vh', overflowY: 'auto' }}
-              onClick={(e) => e.stopPropagation()}
-            >
-              <h3 style={{ fontSize: '16px', fontWeight: 600, marginBottom: '20px', color: '#000000' }}>
-                📋 이전 번역자 인계 메모
-              </h3>
-              <div style={{ display: 'flex', flexDirection: 'column', gap: '14px', marginBottom: '24px' }}>
-                {h.handedOverBy && (
-                  <div>
-                    <span style={{ fontSize: '12px', color: colors.secondaryText, display: 'block', marginBottom: '4px' }}>인계자</span>
-                    <span style={{ fontSize: '13px', color: '#000000' }}>{h.handedOverBy.name}</span>
-                  </div>
-                )}
-                {h.handedOverAt && (
-                  <div>
-                    <span style={{ fontSize: '12px', color: colors.secondaryText, display: 'block', marginBottom: '4px' }}>인계 시각</span>
-                    <span style={{ fontSize: '13px', color: '#000000' }}>{new Date(h.handedOverAt).toLocaleString('ko-KR')}</span>
-                  </div>
-                )}
-                <div>
-                  <span style={{ fontSize: '12px', color: colors.secondaryText, display: 'block', marginBottom: '6px' }}>남은 작업 메모</span>
-                  <div style={{ fontSize: '13px', color: '#000000', whiteSpace: 'pre-wrap', lineHeight: '1.6', padding: '10px', backgroundColor: '#FFF9EC', border: '1px solid #FFE082', borderRadius: '4px' }}>
-                    {h.memo}
-                  </div>
-                </div>
-                {h.terms && (
-                  <div>
-                    <span style={{ fontSize: '12px', color: colors.secondaryText, display: 'block', marginBottom: '6px' }}>주의 용어/표현</span>
-                    <div style={{ fontSize: '13px', color: '#000000', whiteSpace: 'pre-wrap', lineHeight: '1.6', padding: '10px', backgroundColor: '#FFF9EC', border: '1px solid #FFE082', borderRadius: '4px' }}>
-                      {h.terms}
-                    </div>
-                  </div>
-                )}
-              </div>
-              <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
-                <Button variant="secondary" onClick={() => setShowHandoverInfoModal(false)} style={{ fontSize: '12px' }}>
-                  닫기
-                </Button>
-              </div>
-            </div>
-          </div>
-        );
-      })()}
+	return (
+		<div
+			style={{
+				display: "flex",
+				flexDirection: "column",
+				height: "100vh",
+				backgroundColor: colors.primaryBackground,
+			}}
+		>
+			{translationLocked && adminSessionBlocking && !isCompletedOrReview && (
+				<div
+					style={{
+						padding: "10px 24px",
+						backgroundColor: "#FFF3E0",
+						borderBottom: "1px solid #FFB74D",
+						fontSize: "13px",
+						color: "#5D4037",
+					}}
+				>
+					{document.adminSessionUser?.name
+						? `${document.adminSessionUser.name} 관리자`
+						: "관리자"}
+					가 이 원문 번역을 진행 중입니다. 임시 저장·번역 완료·인계는 관리자
+					작업이 끝난 뒤 가능합니다.
+				</div>
+			)}
+			{isCompletedOrReview && (
+				<div
+					style={{
+						padding: "10px 24px",
+						backgroundColor: "#E8F5E9",
+						borderBottom: "1px solid #A5D6A7",
+						fontSize: "13px",
+						color: "#2E7D32",
+					}}
+				>
+					이 문서는 {getStatusText(document.status)} 상태입니다. 조회만
+					가능합니다.
+				</div>
+			)}
+			{/* 상단 고정 바 */}
+			<div
+				style={{
+					padding: "12px 24px",
+					backgroundColor: colors.surface,
+					borderBottom: `1px solid ${colors.border}`,
+					display: "flex",
+					justifyContent: "space-between",
+					alignItems: "center",
+					gap: "16px",
+				}}
+			>
+				{/* 왼쪽: 뒤로가기 + 문서 정보 */}
+				<div
+					style={{
+						display: "flex",
+						alignItems: "center",
+						gap: "16px",
+						flex: 1,
+					}}
+				>
+					<Button
+						variant="secondary"
+						onClick={() => {
+							const hasUnsavedChanges = savedTranslationHtml !== lastSavedHtml;
+							if (hasUnsavedChanges) {
+								const confirmed = window.confirm(
+									"저장하지 않으면 변경사항이 사라집니다. 나가시겠습니까?",
+								);
+								if (!confirmed) return;
+							}
+							navigate(fromPath);
+						}}
+						style={{ fontSize: "12px", padding: "6px 12px" }}
+					>
+						← 뒤로가기
+					</Button>
 
-      {/* 인계 요청 모달 */}
-      {showHandoverModal && (
-        <div
-          style={{
-            position: 'fixed',
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            backgroundColor: 'rgba(0, 0, 0, 0.5)',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            zIndex: 1000,
-          }}
-          onClick={() => setShowHandoverModal(false)}
-        >
-          <div
-            style={{
-              backgroundColor: colors.surface,
-              padding: '24px',
-              borderRadius: '8px',
-              width: '500px',
-              maxWidth: '90vw',
-              border: `1px solid ${colors.border}`,
-            }}
-            onClick={(e) => e.stopPropagation()}
-          >
-            <h3 style={{ fontSize: '16px', fontWeight: 600, marginBottom: '16px' }}>
-              인계 요청
-            </h3>
+					{document && (
+						<div
+							style={{ display: "flex", flexDirection: "column", gap: "2px" }}
+						>
+							<div
+								style={{ fontSize: "14px", fontWeight: 600, color: "#000000" }}
+							>
+								{document.title}
+							</div>
+							<div
+								style={{ display: "flex", gap: "12px", alignItems: "center" }}
+							>
+								<span style={{ fontSize: "11px", color: colors.secondaryText }}>
+									{document.categoryId
+										? `카테고리 ${document.categoryId}`
+										: "미분류"}{" "}
+									· {getStatusText(document.status)}
+								</span>
+								{lockStatus?.lockedBy && (
+									<span
+										style={{ fontSize: "11px", color: colors.secondaryText }}
+									>
+										작업자: {lockStatus.lockedBy.name}
+									</span>
+								)}
+							</div>
+						</div>
+					)}
+				</div>
 
-            <div style={{ marginBottom: '16px' }}>
-              <label style={{ display: 'block', fontSize: '13px', marginBottom: '8px', color: colors.primaryText }}>
-                남은 작업 메모 *
-              </label>
-              <textarea
-                value={handoverMemo}
-                onChange={(e) => setHandoverMemo(e.target.value)}
-                placeholder="예: 15-30번 문단 남음, 전문 용어 주의 필요"
-                style={{
-                  width: '100%',
-                  minHeight: '80px',
-                  padding: '8px',
-                  border: `1px solid ${colors.border}`,
-                  borderRadius: '4px',
-                  fontSize: '13px',
-                  fontFamily: 'inherit',
-                  resize: 'vertical',
-                }}
-              />
-            </div>
+				{/* 인계 메모 확인 버튼 (인계 정보가 있을 때만) */}
+				{document?.latestHandover && (
+					<Button
+						variant="secondary"
+						onClick={() => setShowHandoverInfoModal(true)}
+						style={{
+							fontSize: "12px",
+							padding: "6px 14px",
+							color: "#FF6B00",
+							borderColor: "#FF6B00",
+							whiteSpace: "nowrap",
+						}}
+					>
+						📋 인계 메모 확인
+					</Button>
+				)}
 
-            <div style={{ marginBottom: '24px' }}>
-              <label style={{ display: 'block', fontSize: '13px', marginBottom: '8px', color: colors.primaryText }}>
-                주의 용어/표현 메모 (선택)
-              </label>
-              <textarea
-                value={handoverTerms}
-                onChange={(e) => setHandoverTerms(e.target.value)}
-                placeholder="예: 'API'는 그대로 유지, '서버'는 'server'로 표기"
-                style={{
-                  width: '100%',
-                  minHeight: '60px',
-                  padding: '8px',
-                  border: `1px solid ${colors.border}`,
-                  borderRadius: '4px',
-                  fontSize: '13px',
-                  fontFamily: 'inherit',
-                  resize: 'vertical',
-                }}
-              />
-            </div>
+				{/* 중앙: 문서 보기 옵션 (체크박스로 각 버전 표시/숨김) */}
+				<div
+					style={{
+						display: "flex",
+						alignItems: "center",
+						gap: "24px",
+						padding: "6px 16px",
+						backgroundColor: "#F8F9FA",
+						borderRadius: "6px",
+						border: "1px solid #D3D3D3",
+					}}
+				>
+					<span
+						style={{
+							fontSize: "12px",
+							fontWeight: 600,
+							color: colors.primaryText,
+						}}
+					>
+						문서 보기:
+					</span>
+					<label
+						style={{
+							display: "flex",
+							alignItems: "center",
+							gap: "8px",
+							fontSize: "13px",
+							cursor: "pointer",
+							fontWeight: 500,
+							color: "#7a4b00",
+						}}
+					>
+						<input
+							type="checkbox"
+							checked={showOriginalGlossary}
+							onChange={(e) => setShowOriginalGlossary(e.target.checked)}
+							style={{ cursor: "pointer", width: "16px", height: "16px" }}
+						/>
+						<span>Version 0 용어집 적용 구간 보기</span>
+					</label>
+					<label
+						style={{
+							display: "flex",
+							alignItems: "center",
+							gap: "8px",
+							fontSize: "13px",
+							cursor: "pointer",
+							fontWeight: 500,
+						}}
+					>
+						<input
+							type="checkbox"
+							checked={!collapsedPanels.has("original")}
+							onChange={() => togglePanel("original")}
+							style={{
+								cursor: "pointer",
+								width: "16px",
+								height: "16px",
+							}}
+						/>
+						<span style={{ color: "#000000" }}>원문 (Version 0)</span>
+					</label>
+					<label
+						style={{
+							display: "flex",
+							alignItems: "center",
+							gap: "8px",
+							fontSize: "13px",
+							cursor: "pointer",
+							fontWeight: 500,
+						}}
+					>
+						<input
+							type="checkbox"
+							checked={!collapsedPanels.has("aiDraft")}
+							onChange={() => togglePanel("aiDraft")}
+							style={{
+								cursor: "pointer",
+								width: "16px",
+								height: "16px",
+							}}
+						/>
+						<span style={{ color: "#000000" }}>AI 초벌 번역 (Version 1)</span>
+					</label>
+					<label
+						style={{
+							display: "flex",
+							alignItems: "center",
+							gap: "8px",
+							fontSize: "13px",
+							cursor: "pointer",
+							fontWeight: 500,
+						}}
+					>
+						<input
+							type="checkbox"
+							checked={!collapsedPanels.has("myTranslation")}
+							onChange={() => togglePanel("myTranslation")}
+							style={{
+								cursor: "pointer",
+								width: "16px",
+								height: "16px",
+							}}
+						/>
+						<span style={{ color: "#000000" }}>내 번역 (작업 중)</span>
+					</label>
+				</div>
 
-            <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
-              <Button
-                variant="secondary"
-                onClick={() => {
-                  setShowHandoverModal(false);
-                  setHandoverMemo('');
-                  setHandoverTerms('');
-                }}
-                style={{ fontSize: '12px' }}
-              >
-                취소
-              </Button>
-              <Button
-                variant="primary"
-                onClick={confirmHandover}
-                disabled={handoverSubmitting}
-                style={{ fontSize: '12px' }}
-              >
-                {handoverSubmitting ? '처리 중...' : '인계 요청'}
-              </Button>
-            </div>
-          </div>
-        </div>
-      )}
+				{/* 오른쪽: 채팅 토글 + 저장/완료 버튼 */}
+				<div style={{ display: "flex", gap: "8px" }}>
+					{/* 소통 채팅 토글 */}
+					<button
+						onClick={() => setShowChat((prev) => !prev)}
+						title="소통 채팅"
+						style={{
+							display: "flex",
+							alignItems: "center",
+							gap: "5px",
+							padding: "6px 12px",
+							fontSize: "12px",
+							fontWeight: 500,
+							border: `1px solid ${showChat ? "#3B82F6" : "#D1D5DB"}`,
+							borderRadius: "6px",
+							backgroundColor: showChat ? "#EFF6FF" : "#FFFFFF",
+							color: showChat ? "#3B82F6" : "#374151",
+							cursor: "pointer",
+							whiteSpace: "nowrap",
+						}}
+					>
+						💬 채팅
+					</button>
+					<Button
+						variant={translationLocked ? "disabled" : "secondary"}
+						onClick={async () => {
+							if (translationLocked) return;
+							if (!documentId) {
+								alert("⚠️ 문서 ID가 없습니다.");
+								return;
+							}
 
-      {/* 링크 편집 모달 */}
-      {showLinkModal && editingLink && (
-        <div
-          style={{
-            position: 'fixed',
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            backgroundColor: 'rgba(0, 0, 0, 0.5)',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            zIndex: 1000,
-          }}
-          onClick={() => {
-            setShowLinkModal(false);
-            setEditingLink(null);
-            setLinkUrl('');
-          }}
-        >
-          <div
-            style={{
-              backgroundColor: colors.surface,
-              padding: '24px',
-              borderRadius: '8px',
-              width: '400px',
-              maxWidth: '90vw',
-              border: `1px solid ${colors.border}`,
-            }}
-            onClick={(e) => e.stopPropagation()}
-          >
-            <h3 style={{ fontSize: '16px', fontWeight: 600, marginBottom: '16px' }}>
-              링크 편집
-            </h3>
-            
-            <div style={{ marginBottom: '16px' }}>
-              <label style={{ display: 'block', fontSize: '13px', marginBottom: '8px', color: colors.primaryText }}>
-                URL
-              </label>
-              <input
-                type="text"
-                value={linkUrl}
-                onChange={(e) => setLinkUrl(e.target.value)}
-                placeholder="https://example.com"
-                style={{
-                  width: '100%',
-                  padding: '8px',
-                  border: `1px solid ${colors.border}`,
-                  borderRadius: '4px',
-                  fontSize: '13px',
-                  fontFamily: 'inherit',
-                }}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') {
-                    e.preventDefault();
-                    const iframeDoc = myTranslationIframeRef.current?.contentDocument;
-                    if (iframeDoc && editingLink && linkUrl.trim()) {
-                      // execCommand를 사용하여 링크 URL 업데이트 (undo 스택에 기록)
-                      const selection = iframeDoc.getSelection();
-                      if (selection) {
-                        const range = iframeDoc.createRange();
-                        range.selectNodeContents(editingLink);
-                        selection.removeAllRanges();
-                        selection.addRange(range);
-                        
-                        // 기존 링크 삭제 후 새 링크 생성
-                        iframeDoc.execCommand('unlink', false);
-                        iframeDoc.execCommand('createLink', false, linkUrl.trim());
-                      }
-                    }
-                    setShowLinkModal(false);
-                    setEditingLink(null);
-                    setLinkUrl('');
-                  }
-                }}
-                autoFocus
-              />
-            </div>
+							try {
+								// iframe에서 최신 HTML 가져오기
+								const iframe = myTranslationIframeRef.current;
+								let contentToSave = savedTranslationHtml;
 
-            <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
-              <Button
-                variant="secondary"
-                onClick={() => {
-                  setShowLinkModal(false);
-                  setEditingLink(null);
-                  setLinkUrl('');
-                }}
-                style={{ fontSize: '12px' }}
-              >
-                취소
-              </Button>
-              <Button
-                variant="secondary"
-                onClick={() => {
-                  const iframeDoc = myTranslationIframeRef.current?.contentDocument;
-                  if (iframeDoc && editingLink) {
-                    // execCommand를 사용하여 링크 삭제 (undo 스택에 기록)
-                    const selection = iframeDoc.getSelection();
-                    if (selection) {
-                      const range = iframeDoc.createRange();
-                      range.selectNodeContents(editingLink);
-                      selection.removeAllRanges();
-                      selection.addRange(range);
-                      iframeDoc.execCommand('unlink', false);
-                    }
-                  }
-                  setShowLinkModal(false);
-                  setEditingLink(null);
-                  setLinkUrl('');
-                }}
-                style={{ fontSize: '12px', color: '#dc3545', borderColor: '#dc3545' }}
-              >
-                삭제
-              </Button>
-              <Button
-                variant="primary"
-                onClick={() => {
-                  const iframeDoc = myTranslationIframeRef.current?.contentDocument;
-                  if (iframeDoc && editingLink && linkUrl.trim()) {
-                    // execCommand를 사용하여 링크 URL 업데이트 (undo 스택에 기록)
-                    const selection = iframeDoc.getSelection();
-                    if (selection) {
-                      const range = iframeDoc.createRange();
-                      range.selectNodeContents(editingLink);
-                      selection.removeAllRanges();
-                      selection.addRange(range);
-                      
-                      // 기존 링크 삭제 후 새 링크 생성
-                      iframeDoc.execCommand('unlink', false);
-                      iframeDoc.execCommand('createLink', false, linkUrl.trim());
-                    }
-                  }
-                  setShowLinkModal(false);
-                  setEditingLink(null);
-                  setLinkUrl('');
-                }}
-                style={{ fontSize: '12px' }}
-              >
-                저장
-              </Button>
-            </div>
-          </div>
-        </div>
-      )}
-    </div>
-  );
+								if (iframe) {
+									const iframeDoc =
+										iframe.contentDocument || iframe.contentWindow?.document;
+									if (iframeDoc && iframeDoc.documentElement) {
+										contentToSave = iframeDoc.documentElement.outerHTML;
+										console.log(
+											"💾 iframe에서 최신 HTML 추출:",
+											contentToSave.substring(0, 100) + "...",
+										);
+									}
+								}
+
+								// 서버에 저장
+								await translationWorkApi.saveTranslation(documentId, {
+									content: contentToSave,
+									completedParagraphs: Array.from(completedParagraphs),
+								});
+
+								// 저장 후 상태 업데이트
+								setSavedTranslationHtml(contentToSave);
+								setLastSavedHtml(contentToSave);
+								currentEditorHtmlRef.current = contentToSave;
+
+								alert("✅ 저장되었습니다.");
+							} catch (error) {
+								console.error("저장 실패:", error);
+								alert("⚠️ 저장에 실패했습니다.");
+							}
+						}}
+						style={{ fontSize: "12px" }}
+					>
+						💾 저장하기
+					</Button>
+					<Button
+						variant={translationLocked ? "disabled" : "secondary"}
+						onClick={() => {
+							if (!translationLocked) handleHandover();
+						}}
+						style={{ fontSize: "12px" }}
+					>
+						인계 요청
+					</Button>
+					<Button
+						variant={translationLocked ? "disabled" : "primary"}
+						onClick={() => {
+							if (!translationLocked) handleComplete();
+						}}
+						style={{ fontSize: "12px" }}
+					>
+						번역 완료
+					</Button>
+				</div>
+			</div>
+
+			{/* 3단 레이아웃 + 채팅 사이드바 */}
+			<div style={{ display: "flex", height: "100%", overflow: "hidden" }}>
+				{/* 문서 패널 영역 */}
+				<div
+					style={{
+						flex: 1,
+						display: "flex",
+						gap: "4px",
+						padding: "4px",
+						overflow: "hidden",
+					}}
+				>
+					{[
+						{
+							id: "original",
+							title: "원문",
+							ref: originalIframeRef,
+							editable: false,
+							html: originalHtml,
+						},
+						{
+							id: "aiDraft",
+							title: "AI 초벌 번역",
+							ref: aiDraftIframeRef,
+							editable: false,
+							html: aiDraftHtml,
+						},
+						{
+							id: "myTranslation",
+							title: "내 번역",
+							ref: myTranslationIframeRef,
+							editable: true,
+							html: savedTranslationHtml,
+						},
+					].map((panel) => {
+						const isCollapsed = collapsedPanels.has(panel.id);
+						const isFullscreen = fullscreenPanel === panel.id;
+						const visiblePanels = [
+							"original",
+							"aiDraft",
+							"myTranslation",
+						].filter((id) => !collapsedPanels.has(id));
+						const hasFullscreen = fullscreenPanel !== null;
+						const isHidden = hasFullscreen && !isFullscreen;
+
+						if (isHidden) return null;
+
+						return (
+							<div
+								key={panel.id}
+								style={{
+									flex: isCollapsed
+										? "0 0 0"
+										: isFullscreen
+											? "1"
+											: `1 1 ${100 / visiblePanels.length}%`,
+									display: isCollapsed ? "none" : "flex",
+									flexDirection: "column",
+									transition: "flex 0.2s ease",
+									minWidth: isCollapsed ? "0" : "200px",
+								}}
+							>
+								{/* 패널 헤더 */}
+								<div
+									style={{
+										display: "flex",
+										justifyContent: "space-between",
+										alignItems: "center",
+										padding: "8px 12px",
+										backgroundColor: "#D3D3D3",
+										borderRadius: "4px 4px 0 0",
+										cursor: "default",
+										height: "36px",
+									}}
+								>
+									<span
+										style={{
+											fontSize: "12px",
+											fontWeight: 600,
+											color: "#000000",
+										}}
+									>
+										{panel.title}
+									</span>
+									<div
+										style={{
+											display: "flex",
+											alignItems: "center",
+											gap: "8px",
+										}}
+									>
+										<button
+											onClick={() => toggleFullscreen(panel.id)}
+											style={{
+												padding: "4px 8px",
+												fontSize: "11px",
+												border: "1px solid #A9A9A9",
+												borderRadius: "3px",
+												backgroundColor: "#FFFFFF",
+												color: "#000000",
+												cursor: "pointer",
+												fontWeight: 500,
+											}}
+											title={isFullscreen ? "확대 해제" : "전체화면 확대"}
+										>
+											{isFullscreen ? "축소" : "확대"}
+										</button>
+									</div>
+								</div>
+
+								{/* 패널 내용 */}
+								{
+									<div
+										style={{
+											flex: 1,
+											border: "1px solid #C0C0C0",
+											borderTop: "none",
+											borderRadius: "0 0 4px 4px",
+											overflow: "hidden",
+											backgroundColor: "#FFFFFF",
+											display: "flex",
+											flexDirection: "column",
+											position: "relative", // 오버레이를 위한 relative positioning
+										}}
+									>
+										{panel.id === "myTranslation" ? (
+											// 내 번역 패널 (iframe 기반 에디터 - HTML 구조 보존)
+											<>
+												{translationLocked && (
+													<div
+														style={{
+															position: "absolute",
+															inset: 0,
+															zIndex: 50,
+															backgroundColor: "rgba(255,255,255,0.82)",
+															display: "flex",
+															alignItems: "center",
+															justifyContent: "center",
+															fontSize: "13px",
+															color: "#555",
+															textAlign: "center",
+															padding: "16px",
+														}}
+													>
+														조회 전용 (편집 불가)
+													</div>
+												)}
+												{/* 편집 툴바 */}
+												<div
+													style={{
+														padding: "8px 12px",
+														borderBottom: "1px solid #C0C0C0",
+														display: "flex",
+														justifyContent: "flex-start",
+														alignItems: "center",
+														backgroundColor: "#F8F9FA",
+														flexWrap: "wrap",
+														gap: "8px",
+													}}
+												>
+													<div
+														style={{
+															display: "flex",
+															gap: "4px",
+															alignItems: "center",
+															flexWrap: "wrap",
+														}}
+													>
+														{/* 모드 선택 */}
+														<Button
+															variant={
+																editorMode === "text" ? "primary" : "secondary"
+															}
+															onClick={() => setEditorMode("text")}
+															style={{ fontSize: "11px", padding: "4px 8px" }}
+														>
+															텍스트 편집
+														</Button>
+														<Button
+															variant={
+																editorMode === "component"
+																	? "primary"
+																	: "secondary"
+															}
+															onClick={() => setEditorMode("component")}
+															style={{ fontSize: "11px", padding: "4px 8px" }}
+														>
+															컴포넌트 편집
+														</Button>
+
+														{/* Rich Text 기능 (텍스트 모드일 때만) */}
+														{editorMode === "text" && (
+															<>
+																<div
+																	style={{
+																		width: "1px",
+																		height: "20px",
+																		backgroundColor: "#C0C0C0",
+																		margin: "0 4px",
+																	}}
+																/>
+																<button
+																	onClick={() => {
+																		const iframeDoc =
+																			myTranslationIframeRef.current
+																				?.contentDocument;
+																		if (iframeDoc)
+																			iframeDoc.execCommand("bold", false);
+																	}}
+																	style={{
+																		padding: "4px 8px",
+																		fontSize: "11px",
+																		fontWeight: "bold",
+																		border: "1px solid #A9A9A9",
+																		borderRadius: "3px",
+																		backgroundColor: "#FFFFFF",
+																		color: "#000000",
+																		cursor: "pointer",
+																	}}
+																	title="굵게 (Ctrl+B)"
+																>
+																	B
+																</button>
+																<button
+																	onClick={() => {
+																		const iframeDoc =
+																			myTranslationIframeRef.current
+																				?.contentDocument;
+																		if (iframeDoc)
+																			iframeDoc.execCommand("italic", false);
+																	}}
+																	style={{
+																		padding: "4px 8px",
+																		fontSize: "11px",
+																		fontStyle: "italic",
+																		border: "1px solid #A9A9A9",
+																		borderRadius: "3px",
+																		backgroundColor: "#FFFFFF",
+																		color: "#000000",
+																		cursor: "pointer",
+																	}}
+																	title="기울임 (Ctrl+I)"
+																>
+																	I
+																</button>
+																<button
+																	onClick={() => {
+																		const iframeDoc =
+																			myTranslationIframeRef.current
+																				?.contentDocument;
+																		if (iframeDoc)
+																			iframeDoc.execCommand("underline", false);
+																	}}
+																	style={{
+																		padding: "4px 8px",
+																		fontSize: "11px",
+																		textDecoration: "underline",
+																		border: "1px solid #A9A9A9",
+																		borderRadius: "3px",
+																		backgroundColor: "#FFFFFF",
+																		color: "#000000",
+																		cursor: "pointer",
+																	}}
+																	title="밑줄 (Ctrl+U)"
+																>
+																	U
+																</button>
+																<button
+																	onClick={() => {
+																		const iframeDoc =
+																			myTranslationIframeRef.current
+																				?.contentDocument;
+																		if (iframeDoc)
+																			iframeDoc.execCommand(
+																				"strikeThrough",
+																				false,
+																			);
+																	}}
+																	style={{
+																		padding: "4px 8px",
+																		fontSize: "11px",
+																		textDecoration: "line-through",
+																		border: "1px solid #A9A9A9",
+																		borderRadius: "3px",
+																		backgroundColor: "#FFFFFF",
+																		color: "#000000",
+																		cursor: "pointer",
+																	}}
+																	title="취소선"
+																>
+																	S
+																</button>
+
+																<button
+																	onClick={() => {
+																		const iframeDoc =
+																			myTranslationIframeRef.current
+																				?.contentDocument;
+																		if (!iframeDoc) return;
+																		iframeDoc.execCommand(
+																			"removeFormat",
+																			false,
+																		);
+																		// removeFormat이 border-style:solid 만 남기는 문제 수정
+																		setTimeout(() => {
+																			iframeDoc
+																				.querySelectorAll("*")
+																				.forEach((el) => {
+																					const htmlEl = el as HTMLElement;
+																					if (
+																						htmlEl.style &&
+																						htmlEl.style.borderStyle ===
+																							"solid" &&
+																						!htmlEl.style.borderWidth
+																					) {
+																						htmlEl.style.borderWidth = "0";
+																					}
+																				});
+																		}, 0);
+																	}}
+																	style={{
+																		padding: "4px 8px",
+																		fontSize: "11px",
+																		fontWeight: 600,
+																		border: "1px solid #A9A9A9",
+																		borderRadius: "3px",
+																		backgroundColor: "#FFFFFF",
+																		color: "#000000",
+																		cursor: "pointer",
+																	}}
+																	title="서식 지우기 (선택 영역)"
+																>
+																	서식 지우기
+																</button>
+
+																<div
+																	style={{
+																		width: "1px",
+																		height: "20px",
+																		backgroundColor: "#C0C0C0",
+																		margin: "0 4px",
+																	}}
+																/>
+																<select
+																	onChange={(e) => {
+																		const iframeDoc =
+																			myTranslationIframeRef.current
+																				?.contentDocument;
+																		if (iframeDoc && e.target.value) {
+																			const fontSize = e.target.value;
+																			const selection =
+																				iframeDoc.getSelection();
+
+																			// 선택된 텍스트가 있는지 확인
+																			if (
+																				selection &&
+																				selection.rangeCount > 0 &&
+																				!selection.getRangeAt(0).collapsed
+																			) {
+																				const range = selection.getRangeAt(0);
+																				const selectedText = range.toString();
+
+																				// execCommand('insertHTML')을 사용하여 undo 스택에 기록
+																				// 이 방법이 가장 안정적으로 undo/redo를 지원함
+																				const spanHtml = `<span style="font-size: ${fontSize}pt;">${selectedText}</span>`;
+
+																				try {
+																					// insertHTML이 지원되는 브라우저
+																					iframeDoc.execCommand(
+																						"insertHTML",
+																						false,
+																						spanHtml,
+																					);
+																				} catch (err) {
+																					// insertHTML이 지원되지 않으면 수동으로 삽입
+																					// 하지만 이 경우 undo 스택에 기록되지 않을 수 있음
+																					range.deleteContents();
+																					const tempDiv =
+																						iframeDoc.createElement("div");
+																					tempDiv.innerHTML = spanHtml;
+																					const fragment =
+																						iframeDoc.createDocumentFragment();
+																					while (tempDiv.firstChild) {
+																						fragment.appendChild(
+																							tempDiv.firstChild,
+																						);
+																					}
+																					range.insertNode(fragment);
+
+																					// 선택 영역을 새로 삽입된 span으로 이동
+																					range.setStartAfter(
+																						fragment.lastChild ||
+																							range.startContainer,
+																					);
+																					range.collapse(false);
+																					selection.removeAllRanges();
+																					selection.addRange(range);
+																				}
+																			} else {
+																				// 선택된 텍스트가 없으면 execCommand('fontSize') 사용
+																				// 다음 입력에 적용될 스타일 설정
+																				iframeDoc.execCommand(
+																					"fontSize",
+																					false,
+																					"3",
+																				);
+
+																				// 생성된 <font> 태그를 찾아서 변환
+																				setTimeout(() => {
+																					const fontSizeElements =
+																						iframeDoc.querySelectorAll(
+																							'font[size="3"]',
+																						);
+																					if (fontSizeElements.length > 0) {
+																						const lastElement =
+																							fontSizeElements[
+																								fontSizeElements.length - 1
+																							] as HTMLElement;
+																						lastElement.style.fontSize = `${fontSize}pt`;
+																						lastElement.removeAttribute("size");
+
+																						// <font>를 <span>으로 교체
+																						const span =
+																							iframeDoc.createElement("span");
+																						span.style.fontSize = `${fontSize}pt`;
+																						span.innerHTML =
+																							lastElement.innerHTML;
+
+																						if (lastElement.parentNode) {
+																							lastElement.parentNode.replaceChild(
+																								span,
+																								lastElement,
+																							);
+																						}
+																					}
+																				}, 0);
+																			}
+
+																			e.target.value = ""; // 리셋
+																		}
+																	}}
+																	style={{
+																		fontSize: "11px",
+																		padding: "4px 8px",
+																		border: "1px solid #A9A9A9",
+																		borderRadius: "3px",
+																		backgroundColor: "#FFFFFF",
+																		color: "#000000",
+																		cursor: "pointer",
+																	}}
+																	title="글자 크기 (pt)"
+																>
+																	<option value="">크기</option>
+																	<option value="8">8pt</option>
+																	<option value="9">9pt</option>
+																	<option value="10">10pt</option>
+																	<option value="11">11pt</option>
+																	<option value="12">12pt</option>
+																	<option value="14">14pt</option>
+																	<option value="16">16pt</option>
+																	<option value="18">18pt</option>
+																	<option value="20">20pt</option>
+																	<option value="24">24pt</option>
+																	<option value="28">28pt</option>
+																	<option value="32">32pt</option>
+																	<option value="36">36pt</option>
+																	<option value="48">48pt</option>
+																	<option value="72">72pt</option>
+																</select>
+																<select
+																	onChange={(e) => {
+																		const iframeDoc =
+																			myTranslationIframeRef.current
+																				?.contentDocument;
+																		if (iframeDoc && e.target.value) {
+																			const lineHeight = e.target.value;
+																			const selection =
+																				iframeDoc.getSelection();
+
+																			if (
+																				selection &&
+																				selection.rangeCount > 0
+																			) {
+																				const range = selection.getRangeAt(0);
+
+																				// 블록 요소 찾기 (p, div, h1-h6, li 등)
+																				let blockElement: HTMLElement | null =
+																					null;
+
+																				if (
+																					range.commonAncestorContainer
+																						.nodeType === 1
+																				) {
+																					// Element 노드인 경우
+																					blockElement = (
+																						range.commonAncestorContainer as HTMLElement
+																					).closest(
+																						"p, div, h1, h2, h3, h4, h5, h6, li, blockquote, pre",
+																					);
+																				} else {
+																					// Text 노드인 경우 부모 요소에서 찾기
+																					blockElement =
+																						range.commonAncestorContainer.parentElement?.closest(
+																							"p, div, h1, h2, h3, h4, h5, h6, li, blockquote, pre",
+																						) || null;
+																				}
+
+																				if (blockElement) {
+																					// 블록 요소에 직접 line-height 스타일 적용
+																					// execCommand를 사용하여 undo 스택에 기록하기 위해
+																					// 블록 요소 전체를 선택하고 insertHTML로 교체
+																					try {
+																						// 선택 영역을 블록 요소 전체로 확장
+																						const blockRange =
+																							iframeDoc.createRange();
+																						blockRange.selectNodeContents(
+																							blockElement,
+																						);
+																						selection.removeAllRanges();
+																						selection.addRange(blockRange);
+
+																						// 블록 요소의 HTML을 복사하여 line-height 적용
+																						const originalHtml =
+																							blockElement.innerHTML;
+																						const tagName =
+																							blockElement.tagName.toLowerCase();
+																						const newHtml = `<${tagName} style="line-height: ${lineHeight};">${originalHtml}</${tagName}>`;
+
+																						// insertHTML로 교체 (undo 스택에 기록됨)
+																						iframeDoc.execCommand(
+																							"insertHTML",
+																							false,
+																							newHtml,
+																						);
+																					} catch (err) {
+																						// insertHTML이 실패하면 직접 스타일 적용
+																						blockElement.style.lineHeight =
+																							lineHeight;
+																					}
+																				} else {
+																					// 블록 요소를 찾지 못한 경우, 현재 위치에 div 삽입
+																					const div =
+																						iframeDoc.createElement("div");
+																					div.style.lineHeight = lineHeight;
+																					div.innerHTML = "&nbsp;";
+
+																					try {
+																						iframeDoc.execCommand(
+																							"insertHTML",
+																							false,
+																							div.outerHTML,
+																						);
+																					} catch (err) {
+																						range.insertNode(div);
+																					}
+																				}
+																			}
+
+																			e.target.value = ""; // 리셋
+																		}
+																	}}
+																	style={{
+																		fontSize: "11px",
+																		padding: "4px 8px",
+																		border: "1px solid #A9A9A9",
+																		borderRadius: "3px",
+																		backgroundColor: "#FFFFFF",
+																		color: "#000000",
+																		cursor: "pointer",
+																		marginLeft: "4px",
+																	}}
+																	title="줄간격"
+																>
+																	<option value="">줄간격</option>
+																	<option value="1.0">1.0 (단일)</option>
+																	<option value="1.15">1.15</option>
+																	<option value="1.5">1.5 (기본)</option>
+																	<option value="1.75">1.75</option>
+																	<option value="2.0">2.0 (2배)</option>
+																	<option value="2.5">2.5</option>
+																	<option value="3.0">3.0</option>
+																</select>
+																<div
+																	style={{
+																		position: "relative",
+																		display: "inline-block",
+																		width: "30px",
+																		height: "26px",
+																	}}
+																>
+																	<input
+																		type="color"
+																		onChange={(e) => {
+																			const iframeDoc =
+																				myTranslationIframeRef.current
+																					?.contentDocument;
+																			if (iframeDoc)
+																				iframeDoc.execCommand(
+																					"foreColor",
+																					false,
+																					e.target.value,
+																				);
+																		}}
+																		style={{
+																			position: "absolute",
+																			width: "100%",
+																			height: "100%",
+																			opacity: 0,
+																			cursor: "pointer",
+																			zIndex: 2,
+																		}}
+																		title="글자 색상"
+																	/>
+																	<button
+																		style={{
+																			position: "absolute",
+																			width: "100%",
+																			height: "100%",
+																			border: "1px solid #A9A9A9",
+																			borderRadius: "3px",
+																			backgroundColor: "#FFFFFF",
+																			display: "flex",
+																			alignItems: "center",
+																			justifyContent: "center",
+																			cursor: "pointer",
+																			padding: 0,
+																			pointerEvents: "none",
+																		}}
+																		title="글자 색상"
+																		disabled
+																	>
+																		<Palette size={16} color="#000000" />
+																	</button>
+																</div>
+																<div
+																	style={{
+																		position: "relative",
+																		display: "inline-block",
+																		width: "30px",
+																		height: "26px",
+																		marginLeft: "4px",
+																	}}
+																>
+																	<input
+																		type="color"
+																		onChange={(e) => {
+																			const iframeDoc =
+																				myTranslationIframeRef.current
+																					?.contentDocument;
+																			if (iframeDoc)
+																				iframeDoc.execCommand(
+																					"backColor",
+																					false,
+																					e.target.value,
+																				);
+																		}}
+																		style={{
+																			position: "absolute",
+																			width: "100%",
+																			height: "100%",
+																			opacity: 0,
+																			cursor: "pointer",
+																			zIndex: 2,
+																		}}
+																		title="배경 색상"
+																	/>
+																	<button
+																		style={{
+																			position: "absolute",
+																			width: "100%",
+																			height: "100%",
+																			border: "1px solid #A9A9A9",
+																			borderRadius: "3px",
+																			backgroundColor: "#FFFFFF",
+																			display: "flex",
+																			alignItems: "center",
+																			justifyContent: "center",
+																			cursor: "pointer",
+																			padding: 0,
+																			pointerEvents: "none",
+																		}}
+																		title="배경 색상"
+																		disabled
+																	>
+																		<Highlighter size={16} color="#000000" />
+																	</button>
+																</div>
+																<div
+																	style={{
+																		width: "1px",
+																		height: "20px",
+																		backgroundColor: "#C0C0C0",
+																		margin: "0 4px",
+																	}}
+																/>
+																<button
+																	onClick={() => {
+																		const iframeDoc =
+																			myTranslationIframeRef.current
+																				?.contentDocument;
+																		if (iframeDoc)
+																			iframeDoc.execCommand(
+																				"justifyLeft",
+																				false,
+																			);
+																	}}
+																	style={{
+																		padding: "4px 8px",
+																		fontSize: "11px",
+																		border: "1px solid #A9A9A9",
+																		borderRadius: "3px",
+																		backgroundColor: "#FFFFFF",
+																		color: "#000000",
+																		cursor: "pointer",
+																		display: "flex",
+																		alignItems: "center",
+																		justifyContent: "center",
+																	}}
+																	title="왼쪽 정렬"
+																>
+																	<AlignLeft size={16} />
+																</button>
+																<button
+																	onClick={() => {
+																		const iframeDoc =
+																			myTranslationIframeRef.current
+																				?.contentDocument;
+																		if (iframeDoc)
+																			iframeDoc.execCommand(
+																				"justifyCenter",
+																				false,
+																			);
+																	}}
+																	style={{
+																		padding: "4px 8px",
+																		fontSize: "11px",
+																		border: "1px solid #A9A9A9",
+																		borderRadius: "3px",
+																		backgroundColor: "#FFFFFF",
+																		color: "#000000",
+																		cursor: "pointer",
+																		display: "flex",
+																		alignItems: "center",
+																		justifyContent: "center",
+																	}}
+																	title="가운데 정렬"
+																>
+																	<AlignCenter size={16} />
+																</button>
+																<button
+																	onClick={() => {
+																		const iframeDoc =
+																			myTranslationIframeRef.current
+																				?.contentDocument;
+																		if (iframeDoc)
+																			iframeDoc.execCommand(
+																				"justifyRight",
+																				false,
+																			);
+																	}}
+																	style={{
+																		padding: "4px 8px",
+																		fontSize: "11px",
+																		border: "1px solid #A9A9A9",
+																		borderRadius: "3px",
+																		backgroundColor: "#FFFFFF",
+																		color: "#000000",
+																		cursor: "pointer",
+																		display: "flex",
+																		alignItems: "center",
+																		justifyContent: "center",
+																	}}
+																	title="오른쪽 정렬"
+																>
+																	<AlignRight size={16} />
+																</button>
+
+																<button
+																	onClick={() => {
+																		const iframeDoc =
+																			myTranslationIframeRef.current
+																				?.contentDocument;
+																		if (iframeDoc)
+																			iframeDoc.execCommand(
+																				"justifyFull",
+																				false,
+																			);
+																	}}
+																	style={{
+																		padding: "4px 8px",
+																		fontSize: "11px",
+																		border: "1px solid #A9A9A9",
+																		borderRadius: "3px",
+																		backgroundColor: "#FFFFFF",
+																		color: "#000000",
+																		cursor: "pointer",
+																		display: "flex",
+																		alignItems: "center",
+																		justifyContent: "center",
+																	}}
+																	title="양쪽 정렬"
+																>
+																	<AlignJustify size={16} />
+																</button>
+
+																<div
+																	style={{
+																		width: "1px",
+																		height: "20px",
+																		backgroundColor: "#C0C0C0",
+																		margin: "0 4px",
+																	}}
+																/>
+																<button
+																	onClick={() => {
+																		const iframeDoc =
+																			myTranslationIframeRef.current
+																				?.contentDocument;
+																		if (iframeDoc)
+																			iframeDoc.execCommand(
+																				"insertUnorderedList",
+																				false,
+																			);
+																	}}
+																	style={{
+																		padding: "4px 8px",
+																		fontSize: "11px",
+																		border: "1px solid #A9A9A9",
+																		borderRadius: "3px",
+																		backgroundColor: "#FFFFFF",
+																		color: "#000000",
+																		cursor: "pointer",
+																		display: "flex",
+																		alignItems: "center",
+																		justifyContent: "center",
+																	}}
+																	title="글머리 기호 목록"
+																>
+																	<List size={16} />
+																</button>
+																<button
+																	onClick={() => {
+																		const iframeDoc =
+																			myTranslationIframeRef.current
+																				?.contentDocument;
+																		if (iframeDoc)
+																			iframeDoc.execCommand(
+																				"insertOrderedList",
+																				false,
+																			);
+																	}}
+																	style={{
+																		padding: "4px 8px",
+																		fontSize: "11px",
+																		border: "1px solid #A9A9A9",
+																		borderRadius: "3px",
+																		backgroundColor: "#FFFFFF",
+																		color: "#000000",
+																		cursor: "pointer",
+																		display: "flex",
+																		alignItems: "center",
+																		justifyContent: "center",
+																	}}
+																	title="번호 매기기 목록"
+																>
+																	<ListOrdered size={16} />
+																</button>
+																<button
+																	onClick={() => {
+																		const iframeDoc =
+																			myTranslationIframeRef.current
+																				?.contentDocument;
+																		if (iframeDoc) {
+																			const url = prompt(
+																				"링크 URL을 입력하세요:",
+																			);
+																			if (url)
+																				iframeDoc.execCommand(
+																					"createLink",
+																					false,
+																					url,
+																				);
+																		}
+																	}}
+																	style={{
+																		padding: "4px 8px",
+																		fontSize: "11px",
+																		border: "1px solid #A9A9A9",
+																		borderRadius: "3px",
+																		backgroundColor: "#FFFFFF",
+																		color: "#000000",
+																		cursor: "pointer",
+																		display: "flex",
+																		alignItems: "center",
+																		justifyContent: "center",
+																	}}
+																	title="링크 삽입"
+																>
+																	<Link2 size={16} />
+																</button>
+																<div
+																	style={{
+																		width: "1px",
+																		height: "20px",
+																		backgroundColor: "#C0C0C0",
+																		margin: "0 4px",
+																	}}
+																/>
+																<div
+																	style={{
+																		position: "relative",
+																		display: "inline-block",
+																	}}
+																>
+																	<input
+																		type="file"
+																		accept="image/*"
+																		onChange={(e) => {
+																			const file = e.target.files?.[0];
+																			if (file) {
+																				const reader = new FileReader();
+																				reader.onload = (event) => {
+																					const imageUrl = event.target
+																						?.result as string;
+																					const iframeDoc =
+																						myTranslationIframeRef.current
+																							?.contentDocument;
+																					if (iframeDoc && imageUrl) {
+																						try {
+																							iframeDoc.execCommand(
+																								"insertHTML",
+																								false,
+																								`<img src="${imageUrl}" alt="" style="max-width: 100%; height: auto;" />`,
+																							);
+																						} catch (err) {
+																							const selection =
+																								iframeDoc.getSelection();
+																							if (
+																								selection &&
+																								selection.rangeCount > 0
+																							) {
+																								const range =
+																									selection.getRangeAt(0);
+																								const img =
+																									iframeDoc.createElement(
+																										"img",
+																									);
+																								img.src = imageUrl;
+																								img.alt = "";
+																								img.style.maxWidth = "100%";
+																								img.style.height = "auto";
+																								range.insertNode(img);
+																							}
+																						}
+																					}
+																				};
+																				reader.readAsDataURL(file);
+																			}
+																			// 같은 파일을 다시 선택할 수 있도록 리셋
+																			e.target.value = "";
+																		}}
+																		style={{
+																			position: "absolute",
+																			width: "100%",
+																			height: "100%",
+																			opacity: 0,
+																			cursor: "pointer",
+																			zIndex: 2,
+																		}}
+																		title="이미지 삽입"
+																	/>
+																	<button
+																		style={{
+																			padding: "4px 8px",
+																			fontSize: "11px",
+																			border: "1px solid #A9A9A9",
+																			borderRadius: "3px",
+																			backgroundColor: "#FFFFFF",
+																			color: "#000000",
+																			cursor: "pointer",
+																			display: "flex",
+																			alignItems: "center",
+																			justifyContent: "center",
+																			pointerEvents: "none",
+																		}}
+																		title="이미지 삽입"
+																		disabled
+																	>
+																		<Image size={16} />
+																	</button>
+																</div>
+																<button
+																	onClick={() => {
+																		const iframeDoc =
+																			myTranslationIframeRef.current
+																				?.contentDocument;
+																		if (iframeDoc) {
+																			// 코드 블록 삽입
+																			try {
+																				iframeDoc.execCommand(
+																					"insertHTML",
+																					false,
+																					'<pre style="background-color: #f4f4f4; padding: 10px; border-radius: 4px; overflow-x: auto;"><code></code></pre>',
+																				);
+																			} catch (err) {
+																				// insertHTML이 지원되지 않으면 formatBlock 사용
+																				iframeDoc.execCommand(
+																					"formatBlock",
+																					false,
+																					"pre",
+																				);
+																				const selection =
+																					iframeDoc.getSelection();
+																				if (
+																					selection &&
+																					selection.rangeCount > 0
+																				) {
+																					const range = selection.getRangeAt(0);
+																					const preElement =
+																						range.commonAncestorContainer
+																							.nodeType === 1
+																							? (range.commonAncestorContainer as HTMLElement)
+																							: (range.commonAncestorContainer
+																									.parentElement as HTMLElement);
+																					if (
+																						preElement &&
+																						preElement.tagName === "PRE"
+																					) {
+																						preElement.style.backgroundColor =
+																							"#f4f4f4";
+																						preElement.style.padding = "10px";
+																						preElement.style.borderRadius =
+																							"4px";
+																						preElement.style.overflowX = "auto";
+																					}
+																				}
+																			}
+																		}
+																	}}
+																	style={{
+																		padding: "4px 8px",
+																		fontSize: "11px",
+																		border: "1px solid #A9A9A9",
+																		borderRadius: "3px",
+																		backgroundColor: "#FFFFFF",
+																		color: "#000000",
+																		cursor: "pointer",
+																		display: "flex",
+																		alignItems: "center",
+																		justifyContent: "center",
+																	}}
+																	title="코드 블록"
+																>
+																	<Code size={16} />
+																</button>
+																<div
+																	style={{
+																		position: "relative",
+																		display: "inline-block",
+																	}}
+																	data-more-menu
+																>
+																	<button
+																		onClick={() =>
+																			setShowMoreMenu(!showMoreMenu)
+																		}
+																		style={{
+																			padding: "4px 8px",
+																			fontSize: "11px",
+																			border: "1px solid #A9A9A9",
+																			borderRadius: "3px",
+																			backgroundColor: showMoreMenu
+																				? "#E0E0E0"
+																				: "#FFFFFF",
+																			color: "#000000",
+																			cursor: "pointer",
+																			display: "flex",
+																			alignItems: "center",
+																			justifyContent: "center",
+																		}}
+																		title="더보기"
+																	>
+																		<MoreVertical size={16} />
+																	</button>
+																	{showMoreMenu && (
+																		<div
+																			style={{
+																				position: "absolute",
+																				top: "100%",
+																				right: 0,
+																				marginTop: "4px",
+																				backgroundColor: "#FFFFFF",
+																				border: "1px solid #A9A9A9",
+																				borderRadius: "4px",
+																				boxShadow: "0 2px 8px rgba(0,0,0,0.15)",
+																				zIndex: 1000,
+																				display: "flex",
+																				flexDirection: "row",
+																				gap: "4px",
+																				padding: "4px",
+																			}}
+																			onClick={(e) => e.stopPropagation()}
+																			data-more-menu
+																		>
+																			<button
+																				onClick={() => {
+																					const iframeDoc =
+																						myTranslationIframeRef.current
+																							?.contentDocument;
+																					if (iframeDoc) {
+																						iframeDoc.execCommand(
+																							"formatBlock",
+																							false,
+																							"blockquote",
+																						);
+																					}
+																					setShowMoreMenu(false);
+																				}}
+																				style={{
+																					padding: "4px 8px",
+																					fontSize: "11px",
+																					border: "1px solid #A9A9A9",
+																					borderRadius: "3px",
+																					backgroundColor: "#FFFFFF",
+																					color: "#000000",
+																					cursor: "pointer",
+																					display: "flex",
+																					alignItems: "center",
+																					justifyContent: "center",
+																				}}
+																				title="인용문"
+																			>
+																				<Quote size={16} />
+																			</button>
+																			<button
+																				onClick={() => {
+																					const iframeDoc =
+																						myTranslationIframeRef.current
+																							?.contentDocument;
+																					if (iframeDoc) {
+																						iframeDoc.execCommand(
+																							"insertHorizontalRule",
+																							false,
+																						);
+																					}
+																					setShowMoreMenu(false);
+																				}}
+																				style={{
+																					padding: "4px 8px",
+																					fontSize: "11px",
+																					border: "1px solid #A9A9A9",
+																					borderRadius: "3px",
+																					backgroundColor: "#FFFFFF",
+																					color: "#000000",
+																					cursor: "pointer",
+																					display: "flex",
+																					alignItems: "center",
+																					justifyContent: "center",
+																				}}
+																				title="구분선"
+																			>
+																				<Minus size={16} />
+																			</button>
+																			<button
+																				onClick={() => {
+																					const iframeDoc =
+																						myTranslationIframeRef.current
+																							?.contentDocument;
+																					if (iframeDoc) {
+																						const rows = prompt(
+																							"행 수를 입력하세요 (기본값: 3):",
+																							"3",
+																						);
+																						const cols = prompt(
+																							"열 수를 입력하세요 (기본값: 3):",
+																							"3",
+																						);
+																						const rowCount = Number.parseInt(
+																							rows || "3",
+																							10,
+																						);
+																						const colCount = Number.parseInt(
+																							cols || "3",
+																							10,
+																						);
+
+																						if (rowCount > 0 && colCount > 0) {
+																							let tableHtml =
+																								'<table border="1" style="border-collapse: collapse; width: 100%;">';
+																							for (
+																								let i = 0;
+																								i < rowCount;
+																								i++
+																							) {
+																								tableHtml += "<tr>";
+																								for (
+																									let j = 0;
+																									j < colCount;
+																									j++
+																								) {
+																									tableHtml +=
+																										'<td style="padding: 8px; border: 1px solid #000;">&nbsp;</td>';
+																								}
+																								tableHtml += "</tr>";
+																							}
+																							tableHtml += "</table>";
+
+																							try {
+																								iframeDoc.execCommand(
+																									"insertHTML",
+																									false,
+																									tableHtml,
+																								);
+																							} catch (err) {
+																								const selection =
+																									iframeDoc.getSelection();
+																								if (
+																									selection &&
+																									selection.rangeCount > 0
+																								) {
+																									const range =
+																										selection.getRangeAt(0);
+																									const tempDiv =
+																										iframeDoc.createElement(
+																											"div",
+																										);
+																									tempDiv.innerHTML = tableHtml;
+																									const fragment =
+																										iframeDoc.createDocumentFragment();
+																									while (tempDiv.firstChild) {
+																										fragment.appendChild(
+																											tempDiv.firstChild,
+																										);
+																									}
+																									range.insertNode(fragment);
+																								}
+																							}
+																						}
+																					}
+																					setShowMoreMenu(false);
+																				}}
+																				style={{
+																					padding: "4px 8px",
+																					fontSize: "11px",
+																					border: "1px solid #A9A9A9",
+																					borderRadius: "3px",
+																					backgroundColor: "#FFFFFF",
+																					color: "#000000",
+																					cursor: "pointer",
+																					display: "flex",
+																					alignItems: "center",
+																					justifyContent: "center",
+																				}}
+																				title="표"
+																			>
+																				<Table size={16} />
+																			</button>
+																			<button
+																				onClick={() => {
+																					const iframeDoc =
+																						myTranslationIframeRef.current
+																							?.contentDocument;
+																					if (iframeDoc) {
+																						const selection =
+																							iframeDoc.getSelection();
+																						if (
+																							selection &&
+																							selection.rangeCount > 0 &&
+																							!selection.getRangeAt(0).collapsed
+																						) {
+																							const range =
+																								selection.getRangeAt(0);
+																							const selectedText =
+																								range.toString();
+
+																							try {
+																								iframeDoc.execCommand(
+																									"insertHTML",
+																									false,
+																									`<sup>${selectedText}</sup>`,
+																								);
+																							} catch (err) {
+																								const sup =
+																									iframeDoc.createElement(
+																										"sup",
+																									);
+																								sup.textContent = selectedText;
+																								range.deleteContents();
+																								range.insertNode(sup);
+																							}
+																						} else {
+																							try {
+																								iframeDoc.execCommand(
+																									"insertHTML",
+																									false,
+																									"<sup></sup>",
+																								);
+																							} catch (err) {
+																								const selection =
+																									iframeDoc.getSelection();
+																								if (
+																									selection &&
+																									selection.rangeCount > 0
+																								) {
+																									const range =
+																										selection.getRangeAt(0);
+																									const sup =
+																										iframeDoc.createElement(
+																											"sup",
+																										);
+																									sup.innerHTML = "&nbsp;";
+																									range.insertNode(sup);
+																								}
+																							}
+																						}
+																					}
+																					setShowMoreMenu(false);
+																				}}
+																				style={{
+																					padding: "4px 8px",
+																					fontSize: "11px",
+																					border: "1px solid #A9A9A9",
+																					borderRadius: "3px",
+																					backgroundColor: "#FFFFFF",
+																					color: "#000000",
+																					cursor: "pointer",
+																					display: "flex",
+																					alignItems: "center",
+																					justifyContent: "center",
+																				}}
+																				title="위 첨자"
+																			>
+																				<Superscript size={16} />
+																			</button>
+																			<button
+																				onClick={() => {
+																					const iframeDoc =
+																						myTranslationIframeRef.current
+																							?.contentDocument;
+																					if (iframeDoc) {
+																						const selection =
+																							iframeDoc.getSelection();
+																						if (
+																							selection &&
+																							selection.rangeCount > 0 &&
+																							!selection.getRangeAt(0).collapsed
+																						) {
+																							const range =
+																								selection.getRangeAt(0);
+																							const selectedText =
+																								range.toString();
+
+																							try {
+																								iframeDoc.execCommand(
+																									"insertHTML",
+																									false,
+																									`<sub>${selectedText}</sub>`,
+																								);
+																							} catch (err) {
+																								const sub =
+																									iframeDoc.createElement(
+																										"sub",
+																									);
+																								sub.textContent = selectedText;
+																								range.deleteContents();
+																								range.insertNode(sub);
+																							}
+																						} else {
+																							try {
+																								iframeDoc.execCommand(
+																									"insertHTML",
+																									false,
+																									"<sub></sub>",
+																								);
+																							} catch (err) {
+																								const selection =
+																									iframeDoc.getSelection();
+																								if (
+																									selection &&
+																									selection.rangeCount > 0
+																								) {
+																									const range =
+																										selection.getRangeAt(0);
+																									const sub =
+																										iframeDoc.createElement(
+																											"sub",
+																										);
+																									sub.innerHTML = "&nbsp;";
+																									range.insertNode(sub);
+																								}
+																							}
+																						}
+																					}
+																					setShowMoreMenu(false);
+																				}}
+																				style={{
+																					padding: "4px 8px",
+																					fontSize: "11px",
+																					border: "1px solid #A9A9A9",
+																					borderRadius: "3px",
+																					backgroundColor: "#FFFFFF",
+																					color: "#000000",
+																					cursor: "pointer",
+																					display: "flex",
+																					alignItems: "center",
+																					justifyContent: "center",
+																				}}
+																				title="아래 첨자"
+																			>
+																				<Subscript size={16} />
+																			</button>
+																		</div>
+																	)}
+																</div>
+																<div
+																	style={{
+																		width: "1px",
+																		height: "20px",
+																		backgroundColor: "#C0C0C0",
+																		margin: "0 4px",
+																	}}
+																/>
+																<button
+																	onClick={() => {
+																		if (!myTranslationIframeRef.current) return;
+																		const iframeDoc =
+																			myTranslationIframeRef.current
+																				.contentDocument;
+																		if (!iframeDoc) return;
+
+																		if (editorMode === "text") {
+																			// ⭐ 버튼 클릭 시 focus를 iframe body로 이동 (execCommand가 작동하려면 필요)
+																			iframeDoc.body.setAttribute(
+																				"tabindex",
+																				"-1",
+																			);
+																			iframeDoc.body.focus();
+
+																			iframeDoc.execCommand("undo", false);
+																			const updatedHtml =
+																				iframeDoc.documentElement.outerHTML;
+																			currentEditorHtmlRef.current =
+																				updatedHtml;
+																			// ⭐ setSavedTranslationHtml 제거 - Step 5와 동일하게 useEffect 재트리거 방지
+																			console.log(
+																				"↩️ Undo (TranslationWork 텍스트 - 버튼)",
+																			);
+																		} else {
+																			if (undoStackRef.current.length > 0) {
+																				const previousHtml =
+																					undoStackRef.current.pop()!;
+																				redoStackRef.current.push(
+																					currentEditorHtmlRef.current,
+																				);
+																				currentEditorHtmlRef.current =
+																					previousHtml;
+																				iframeDoc.open();
+																				iframeDoc.write(previousHtml);
+																				iframeDoc.close();
+																				setSavedTranslationHtml(previousHtml);
+
+																				// ⭐ savedTranslationHtml 의존성 배열에 추가되어 useEffect가 자동으로 재실행됨
+																				// iframe에 포커스를 주어 키보드 이벤트가 계속 작동하도록 함
+																				setTimeout(() => {
+																					const newIframeDoc =
+																						myTranslationIframeRef.current
+																							?.contentDocument ||
+																						myTranslationIframeRef.current
+																							?.contentWindow?.document;
+																					if (newIframeDoc?.body) {
+																						newIframeDoc.body.setAttribute(
+																							"tabindex",
+																							"-1",
+																						);
+																						newIframeDoc.body.focus();
+																					}
+																				}, 50);
+																			}
+																		}
+																	}}
+																	style={{
+																		padding: "4px 8px",
+																		fontSize: "11px",
+																		border: "1px solid #A9A9A9",
+																		borderRadius: "3px",
+																		backgroundColor: "#FFFFFF",
+																		color: "#000000",
+																		cursor: "pointer",
+																		display: "flex",
+																		alignItems: "center",
+																		justifyContent: "center",
+																	}}
+																	title="실행 취소 (Ctrl/Cmd+Z)"
+																>
+																	<Undo2 size={16} color="#000000" />
+																</button>
+																<button
+																	onClick={() => {
+																		if (!myTranslationIframeRef.current) return;
+																		const iframeDoc =
+																			myTranslationIframeRef.current
+																				.contentDocument;
+																		if (!iframeDoc) return;
+
+																		if (editorMode === "text") {
+																			// ⭐ 버튼 클릭 시 focus를 iframe body로 이동 (execCommand가 작동하려면 필요)
+																			iframeDoc.body.setAttribute(
+																				"tabindex",
+																				"-1",
+																			);
+																			iframeDoc.body.focus();
+
+																			iframeDoc.execCommand("redo", false);
+																			const updatedHtml =
+																				iframeDoc.documentElement.outerHTML;
+																			currentEditorHtmlRef.current =
+																				updatedHtml;
+																			// ⭐ setSavedTranslationHtml 제거 - Step 5와 동일하게 useEffect 재트리거 방지
+																			console.log(
+																				"↪️ Redo (TranslationWork 텍스트 - 버튼)",
+																			);
+																		} else {
+																			if (redoStackRef.current.length > 0) {
+																				const nextHtml =
+																					redoStackRef.current.pop()!;
+																				undoStackRef.current.push(
+																					currentEditorHtmlRef.current,
+																				);
+																				currentEditorHtmlRef.current = nextHtml;
+																				iframeDoc.open();
+																				iframeDoc.write(nextHtml);
+																				iframeDoc.close();
+																				setSavedTranslationHtml(nextHtml);
+
+																				// ⭐ savedTranslationHtml 의존성 배열에 추가되어 useEffect가 자동으로 재실행됨
+																				// iframe에 포커스를 주어 키보드 이벤트가 계속 작동하도록 함
+																				setTimeout(() => {
+																					const newIframeDoc =
+																						myTranslationIframeRef.current
+																							?.contentDocument ||
+																						myTranslationIframeRef.current
+																							?.contentWindow?.document;
+																					if (newIframeDoc?.body) {
+																						newIframeDoc.body.setAttribute(
+																							"tabindex",
+																							"-1",
+																						);
+																						newIframeDoc.body.focus();
+																					}
+																				}, 50);
+																			}
+																		}
+																	}}
+																	style={{
+																		padding: "4px 8px",
+																		fontSize: "11px",
+																		border: "1px solid #A9A9A9",
+																		borderRadius: "3px",
+																		backgroundColor: "#FFFFFF",
+																		color: "#000000",
+																		cursor: "pointer",
+																		display: "flex",
+																		alignItems: "center",
+																		justifyContent: "center",
+																	}}
+																	title="다시 실행 (Ctrl/Cmd+Y)"
+																>
+																	<Redo2 size={16} color="#000000" />
+																</button>
+															</>
+														)}
+
+														{/* 컴포넌트 편집 모드 */}
+														{editorMode === "component" &&
+															selectedElements.length > 0 && (
+																<>
+																	<span
+																		style={{
+																			fontSize: "11px",
+																			color: "#696969",
+																			marginRight: "4px",
+																		}}
+																	>
+																		{selectedElements.length}개 선택됨
+																	</span>
+																	<Button
+																		variant="secondary"
+																		onClick={() => {
+																			if (!myTranslationIframeRef.current)
+																				return;
+																			const iframeDoc =
+																				myTranslationIframeRef.current
+																					.contentDocument;
+																			if (!iframeDoc) return;
+
+																			// 선택된 요소들의 선택 상태 제거
+																			selectedElements.forEach((el) => {
+																				el.classList.remove(
+																					"component-selected",
+																				);
+																				el.style.outline = "";
+																				el.style.boxShadow = "";
+																				el.style.backgroundColor = "";
+																				el.style.outlineOffset = "";
+																			});
+																			setSelectedElements([]);
+																			console.log(
+																				"🔄 전체 선택 취소:",
+																				selectedElements.length,
+																				"개",
+																			);
+																		}}
+																		style={{
+																			fontSize: "11px",
+																			padding: "4px 8px",
+																		}}
+																	>
+																		선택 취소
+																	</Button>
+																	<Button
+																		variant="primary"
+																		onClick={() => {
+																			if (!myTranslationIframeRef.current)
+																				return;
+																			const iframeDoc =
+																				myTranslationIframeRef.current
+																					.contentDocument;
+																			if (!iframeDoc) return;
+
+																			// Undo Stack에 현재 상태 저장
+																			undoStackRef.current.push(
+																				currentEditorHtmlRef.current,
+																			);
+																			redoStackRef.current = [];
+
+																			// 선택된 요소 삭제
+																			selectedElements.forEach((el) =>
+																				el.remove(),
+																			);
+																			setSelectedElements([]);
+
+																			// 변경된 HTML 저장
+																			const updatedHtml =
+																				iframeDoc.documentElement.outerHTML;
+																			currentEditorHtmlRef.current =
+																				updatedHtml;
+																			setSavedTranslationHtml(updatedHtml);
+																			console.log(
+																				"🗑️ 선택된 요소 삭제:",
+																				selectedElements.length,
+																				"개",
+																			);
+
+																			// ⭐ 삭제 후 iframe에 포커스를 주어 키보드 단축키가 바로 작동하도록 함
+																			setTimeout(() => {
+																				// body에 tabIndex 설정하여 포커스 가능하게 만들기
+																				if (iframeDoc.body) {
+																					iframeDoc.body.setAttribute(
+																						"tabindex",
+																						"-1",
+																					);
+																					iframeDoc.body.focus();
+																				}
+																				if (
+																					myTranslationIframeRef.current
+																						?.contentWindow
+																				) {
+																					myTranslationIframeRef.current.contentWindow.focus();
+																				}
+																				myTranslationIframeRef.current?.focus();
+																				console.log(
+																					"🎯 TranslationWork iframe에 포커스 설정",
+																				);
+																			}, 100);
+																		}}
+																		style={{
+																			fontSize: "11px",
+																			padding: "4px 8px",
+																		}}
+																	>
+																		삭제
+																	</Button>
+																</>
+															)}
+													</div>
+												</div>
+												{/* iframe 에디터 */}
+												<iframe
+													ref={myTranslationIframeRef}
+													srcDoc={savedTranslationHtml}
+													style={{
+														flex: 1,
+														width: "100%",
+														border: "none",
+														backgroundColor: "#FFFFFF",
+													}}
+													title="내 번역 에디터"
+													onLoad={() => {
+														const iframe = myTranslationIframeRef.current;
+														if (!iframe) return;
+
+														const iframeDoc =
+															iframe.contentDocument ||
+															iframe.contentWindow?.document;
+														if (!iframeDoc || !iframeDoc.body) return;
+
+														try {
+															// body를 편집 가능하게 설정
+															iframeDoc.body.contentEditable = "true";
+															iframeDoc.body.style.padding = "16px";
+															iframeDoc.body.style.wordWrap = "break-word";
+
+															// 편집 시 자동 저장 (debounce)
+															let saveTimeout: NodeJS.Timeout;
+															const handleInput = () => {
+																clearTimeout(saveTimeout);
+																saveTimeout = setTimeout(() => {
+																	if (iframeDoc.documentElement) {
+																		const updatedHtml =
+																			iframeDoc.documentElement.outerHTML;
+																		currentEditorHtmlRef.current = updatedHtml;
+																		console.log(
+																			"📝 편집 내용 임시 저장됨 (메모리)",
+																		);
+																	}
+																}, 500);
+															};
+
+															iframeDoc.body.addEventListener(
+																"input",
+																handleInput,
+															);
+
+															if (!hasRenderedMyTranslation.current) {
+																hasRenderedMyTranslation.current = true;
+																setIsTranslationEditorInitialized(true);
+															}
+
+															console.log(
+																`✅ 내 번역 iframe 설정 완료 (문단 ${paragraphs.length}개, 완료 표시 기능 활성화)`,
+															);
+														} catch (error) {
+															console.error("내 번역 iframe 설정 실패:", error);
+														}
+													}}
+												/>
+											</>
+										) : // 원문 / AI 초벌 번역 패널 (iframe)
+										panel.html ? (
+											<iframe
+												ref={panel.ref as React.RefObject<HTMLIFrameElement>}
+												srcDoc={panel.html}
+												style={{
+													width: "100%",
+													height: "100%",
+													border: "none",
+													backgroundColor: "#FFFFFF",
+												}}
+												title={panel.title}
+											/>
+										) : (
+											<div
+												style={{
+													display: "flex",
+													alignItems: "center",
+													justifyContent: "center",
+													height: "100%",
+													color: colors.secondaryText,
+													fontSize: "13px",
+												}}
+											>
+												{panel.id === "original"
+													? "원문이 없습니다."
+													: "AI 초벌 번역이 없습니다."}
+											</div>
+										)}
+									</div>
+								}
+							</div>
+						);
+					})}
+				</div>
+
+				{/* 소통 채팅 사이드바 */}
+				{showChat && documentId && (
+					<div
+						style={{
+							width: "300px",
+							flexShrink: 0,
+							padding: "4px 4px 4px 0",
+							display: "flex",
+							flexDirection: "column",
+						}}
+					>
+						<DocumentChat documentId={documentId} height="100%" />
+					</div>
+				)}
+			</div>
+
+			{/* 인계 메모 확인 모달 */}
+			{showHandoverInfoModal &&
+				document?.latestHandover &&
+				(() => {
+					const h = document.latestHandover!;
+					return (
+						<div
+							style={{
+								position: "fixed",
+								top: 0,
+								left: 0,
+								right: 0,
+								bottom: 0,
+								backgroundColor: "rgba(0,0,0,0.5)",
+								display: "flex",
+								alignItems: "center",
+								justifyContent: "center",
+								zIndex: 1100,
+							}}
+							onClick={() => setShowHandoverInfoModal(false)}
+						>
+							<div
+								style={{
+									backgroundColor: colors.surface,
+									padding: "24px",
+									borderRadius: "8px",
+									width: "500px",
+									maxWidth: "90vw",
+									border: `1px solid ${colors.border}`,
+									maxHeight: "80vh",
+									overflowY: "auto",
+								}}
+								onClick={(e) => e.stopPropagation()}
+							>
+								<h3
+									style={{
+										fontSize: "16px",
+										fontWeight: 600,
+										marginBottom: "20px",
+										color: "#000000",
+									}}
+								>
+									📋 이전 번역자 인계 메모
+								</h3>
+								<div
+									style={{
+										display: "flex",
+										flexDirection: "column",
+										gap: "14px",
+										marginBottom: "24px",
+									}}
+								>
+									{h.handedOverBy && (
+										<div>
+											<span
+												style={{
+													fontSize: "12px",
+													color: colors.secondaryText,
+													display: "block",
+													marginBottom: "4px",
+												}}
+											>
+												인계자
+											</span>
+											<span style={{ fontSize: "13px", color: "#000000" }}>
+												{h.handedOverBy.name}
+											</span>
+										</div>
+									)}
+									{h.handedOverAt && (
+										<div>
+											<span
+												style={{
+													fontSize: "12px",
+													color: colors.secondaryText,
+													display: "block",
+													marginBottom: "4px",
+												}}
+											>
+												인계 시각
+											</span>
+											<span style={{ fontSize: "13px", color: "#000000" }}>
+												{new Date(h.handedOverAt).toLocaleString("ko-KR")}
+											</span>
+										</div>
+									)}
+									<div>
+										<span
+											style={{
+												fontSize: "12px",
+												color: colors.secondaryText,
+												display: "block",
+												marginBottom: "6px",
+											}}
+										>
+											남은 작업 메모
+										</span>
+										<div
+											style={{
+												fontSize: "13px",
+												color: "#000000",
+												whiteSpace: "pre-wrap",
+												lineHeight: "1.6",
+												padding: "10px",
+												backgroundColor: "#FFF9EC",
+												border: "1px solid #FFE082",
+												borderRadius: "4px",
+											}}
+										>
+											{h.memo}
+										</div>
+									</div>
+									{h.terms && (
+										<div>
+											<span
+												style={{
+													fontSize: "12px",
+													color: colors.secondaryText,
+													display: "block",
+													marginBottom: "6px",
+												}}
+											>
+												주의 용어/표현
+											</span>
+											<div
+												style={{
+													fontSize: "13px",
+													color: "#000000",
+													whiteSpace: "pre-wrap",
+													lineHeight: "1.6",
+													padding: "10px",
+													backgroundColor: "#FFF9EC",
+													border: "1px solid #FFE082",
+													borderRadius: "4px",
+												}}
+											>
+												{h.terms}
+											</div>
+										</div>
+									)}
+								</div>
+								<div style={{ display: "flex", justifyContent: "flex-end" }}>
+									<Button
+										variant="secondary"
+										onClick={() => setShowHandoverInfoModal(false)}
+										style={{ fontSize: "12px" }}
+									>
+										닫기
+									</Button>
+								</div>
+							</div>
+						</div>
+					);
+				})()}
+
+			{/* 인계 요청 모달 */}
+			{showHandoverModal && (
+				<div
+					style={{
+						position: "fixed",
+						top: 0,
+						left: 0,
+						right: 0,
+						bottom: 0,
+						backgroundColor: "rgba(0, 0, 0, 0.5)",
+						display: "flex",
+						alignItems: "center",
+						justifyContent: "center",
+						zIndex: 1000,
+					}}
+					onClick={() => setShowHandoverModal(false)}
+				>
+					<div
+						style={{
+							backgroundColor: colors.surface,
+							padding: "24px",
+							borderRadius: "8px",
+							width: "500px",
+							maxWidth: "90vw",
+							border: `1px solid ${colors.border}`,
+						}}
+						onClick={(e) => e.stopPropagation()}
+					>
+						<h3
+							style={{
+								fontSize: "16px",
+								fontWeight: 600,
+								marginBottom: "16px",
+							}}
+						>
+							인계 요청
+						</h3>
+
+						<div style={{ marginBottom: "16px" }}>
+							<label
+								style={{
+									display: "block",
+									fontSize: "13px",
+									marginBottom: "8px",
+									color: colors.primaryText,
+								}}
+							>
+								남은 작업 메모 *
+							</label>
+							<textarea
+								value={handoverMemo}
+								onChange={(e) => setHandoverMemo(e.target.value)}
+								placeholder="예: 15-30번 문단 남음, 전문 용어 주의 필요"
+								style={{
+									width: "100%",
+									minHeight: "80px",
+									padding: "8px",
+									border: `1px solid ${colors.border}`,
+									borderRadius: "4px",
+									fontSize: "13px",
+									fontFamily: "inherit",
+									resize: "vertical",
+								}}
+							/>
+						</div>
+
+						<div style={{ marginBottom: "24px" }}>
+							<label
+								style={{
+									display: "block",
+									fontSize: "13px",
+									marginBottom: "8px",
+									color: colors.primaryText,
+								}}
+							>
+								주의 용어/표현 메모 (선택)
+							</label>
+							<textarea
+								value={handoverTerms}
+								onChange={(e) => setHandoverTerms(e.target.value)}
+								placeholder="예: 'API'는 그대로 유지, '서버'는 'server'로 표기"
+								style={{
+									width: "100%",
+									minHeight: "60px",
+									padding: "8px",
+									border: `1px solid ${colors.border}`,
+									borderRadius: "4px",
+									fontSize: "13px",
+									fontFamily: "inherit",
+									resize: "vertical",
+								}}
+							/>
+						</div>
+
+						<div
+							style={{
+								display: "flex",
+								gap: "8px",
+								justifyContent: "flex-end",
+							}}
+						>
+							<Button
+								variant="secondary"
+								onClick={() => {
+									setShowHandoverModal(false);
+									setHandoverMemo("");
+									setHandoverTerms("");
+								}}
+								style={{ fontSize: "12px" }}
+							>
+								취소
+							</Button>
+							<Button
+								variant="primary"
+								onClick={confirmHandover}
+								disabled={handoverSubmitting}
+								style={{ fontSize: "12px" }}
+							>
+								{handoverSubmitting ? "처리 중..." : "인계 요청"}
+							</Button>
+						</div>
+					</div>
+				</div>
+			)}
+
+			{/* 링크 편집 모달 */}
+			{showLinkModal && editingLink && (
+				<div
+					style={{
+						position: "fixed",
+						top: 0,
+						left: 0,
+						right: 0,
+						bottom: 0,
+						backgroundColor: "rgba(0, 0, 0, 0.5)",
+						display: "flex",
+						alignItems: "center",
+						justifyContent: "center",
+						zIndex: 1000,
+					}}
+					onClick={() => {
+						setShowLinkModal(false);
+						setEditingLink(null);
+						setLinkUrl("");
+					}}
+				>
+					<div
+						style={{
+							backgroundColor: colors.surface,
+							padding: "24px",
+							borderRadius: "8px",
+							width: "400px",
+							maxWidth: "90vw",
+							border: `1px solid ${colors.border}`,
+						}}
+						onClick={(e) => e.stopPropagation()}
+					>
+						<h3
+							style={{
+								fontSize: "16px",
+								fontWeight: 600,
+								marginBottom: "16px",
+							}}
+						>
+							링크 편집
+						</h3>
+
+						<div style={{ marginBottom: "16px" }}>
+							<label
+								style={{
+									display: "block",
+									fontSize: "13px",
+									marginBottom: "8px",
+									color: colors.primaryText,
+								}}
+							>
+								URL
+							</label>
+							<input
+								type="text"
+								value={linkUrl}
+								onChange={(e) => setLinkUrl(e.target.value)}
+								placeholder="https://example.com"
+								style={{
+									width: "100%",
+									padding: "8px",
+									border: `1px solid ${colors.border}`,
+									borderRadius: "4px",
+									fontSize: "13px",
+									fontFamily: "inherit",
+								}}
+								onKeyDown={(e) => {
+									if (e.key === "Enter") {
+										e.preventDefault();
+										const iframeDoc =
+											myTranslationIframeRef.current?.contentDocument;
+										if (iframeDoc && editingLink && linkUrl.trim()) {
+											// execCommand를 사용하여 링크 URL 업데이트 (undo 스택에 기록)
+											const selection = iframeDoc.getSelection();
+											if (selection) {
+												const range = iframeDoc.createRange();
+												range.selectNodeContents(editingLink);
+												selection.removeAllRanges();
+												selection.addRange(range);
+
+												// 기존 링크 삭제 후 새 링크 생성
+												iframeDoc.execCommand("unlink", false);
+												iframeDoc.execCommand(
+													"createLink",
+													false,
+													linkUrl.trim(),
+												);
+											}
+										}
+										setShowLinkModal(false);
+										setEditingLink(null);
+										setLinkUrl("");
+									}
+								}}
+								autoFocus
+							/>
+						</div>
+
+						<div
+							style={{
+								display: "flex",
+								gap: "8px",
+								justifyContent: "flex-end",
+							}}
+						>
+							<Button
+								variant="secondary"
+								onClick={() => {
+									setShowLinkModal(false);
+									setEditingLink(null);
+									setLinkUrl("");
+								}}
+								style={{ fontSize: "12px" }}
+							>
+								취소
+							</Button>
+							<Button
+								variant="secondary"
+								onClick={() => {
+									const iframeDoc =
+										myTranslationIframeRef.current?.contentDocument;
+									if (iframeDoc && editingLink) {
+										// execCommand를 사용하여 링크 삭제 (undo 스택에 기록)
+										const selection = iframeDoc.getSelection();
+										if (selection) {
+											const range = iframeDoc.createRange();
+											range.selectNodeContents(editingLink);
+											selection.removeAllRanges();
+											selection.addRange(range);
+											iframeDoc.execCommand("unlink", false);
+										}
+									}
+									setShowLinkModal(false);
+									setEditingLink(null);
+									setLinkUrl("");
+								}}
+								style={{
+									fontSize: "12px",
+									color: "#dc3545",
+									borderColor: "#dc3545",
+								}}
+							>
+								삭제
+							</Button>
+							<Button
+								variant="primary"
+								onClick={() => {
+									const iframeDoc =
+										myTranslationIframeRef.current?.contentDocument;
+									if (iframeDoc && editingLink && linkUrl.trim()) {
+										// execCommand를 사용하여 링크 URL 업데이트 (undo 스택에 기록)
+										const selection = iframeDoc.getSelection();
+										if (selection) {
+											const range = iframeDoc.createRange();
+											range.selectNodeContents(editingLink);
+											selection.removeAllRanges();
+											selection.addRange(range);
+
+											// 기존 링크 삭제 후 새 링크 생성
+											iframeDoc.execCommand("unlink", false);
+											iframeDoc.execCommand(
+												"createLink",
+												false,
+												linkUrl.trim(),
+											);
+										}
+									}
+									setShowLinkModal(false);
+									setEditingLink(null);
+									setLinkUrl("");
+								}}
+								style={{ fontSize: "12px" }}
+							>
+								저장
+							</Button>
+						</div>
+					</div>
+				</div>
+			)}
+		</div>
+	);
 }
-


### PR DESCRIPTION
issue: #66 
## [FE] 검토 화면 저장 UX 개선 및 리뷰 목록 버튼 레이아웃 정리
### 배경
- 관리자 검토 화면에서 번역본(검토 대상) 수정 후 즉시 저장할 수 있는 전용 액션이 필요함
- 리뷰 목록(`/reviews`)에서 `검토하기` 버튼이 테이블 셀 밖으로 밀려 레이아웃이 깨지는 문제 존재
### 변경 사항
- `DocumentReview` 페이지 개선
  - `번역본 (검토 대상)` 패널 헤더(확대 버튼 옆)에 `저장하기` 버튼 추가
  - 저장 시 번역본 iframe의 최신 HTML을 읽어 `MANUAL_TRANSLATION` 새 버전으로 저장
  - 변경사항이 없으면 저장 스킵 안내, 성공 시 화면 상태 동기화
- `Reviews` 페이지 레이아웃 개선
  - 액션 컬럼 너비를 퍼센트 기반에서 고정폭으로 조정
  - `검토하기` 버튼을 셀 내부 중앙 정렬로 고정
  - 버튼 패딩/최소폭/줄바꿈 방지 설정으로 overflow 방지
### 기대 효과
- 검토자가 승인 전에 중간 저장 가능
- 리뷰 목록 테이블 우측 버튼 overflow 제거로 화면 안정성 향상
### 검증 항목
- [ ] `/reviews/:id/review` 진입 후 번역본 수정 → `저장하기` 클릭 시 저장 성공 확인
- [ ] 저장 후 새로고침 시 수정 내용 유지 확인
- [ ] `/reviews` 목록에서 `검토하기` 버튼이 셀 바깥으로 나가지 않는지 확인
- [ ] 좁은 화면(브라우저 폭 축소)에서도 버튼 레이아웃 유지 확인
